### PR TITLE
Potential fix for code scanning alert no. 104: Clear-text logging of sensitive information

### DIFF
--- a/src/bnnr/events.py
+++ b/src/bnnr/events.py
@@ -155,7 +155,7 @@ def load_events(events_file: Path) -> list[dict[str, Any]]:
         except json.JSONDecodeError as exc:
             logger.warning(
                 "Skipping invalid JSONL line in %s: %s",
-                events_file,
+                "events.jsonl",
                 exc,
             )
     return rows
@@ -184,7 +184,7 @@ def load_events_from_offset(events_file: Path, byte_offset: int) -> tuple[list[d
             except json.JSONDecodeError as exc:
                 logger.warning(
                     "Skipping invalid JSONL line in %s (from offset %s): %s",
-                    events_file,
+                    "events.jsonl",
                     byte_offset,
                     exc,
                 )


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/104](https://github.com/bnnr-team/bnnr/security/code-scanning/104)

To fix this without changing functionality, keep the warning logs but remove sensitive path data from log messages. The best approach is to log only non-sensitive context (for example, filename `events.jsonl` and error details), not absolute/derived directory paths.

In `src/bnnr/events.py`, update the two warning calls in:
- `load_events(...)` (around lines 156–160)
- `load_events_from_offset(...)` (around lines 185–190)

Replace `events_file` in log arguments with a safe constant (`"events.jsonl"`), and adjust message text accordingly. No behavior changes to parsing or return values are needed. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
