### PR TITLE
Potential fix for code scanning alert no. 27: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -16,6 +16,9 @@ _STATIC_DIR = Path(__file__).parent / "static"
 def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path | None = None) -> Path:
     run_dir = run_dir.resolve()
     out_dir = out_dir.resolve()
+    export_root = (run_dir / "dashboard_export").resolve()
+    if out_dir != export_root and export_root not in out_dir.parents:
+        raise ValueError(f"out_dir must be within {export_root}, got: {out_dir}")
     out_dir.mkdir(parents=True, exist_ok=True)
 
     events_file = run_dir / "events.jsonl"


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/27](https://github.com/bnnr-team/bnnr/security/code-scanning/27)

General fix: enforce canonical-path containment checks before using user-influenced paths in filesystem operations. Resolve both the allowed base and candidate path, and reject if the candidate is not inside the allowed base.

Best targeted fix here: in `src/bnnr/dashboard/exporter.py`, validate that `out_dir` is inside `run_dir / "dashboard_export"` before creating directories or writing files. This preserves current behavior (exports still go to timestamped subdirectories) while making the sink robust regardless of caller assumptions.

Changes needed:
- In `export_dashboard_snapshot(...)`, after resolving `run_dir`/`out_dir`, compute `export_root = (run_dir / "dashboard_export").resolve()`.
- Verify `out_dir` is either exactly `export_root` or a descendant (`export_root in out_dir.parents`).
- If not, raise `ValueError`.
- Keep all existing functionality unchanged otherwise.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
