### PR TITLE
Potential fix for code scanning alert no. 42: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -104,7 +105,20 @@ def list_runs(run_root: Path) -> list[dict[str, Any]]:
     return runs
 
 
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _validate_run_id(run_id: str) -> None:
+    if not run_id or run_id in {".", ".."}:
+        raise HTTPException(status_code=400, detail="Invalid run id")
+    if "/" in run_id or "\\" in run_id:
+        raise HTTPException(status_code=400, detail="Invalid run id")
+    if not _RUN_ID_RE.fullmatch(run_id):
+        raise HTTPException(status_code=400, detail="Invalid run id")
+
+
 def _resolve_run_dir(run_root: Path, run_id: str) -> Path:
+    _validate_run_id(run_id)
     run_dir = (run_root / run_id).resolve()
     if not run_dir.exists() or run_root.resolve() not in run_dir.parents:
         raise HTTPException(status_code=404, detail="Run not found")


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/42](https://github.com/bnnr-team/bnnr/security/code-scanning/42)

Best fix: validate `run_id` before using it in filesystem path construction, using a strict allowlist of safe characters and prohibiting path separators / traversal semantics.

In `src/bnnr/dashboard/backend.py`:
- Add a helper (near `_resolve_run_dir`) to validate run IDs, e.g. allow only `[A-Za-z0-9._-]`, reject empty values, `"."`, `".."`, and any separator (`/` or `\` via `Path.parts`/direct checks).
- Call this validator at the start of `_resolve_run_dir` before constructing `(run_root / run_id).resolve()`.

This keeps existing functionality for legitimate run IDs (directory names already listed by `list_runs`), while preventing ambiguous or dangerous identifiers and satisfying CodeQL’s taint concerns at the source-to-sink boundary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
