### PR TITLE
fix(ci): add workflow permissions for CodeQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality-linux:
     name: quality-linux


### PR DESCRIPTION
## Summary
- Add workflow-level `permissions: contents: read` to close CodeQL alerts #1, #2, #3, #46 (`actions/missing-workflow-permissions`).
- Supersedes draft PRs #38, #39, #40, #41.

## Test plan
- [ ] CI green on this PR
- [ ] CodeQL actions analysis passes

Made with [Cursor](https://cursor.com)