### PR TITLE
Potential fix for code scanning alert no. 44: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -105,8 +105,13 @@ def list_runs(run_root: Path) -> list[dict[str, Any]]:
 
 
 def _resolve_run_dir(run_root: Path, run_id: str) -> Path:
-    run_dir = (run_root / run_id).resolve()
-    if not run_dir.exists() or run_root.resolve() not in run_dir.parents:
+    resolved_root = run_root.resolve()
+    run_dir = (resolved_root / run_id).resolve()
+    try:
+        run_dir.relative_to(resolved_root)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Run not found")
+    if not run_dir.exists():
         raise HTTPException(status_code=404, detail="Run not found")
     return run_dir
 


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/44](https://github.com/bnnr-team/bnnr/security/code-scanning/44)

General fix: enforce strict canonical path validation at the trust boundary (where `run_id` becomes a filesystem path), ensuring resolved target paths remain inside an approved root directory using normalized/real resolved paths.

Best fix here (without changing functionality): harden `_resolve_run_dir` in `src/bnnr/dashboard/backend.py` to:
- resolve `run_root` once,
- build `run_dir` from resolved root,
- verify containment via `run_dir.relative_to(resolved_root)` (robust and explicit),
- keep existing not-found behavior.

This ensures downstream paths (`out_dir`, and then `_copy_logos_to(dest)`) cannot escape the allowed run root even with crafted `run_id`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
