### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality-linux:
     name: quality-linux


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/1](https://github.com/bnnr-team/bnnr/security/code-scanning/1)

Add a **workflow-level `permissions` block** so every job gets least-privilege defaults unless explicitly overridden.  
Best fix in this file: insert below `concurrency` and above `jobs`:

```yml
permissions:
  contents: read
```

Why this is best here:
- Minimal and safe: preserves existing behavior for read-only operations like checkout/tests.
- Covers all jobs currently missing permissions (`notebooks-smoke`, `test-ubuntu-matrix`, `test-cross-platform`, etc.) in one change.
- Does not break `publish-pypi`, which already defines job-level permissions (`id-token: write`, `contents: read`) and will override/extend as needed.

No imports, methods, or external definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
