### PR TITLE
Potential fix for code scanning alert no. 106: Clear-text storage of sensitive information

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -64,7 +64,7 @@ def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path 
             {
                 "version": "1.0",
                 "mode": "offline_replay",
-                "run_dir": str(trusted_run),
+                "run_dir": trusted_run.name,
                 "has_frontend": False,
                 "files": {
                     "events": "data/events.jsonl",


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/106](https://github.com/bnnr-team/bnnr/security/code-scanning/106)

General fix: do not persist sensitive filesystem details in export artifacts. Minimize stored metadata to the least sensitive value required for functionality.

Best fix here (without changing existing behavior materially): in `src/bnnr/dashboard/exporter.py`, update the manifest payload so it does not write `str(trusted_run)` to `manifest.json`. Replace it with `trusted_run.name` (or another non-sensitive relative identifier). This keeps manifest usefulness (identifying the run) while removing clear-text absolute path disclosure.

Change needed:
- File: `src/bnnr/dashboard/exporter.py`
- Region: manifest construction in `export_dashboard_snapshot(...)` around lines 62–69.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
