### PR TITLE
Potential fix for code scanning alert no. 21: Uncontrolled data used in path expression

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -119,8 +119,9 @@ def _validate_run_id(run_id: str) -> None:
 
 def _resolve_run_dir(run_root: Path, run_id: str) -> Path:
     _validate_run_id(run_id)
-    run_dir = (run_root / run_id).resolve()
-    if not run_dir.exists() or run_root.resolve() not in run_dir.parents:
+    resolved_root = run_root.resolve()
+    run_dir = (resolved_root / run_id).resolve()
+    if not run_dir.exists() or (run_dir != resolved_root and resolved_root not in run_dir.parents):
         raise HTTPException(status_code=404, detail="Run not found")
     return run_dir
 


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/21](https://github.com/bnnr-team/bnnr/security/code-scanning/21)

General fix approach: when using user-influenced path segments, resolve both base and candidate paths and enforce that the candidate is within the base via a canonical containment check (`candidate == base or base in candidate.parents`), then use that validated path for file operations.

Best single fix in this file: harden `_resolve_run_dir` so the resolved `run_dir` must be equal to `run_root` or a descendant of it, using pre-resolved `resolved_root` and `run_dir`. This preserves existing behavior for valid run IDs while making the sanitization explicit and robust.

Change location:
- **File:** `src/bnnr/dashboard/backend.py`
- **Region:** function `_resolve_run_dir` (lines around 120–125 in provided snippet)

What is needed:
- No new imports or dependencies.
- Replace the existing parent-only containment check with an explicit root-or-descendant check using resolved paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
