### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -16,6 +16,10 @@ _STATIC_DIR = Path(__file__).parent / "static"
 def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path | None = None) -> Path:
     run_dir = run_dir.resolve()
     out_dir = out_dir.resolve()
+    try:
+        out_dir.relative_to(run_dir)
+    except ValueError as exc:
+        raise ValueError(f"Export output directory must be inside run directory: {out_dir}") from exc
     out_dir.mkdir(parents=True, exist_ok=True)
 
     events_file = run_dir / "events.jsonl"


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/30](https://github.com/bnnr-team/bnnr/security/code-scanning/30)

General fix: when using a path influenced by untrusted input, resolve/normalize it and enforce that it remains inside an approved root before any filesystem access.

Best fix here without changing behavior: harden `export_dashboard_snapshot` in `src/bnnr/dashboard/exporter.py` by constraining `out_dir` to be within `run_dir` (which matches current behavior from `backend.py`, where exports are under each run directory). Add a containment check immediately after resolving both paths and before `mkdir`/writes. If `out_dir` is outside `run_dir`, raise `ValueError`.

Change region:
- `src/bnnr/dashboard/exporter.py`, inside `export_dashboard_snapshot` right after:
  - `run_dir = run_dir.resolve()`
  - `out_dir = out_dir.resolve()`

No new dependencies required; use `Path.relative_to()` from stdlib for robust containment check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
