### PR TITLE
Potential fix for code scanning alert no. 31: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -16,6 +16,11 @@ _STATIC_DIR = Path(__file__).parent / "static"
 def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path | None = None) -> Path:
     run_dir = run_dir.resolve()
     out_dir = out_dir.resolve()
+    allowed_export_root = (run_dir / "dashboard_export").resolve()
+    try:
+        out_dir.relative_to(allowed_export_root)
+    except ValueError as exc:
+        raise ValueError(f"Invalid export output directory: {out_dir}") from exc
     out_dir.mkdir(parents=True, exist_ok=True)
 
     events_file = run_dir / "events.jsonl"


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/31](https://github.com/bnnr-team/bnnr/security/code-scanning/31)

General fix: enforce canonical path containment before any filesystem write. Resolve/normalize paths, define a trusted root, and reject paths that escape that root.

Best fix here without changing functionality: in `src/bnnr/dashboard/exporter.py`, constrain `out_dir` to be inside `run_dir / "dashboard_export"`. That preserves the current behavior used by `api_run_export` while hardening the sink. Use `Path.resolve()` and `Path.relative_to()` for robust containment checks, and raise `ValueError` on invalid output path before `mkdir`/copy/write calls.

Changes needed:
- In `export_dashboard_snapshot(...)`, after resolving `run_dir`/`out_dir` and before `out_dir.mkdir(...)`:
  - compute `allowed_export_root = (run_dir / "dashboard_export").resolve()`
  - verify `out_dir.relative_to(allowed_export_root)` in a `try/except ValueError`
  - raise clear `ValueError` if outside allowed root.

No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
