### PR TITLE
Potential fix for code scanning alert no. 41: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -105,8 +105,13 @@ def list_runs(run_root: Path) -> list[dict[str, Any]]:
 
 
 def _resolve_run_dir(run_root: Path, run_id: str) -> Path:
-    run_dir = (run_root / run_id).resolve()
-    if not run_dir.exists() or run_root.resolve() not in run_dir.parents:
+    resolved_root = run_root.resolve()
+    run_dir = (resolved_root / run_id).resolve()
+    if resolved_root not in run_dir.parents:
+        raise HTTPException(status_code=404, detail="Run not found")
+    if not run_dir.exists() or not run_dir.is_dir():
+        raise HTTPException(status_code=404, detail="Run not found")
+    if not (run_dir / "events.jsonl").exists():
         raise HTTPException(status_code=404, detail="Run not found")
     return run_dir
 


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/41](https://github.com/bnnr-team/bnnr/security/code-scanning/41)

General fix: enforce strict canonical-path containment and directory-type validation at the point where `run_id` is resolved, before any filesystem writes occur. The most reliable pattern is: resolve both root and candidate, then require `candidate == root` **or** `root in candidate.parents` depending on policy. Here policy should disallow root itself and only allow direct child run directories.

Best minimal fix without changing intended behavior:
- In `src/bnnr/dashboard/backend.py`, harden `_resolve_run_dir`:
  1. Resolve `run_root` once to `resolved_root`.
  2. Resolve candidate as `(resolved_root / run_id).resolve()`.
  3. Reject if candidate is not strictly inside root (`resolved_root not in run_dir.parents`).
  4. Reject if candidate does not exist or is not a directory.
  5. Optionally require `events.jsonl` exists to ensure it is truly a run directory (consistent with rest of code behavior and prevents exporting non-run dirs).
- No changes are required in `exporter.py` once taint is blocked at source resolution.

This preserves functionality: valid run IDs still export exactly as before, invalid/traversal-like IDs return 404.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
