### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality-linux:
     name: quality-linux


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/3](https://github.com/bnnr-team/bnnr/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs without their own `permissions` inherit least-privilege defaults. The best minimal fix is:

- `permissions:`
  - `contents: read`

Place it at workflow root level (e.g., after `concurrency` and before `jobs`). This preserves existing behavior while making token scope explicit and restricted for build/test jobs. Keep the existing `publish-pypi` job-level permissions unchanged, since it needs `id-token: write` for trusted publishing and already overrides appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
