### PR TITLE
Potential fix for code scanning alert no. 43: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -46,6 +47,9 @@ _MAX_CONFUSION_ENTRIES = 30
 
 # Signal file name used for pause/resume
 PAUSE_SIGNAL_FILENAME = ".bnnr_pause"
+
+# Restrict externally provided run IDs to simple directory-name-safe tokens.
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 class ControlAction(_PydanticBaseModel):
@@ -105,8 +109,12 @@ def list_runs(run_root: Path) -> list[dict[str, Any]]:
 
 
 def _resolve_run_dir(run_root: Path, run_id: str) -> Path:
-    run_dir = (run_root / run_id).resolve()
-    if not run_dir.exists() or run_root.resolve() not in run_dir.parents:
+    if not run_id or not _RUN_ID_RE.fullmatch(run_id):
+        raise HTTPException(status_code=400, detail="Invalid run id")
+
+    resolved_root = run_root.resolve()
+    run_dir = (resolved_root / run_id).resolve()
+    if not run_dir.exists() or resolved_root not in run_dir.parents:
         raise HTTPException(status_code=404, detail="Run not found")
     return run_dir
 


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/43](https://github.com/bnnr-team/bnnr/security/code-scanning/43)

Best fix: validate `run_id` against a strict allowlist pattern before path construction, then keep existing resolved-path containment checks.

In `src/bnnr/dashboard/backend.py`, update `_resolve_run_dir` to reject unsafe run IDs (empty, absolute/path-like, or containing characters outside a safe set like letters, digits, `_`, `-`, `.`). Then resolve and enforce containment as already done. This preserves functionality for normal run directory names while blocking traversal payloads and making trust boundaries explicit for CodeQL.

No changes are required in `exporter.py`; once `run_id` is validated at ingress and resolved under `run_root`, downstream file operations are bounded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
