### PR TITLE
Potential fix for code scanning alert no. 45: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -104,9 +104,25 @@ def list_runs(run_root: Path) -> list[dict[str, Any]]:
     return runs
 
 
+def _validate_run_id(run_id: str) -> str:
+    """Validate route-provided run_id so it can only reference a direct run directory name."""
+    if not run_id:
+        raise HTTPException(status_code=400, detail="Invalid run id")
+    p = Path(run_id)
+    if p.is_absolute() or len(p.parts) != 1 or p.name != run_id or run_id in {".", ".."}:
+        raise HTTPException(status_code=400, detail="Invalid run id")
+    return run_id
+
+
 def _resolve_run_dir(run_root: Path, run_id: str) -> Path:
-    run_dir = (run_root / run_id).resolve()
-    if not run_dir.exists() or run_root.resolve() not in run_dir.parents:
+    run_id = _validate_run_id(run_id)
+    resolved_root = run_root.resolve()
+    run_dir = (resolved_root / run_id).resolve()
+    try:
+        run_dir.relative_to(resolved_root)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Run not found")
+    if not run_dir.exists() or not run_dir.is_dir():
         raise HTTPException(status_code=404, detail="Run not found")
     return run_dir
 


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/45](https://github.com/bnnr-team/bnnr/security/code-scanning/45)

To fix this safely without changing functionality, validate `run_id` before building filesystem paths, and strengthen run directory resolution using canonical containment checks that are explicit and robust.

Best approach in this code:
- In `src/bnnr/dashboard/backend.py`, add a small validator for `run_id` that rejects path separators, traversal tokens (`..`), and absolute-like inputs.
- Call that validator inside `_resolve_run_dir` before combining `run_root / run_id`.
- Use `relative_to`-based containment after `resolve()` to ensure the resolved `run_dir` is inside resolved `run_root`.
- Keep behavior the same for legitimate run IDs (directory names returned by `list_runs`), while rejecting malformed/untrusted path-like IDs early.

No change is needed in `exporter.py`; once `run_id` is constrained at ingress and `_resolve_run_dir` guarantees safe containment, `out_dir` and downstream `dst` become controlled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
