### PR TITLE
Potential fix for code scanning alert no. 32: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -119,8 +119,12 @@ def _validate_run_id(run_id: str) -> None:
 
 def _resolve_run_dir(run_root: Path, run_id: str) -> Path:
     _validate_run_id(run_id)
-    run_dir = (run_root / run_id).resolve()
-    if not run_dir.exists() or run_root.resolve() not in run_dir.parents:
+    resolved_root = run_root.resolve()
+    candidate = run_root / run_id
+    run_dir = candidate.resolve()
+    if not run_dir.exists() or not run_dir.is_dir() or resolved_root not in run_dir.parents:
+        raise HTTPException(status_code=404, detail="Run not found")
+    if candidate.is_symlink():
         raise HTTPException(status_code=404, detail="Run not found")
     return run_dir
 


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/32](https://github.com/bnnr-team/bnnr/security/code-scanning/32)

General fix: enforce a trusted-root containment check on normalized/resolved paths immediately before filesystem use. This ensures that even if callers are changed later or validation is bypassed, path traversal cannot reach unexpected files.

Best fix here (without changing behavior): in `src/bnnr/dashboard/backend.py`, strengthen `_resolve_run_dir` so it only returns actual directories under `run_root`, and explicitly rejects symlinked run directories. This removes ambiguity and makes the taint path to exporter safer and clearer for static analysis. No functional change for valid run IDs/directories.

Changes needed:
- In `_resolve_run_dir`:
  - Resolve `run_root` once.
  - Require `run_dir.is_dir()` (not just exists).
  - Keep containment check against resolved root.
  - Reject `run_dir.is_symlink()` to prevent symlink-based escape.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
