### PR TITLE
Potential fix for code scanning alert no. 47: Binding a socket to all network interfaces

### DIFF
--- a/src/bnnr/dashboard/serve.py
+++ b/src/bnnr/dashboard/serve.py
@@ -40,20 +40,19 @@ def _get_lan_ip() -> str:
 def _pick_bind_host(port: int) -> str:
     """Pick the best bind host for the dashboard server.
 
-    Prefer ``0.0.0.0`` for LAN access. If that bind is not permitted in the
-    environment, gracefully fall back to ``127.0.0.1`` so local access still
-    works.
+    Bind to loopback only (``127.0.0.1``) to avoid exposing the dashboard on
+    all network interfaces.
     """
-    for host in ("0.0.0.0", "127.0.0.1"):
+    for host in ("127.0.0.1",):
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind((host, port))
             return host
         except OSError:
             continue
-    # If both probes fail, keep historical behavior so uvicorn surfaces
+    # If probing fails, keep loopback as the default so uvicorn surfaces
     # the concrete bind error to the user.
-    return "0.0.0.0"
+    return "127.0.0.1"
 
 
 def _print_qr_code(url: str) -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/47](https://github.com/bnnr-team/bnnr/security/code-scanning/47)

To fix this without breaking core functionality, change `_pick_bind_host` so it no longer tries `0.0.0.0` and instead binds only to loopback (`127.0.0.1`). This removes the all-interfaces bind pattern while preserving dashboard availability on the local machine.

Best single change in `src/bnnr/dashboard/serve.py`:
- Update `_pick_bind_host` docstring to reflect secure behavior.
- Replace host iteration from `("0.0.0.0", "127.0.0.1")` to just `("127.0.0.1",)`.
- Update fallback return from `"0.0.0.0"` to `"127.0.0.1"`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
