### PR TITLE
Potential fix for code scanning alert no. 33: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -16,6 +16,10 @@ _STATIC_DIR = Path(__file__).parent / "static"
 def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path | None = None) -> Path:
     run_dir = run_dir.resolve()
     out_dir = out_dir.resolve()
+    try:
+        out_dir.relative_to(run_dir)
+    except ValueError as exc:
+        raise ValueError(f"Export output directory must be within run directory: {out_dir}") from exc
     out_dir.mkdir(parents=True, exist_ok=True)
 
     events_file = run_dir / "events.jsonl"
@@ -37,7 +41,11 @@ def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path 
     _copy_logos_to(out_dir)
 
     # Write state.json for offline mode (also used when served via HTTP)
-    data_dir = out_dir / "data"
+    data_dir = (out_dir / "data").resolve()
+    try:
+        data_dir.relative_to(out_dir)
+    except ValueError as exc:
+        raise ValueError(f"Export data directory escapes output directory: {data_dir}") from exc
     data_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(events_file, data_dir / "events.jsonl")
     (data_dir / "state.json").write_text(json.dumps(state, indent=2, default=str), encoding="utf-8")


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/33](https://github.com/bnnr-team/bnnr/security/code-scanning/33)

General fix: enforce canonical path containment before any filesystem write/copy that uses potentially user-influenced paths. In Python, resolve both paths and verify the target remains under an approved root using `Path.relative_to()` (or equivalent), raising an error if it escapes.

Best single fix here (without changing behavior): in `src/bnnr/dashboard/exporter.py`, after resolving `run_dir` and `out_dir`, add checks that:
1. `out_dir` is inside `run_dir` (expected by current caller, which uses `run_dir / "dashboard_export"/timestamp`),
2. `data_dir` is inside `out_dir` before using it as a destination.

This preserves existing functionality for valid requests while preventing unexpected filesystem destinations if future code passes unsafe paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
