### PR TITLE
Potential fix for code scanning alert no. 25: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -186,6 +186,7 @@ def create_dashboard_app(
         return events_file
 
     def _state_for_run(run_id: str) -> dict[str, Any]:
+        _validate_run_id(run_id)
         events_file = _events_file(run_id)
         mtime = events_file.stat().st_mtime
         now = time.monotonic()


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/25](https://github.com/bnnr-team/bnnr/security/code-scanning/25)

General fix approach: ensure any filesystem path derived from request `run_id` is validated and canonicalized before use, and ensure all endpoints use the validated value consistently.

Best single fix: add explicit `run_id` validation at the start of `_state_for_run(run_id)` so every endpoint that calls this helper is protected by one centralized guard before `_events_file(run_id)` is called. This preserves existing behavior while making the trust boundary explicit and should address all alert variants that flow via `_state_for_run` into event-file reads.

Change needed in:
- `src/bnnr/dashboard/backend.py` in function `_state_for_run(run_id: str)`:
  - Insert `_validate_run_id(run_id)` as the first statement before any path/file operations.

No new imports, dependencies, or new helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
