### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality-linux:
     name: quality-linux


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/2](https://github.com/bnnr-team/bnnr/security/code-scanning/2)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` near the top (after `concurrency` is a clean location), setting least-privilege defaults for all jobs:

- `contents: read`

This preserves functionality for jobs that only need read access (checkout/tests/build). The existing `publish-pypi` job already defines its own `permissions` (`id-token: write`, `contents: read`), so it will continue to use those elevated permissions only where needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
