### PR TITLE
Potential fix for code scanning alert no. 29: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -307,7 +307,9 @@ def create_dashboard_app(
     @app.post("/api/run/{run_id}/export", dependencies=[Depends(_require_control_auth)])
     def api_run_export(run_id: str) -> dict[str, Any]:
         run_dir = _resolve_run_dir(run_root, run_id)
-        out_dir = run_dir / "dashboard_export" / datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_dir = (run_dir / "dashboard_export" / datetime.now().strftime("%Y%m%d_%H%M%S")).resolve()
+        if run_dir not in out_dir.parents:
+            raise HTTPException(status_code=400, detail="Invalid export path")
         exported = export_dashboard_snapshot(run_dir=run_dir, out_dir=out_dir, frontend_dist=static_dir)
         return {"ok": True, "path": str(exported), "index": str(exported / "index.html")}
 


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/29](https://github.com/bnnr-team/bnnr/security/code-scanning/29)

General fix: ensure any filesystem path derived from potentially untrusted input is canonicalized (`resolve`) and verified to stay within an allowed root before file access.

Best fix here without changing existing behavior: harden `api_run_export` in `src/bnnr/dashboard/backend.py` so the export destination is explicitly validated against the already-resolved `run_dir` before calling `export_dashboard_snapshot`. This keeps semantics identical for normal requests, but guarantees `out_dir` cannot escape the run directory even if future code changes alter path construction.

Change region:
- `src/bnnr/dashboard/backend.py`, inside `api_run_export` (around lines 308–312 in the snippet).

Implementation details:
- Add a small containment check after computing `out_dir`:
  - resolve `out_dir`
  - verify `run_dir` is in `out_dir.parents`
  - raise `HTTPException(400)` if invalid
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
