### PR TITLE
Potential fix for code scanning alert no. 36: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -13,12 +13,21 @@ from bnnr.events import load_events, replay_events
 _STATIC_DIR = Path(__file__).parent / "static"
 
 
+def _ensure_within(base: Path, candidate: Path) -> Path:
+    """Resolve *candidate* and ensure it stays within *base*."""
+    resolved_base = base.resolve()
+    resolved_candidate = candidate.resolve()
+    if resolved_candidate != resolved_base and resolved_base not in resolved_candidate.parents:
+        raise ValueError(f"Path escapes base directory: {resolved_candidate}")
+    return resolved_candidate
+
+
 def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path | None = None) -> Path:
     run_dir = run_dir.resolve()
     out_dir = out_dir.resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    events_file = run_dir / "events.jsonl"
+    events_file = _ensure_within(run_dir, run_dir / "events.jsonl")
     if not events_file.exists():
         raise FileNotFoundError(f"events.jsonl not found in run directory: {run_dir}")
 
@@ -42,12 +51,12 @@ def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path 
     shutil.copy2(events_file, data_dir / "events.jsonl")
     (data_dir / "state.json").write_text(json.dumps(state, indent=2, default=str), encoding="utf-8")
 
-    report_json = run_dir / "report.json"
+    report_json = _ensure_within(run_dir, run_dir / "report.json")
     if report_json.exists():
         shutil.copy2(report_json, data_dir / "report.json")
 
     # Copy artifacts
-    artifacts_src = run_dir / "artifacts"
+    artifacts_src = _ensure_within(run_dir, run_dir / "artifacts")
     artifacts_dst = out_dir / "artifacts"
     if artifacts_src.exists():
         shutil.copytree(artifacts_src, artifacts_dst, dirs_exist_ok=True)


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/36](https://github.com/bnnr-team/bnnr/security/code-scanning/36)

General fix: whenever a function performs filesystem access using path arguments that may originate from request data, enforce canonicalization and root containment *inside that function* before any file operations.

Best fix here (without changing functionality): in `src/bnnr/dashboard/exporter.py`, add a small helper that ensures a candidate path is within a given base directory after `resolve()`, then use it for `events.jsonl`, `report.json`, and `artifacts` paths. Since `run_dir` and `out_dir` are already resolved, this keeps behavior intact for valid runs but hardens against misuse and addresses the static analysis concern.

Changes needed:
- Add `_ensure_within(base: Path, candidate: Path) -> Path` near top-level helpers.
- In `export_dashboard_snapshot`, replace direct `run_dir / ...` usage with `_ensure_within(run_dir, run_dir / ...)` for sensitive read/copy sources (`events_file`, `report_json`, `artifacts_src`).

No new external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
