### PR TITLE
Potential fix for code scanning alert no. 46: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
   notebooks-smoke:
     name: notebooks-smoke
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/46](https://github.com/bnnr-team/bnnr/security/code-scanning/46)

Add an explicit `permissions` block to the `notebooks-smoke` job so it no longer relies on repository/org defaults.  
Best minimal fix without changing behavior: set:

```yml
permissions:
  contents: read
```

Place it under `runs-on` (or alongside other job keys) in `.github/workflows/ci.yml` for the `notebooks-smoke` job. This matches what the workflow already does for `quality-linux` and satisfies CodeQL’s recommendation while preserving current functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
