### PR TITLE
Potential fix for code scanning alert no. 26: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -307,8 +307,12 @@ def create_dashboard_app(
     @app.post("/api/run/{run_id}/export", dependencies=[Depends(_require_control_auth)])
     def api_run_export(run_id: str) -> dict[str, Any]:
         run_dir = _resolve_run_dir(run_root, run_id)
-        out_dir = run_dir / "dashboard_export" / datetime.now().strftime("%Y%m%d_%H%M%S")
-        exported = export_dashboard_snapshot(run_dir=run_dir, out_dir=out_dir, frontend_dist=static_dir)
+        resolved_root = run_root.resolve()
+        resolved_run_dir = run_dir.resolve()
+        if resolved_root not in resolved_run_dir.parents:
+            raise HTTPException(status_code=400, detail="Invalid run directory")
+        out_dir = resolved_run_dir / "dashboard_export" / datetime.now().strftime("%Y%m%d_%H%M%S")
+        exported = export_dashboard_snapshot(run_dir=resolved_run_dir, out_dir=out_dir, frontend_dist=static_dir)
         return {"ok": True, "path": str(exported), "index": str(exported / "index.html")}
 
     @app.get("/api/run/{run_id}/events")


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/26](https://github.com/bnnr-team/bnnr/security/code-scanning/26)

General fix: enforce path containment at the point where user-influenced paths are converted into filesystem access. Canonicalize (`resolve`) and verify the resolved path is inside a trusted root before any reads/writes.

Best fix here without changing behavior: harden `api_run_export` in `src/bnnr/dashboard/backend.py` by adding an explicit post-resolution containment check right before invoking `export_dashboard_snapshot`. This is redundant with `_resolve_run_dir` today, but it makes the trust boundary explicit at the sensitive sink call and satisfies static analysis flow expectations. No functional change for valid inputs; invalid paths are rejected with HTTP 400/404 as appropriate.

Changes needed:
- File: `src/bnnr/dashboard/backend.py`
- Region: `api_run_export` (around lines 307–312)
- Add:
  - `resolved_root = run_root.resolve()`
  - `resolved_run_dir = run_dir.resolve()`
  - containment guard: `if resolved_root not in resolved_run_dir.parents: raise HTTPException(...)`
  - pass `resolved_run_dir` to `export_dashboard_snapshot`

No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
