### PR TITLE
Potential fix for code scanning alert no. 28: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -16,6 +16,8 @@ _STATIC_DIR = Path(__file__).parent / "static"
 def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path | None = None) -> Path:
     run_dir = run_dir.resolve()
     out_dir = out_dir.resolve()
+    if out_dir != run_dir and run_dir not in out_dir.parents:
+        raise ValueError(f"Output directory must be inside run directory: {out_dir}")
     out_dir.mkdir(parents=True, exist_ok=True)
 
     events_file = run_dir / "events.jsonl"


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/28](https://github.com/bnnr-team/bnnr/security/code-scanning/28)

General fix: when a path may be derived from untrusted input, normalize/resolve it and enforce that it stays inside a trusted base directory before any file operation.

Best targeted fix here (without changing behavior): in `src/bnnr/dashboard/exporter.py`, add a containment check at the start of `export_dashboard_snapshot` to ensure `out_dir` is inside `run_dir`. Since current caller already constructs `out_dir` as `run_dir / "dashboard_export" / timestamp`, this preserves intended behavior while preventing unsafe future callers.

Changes needed:
- In `export_dashboard_snapshot` (around lines 17–19), after resolving paths, validate:
  - `out_dir == run_dir` or `run_dir in out_dir.parents`
  - otherwise raise `ValueError`.
- No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
