### PR TITLE
Potential fix for code scanning alert no. 35: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -308,7 +308,12 @@ def create_dashboard_app(
     def api_run_export(run_id: str) -> dict[str, Any]:
         run_dir = _resolve_run_dir(run_root, run_id)
         out_dir = run_dir / "dashboard_export" / datetime.now().strftime("%Y%m%d_%H%M%S")
-        exported = export_dashboard_snapshot(run_dir=run_dir, out_dir=out_dir, frontend_dist=static_dir)
+        exported = export_dashboard_snapshot(
+            run_dir=run_dir,
+            out_dir=out_dir,
+            frontend_dist=static_dir,
+            safe_run_root=run_root,
+        )
         return {"ok": True, "path": str(exported), "index": str(exported / "index.html")}
 
     @app.get("/api/run/{run_id}/events")

--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -13,8 +13,17 @@ from bnnr.events import load_events, replay_events
 _STATIC_DIR = Path(__file__).parent / "static"
 
 
-def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path | None = None) -> Path:
+def export_dashboard_snapshot(
+    run_dir: Path,
+    out_dir: Path,
+    frontend_dist: Path | None = None,
+    safe_run_root: Path | None = None,
+) -> Path:
     run_dir = run_dir.resolve()
+    if safe_run_root is not None:
+        resolved_root = safe_run_root.resolve()
+        if run_dir != resolved_root and resolved_root not in run_dir.parents:
+            raise ValueError(f"run_dir must be inside safe_run_root: {run_dir}")
     out_dir = out_dir.resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/35](https://github.com/bnnr-team/bnnr/security/code-scanning/35)

General fix: before using any path derived from untrusted input, canonicalize it (`resolve`) and enforce it is inside an expected safe root directory.

Best fix here without changing behavior: strengthen `export_dashboard_snapshot` so it validates `run_dir` against an optional trusted base directory. Then pass `run_root` from the backend call site. This preserves current behavior for existing callers (parameter optional), while making the API path explicitly safe and removing uncontrolled-path concerns in exporter.

Changes needed:
- **`src/bnnr/dashboard/exporter.py`**
  - Update `export_dashboard_snapshot` signature to accept `safe_run_root: Path | None = None`.
  - After resolving `run_dir`, if `safe_run_root` is provided, resolve it and verify `run_dir` is exactly root or a descendant; otherwise raise `ValueError`.
- **`src/bnnr/dashboard/backend.py`**
  - In `api_run_export`, pass `safe_run_root=run_root` to `export_dashboard_snapshot`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
