### PR TITLE
Potential fix for code scanning alert no. 39: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -105,9 +105,14 @@ def list_runs(run_root: Path) -> list[dict[str, Any]]:
 
 
 def _resolve_run_dir(run_root: Path, run_id: str) -> Path:
-    run_dir = (run_root / run_id).resolve()
-    if not run_dir.exists() or run_root.resolve() not in run_dir.parents:
+    resolved_root = _normalize_run_root(run_root).resolve()
+    run_dir = (resolved_root / run_id).resolve()
+    if not run_dir.exists() or not run_dir.is_dir():
         raise HTTPException(status_code=404, detail="Run not found")
+    try:
+        run_dir.relative_to(resolved_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Run not found") from exc
     return run_dir
 
 

--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -293,8 +293,14 @@ def create_dashboard_app(
     @app.post("/api/run/{run_id}/export", dependencies=[Depends(_require_control_auth)])
     def api_run_export(run_id: str) -> dict[str, Any]:
         run_dir = _resolve_run_dir(run_root, run_id)
-        out_dir = run_dir / "dashboard_export" / datetime.now().strftime("%Y%m%d_%H%M%S")
-        exported = export_dashboard_snapshot(run_dir=run_dir, out_dir=out_dir, frontend_dist=static_dir)
+        resolved_root = _normalize_run_root(run_root).resolve()
+        resolved_run_dir = run_dir.resolve()
+        try:
+            resolved_run_dir.relative_to(resolved_root)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="Invalid run path") from exc
+        out_dir = resolved_run_dir / "dashboard_export" / datetime.now().strftime("%Y%m%d_%H%M%S")
+        exported = export_dashboard_snapshot(run_dir=resolved_run_dir, out_dir=out_dir, frontend_dist=static_dir)
         return {"ok": True, "path": str(exported), "index": str(exported / "index.html")}
 
     @app.get("/api/run/{run_id}/events")


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/39](https://github.com/bnnr-team/bnnr/security/code-scanning/39)

General fix: ensure any filesystem path derived from user-influenced values is canonicalized and strictly verified to remain under an allowed root before use in file operations.

Best fix here without changing behavior: add a strict containment check in `api_run_export` before calling `export_dashboard_snapshot`, using resolved paths and `Path.relative_to(...)` to ensure `run_dir` is inside normalized `run_root`. This keeps existing functionality (exporting valid runs) while guaranteeing only runs under the configured root are exported. No new dependencies are needed.

Change location:
- `src/bnnr/dashboard/backend.py` in `api_run_export` (around lines 294–298 in provided snippet).

Implementation details:
- Compute `resolved_root = _normalize_run_root(run_root).resolve()`.
- Compute `resolved_run_dir = run_dir.resolve()`.
- Reject if `resolved_run_dir` is not within `resolved_root` (catch `ValueError` from `relative_to`).
- Use `resolved_run_dir` for `out_dir` and export call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
