### PR TITLE
fix(security): harden dashboard export manifest and HTML

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -64,7 +64,7 @@ def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path 
             {
                 "version": "1.0",
                 "mode": "offline_replay",
-                "run_dir": str(trusted_run),
+                "run_dir": trusted_run.name,
                 "has_frontend": False,
                 "files": {
                     "events": "data/events.jsonl",
@@ -92,6 +92,8 @@ def _copy_logos_to(dest: Path) -> None:
 
 def _standalone_report_html(state: dict, run_name: str) -> str:
     """Generate a professional standalone HTML report when no frontend build is available."""
+
+    safe_run_name = html.escape(str(run_name))
 
     # Extract key data
     mt = state.get("metrics_timeline", [])
@@ -360,7 +362,7 @@ def _standalone_report_html(state: dict, run_name: str) -> str:
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>BNNR Report — {run_name}</title>
+    <title>BNNR Report — {safe_run_name}</title>
     <style>
         :root {{
             --bg: #f8fafc; --card: #ffffff; --fg: #0f172a; --muted: #64748b;
@@ -423,7 +425,7 @@ def _standalone_report_html(state: dict, run_name: str) -> str:
         <div class="header">
             <img src="./logo_light.png" alt="BNNR" class="logo" onerror="this.style.display='none'"/>
             <h1>BNNR Training Report</h1>
-            <div class="run-id">{run_name}</div>
+            <div class="run-id">{safe_run_name}</div>
             <div class="badge">Offline Report</div>
         </div>
 

--- a/tests/test_dashboard_export.py
+++ b/tests/test_dashboard_export.py
@@ -36,6 +36,33 @@ def test_export_dashboard_snapshot_creates_static_bundle(temp_dir) -> None:
     assert (exported / "data" / "state.json").exists()
     assert (exported / "artifacts" / "a.txt").exists()
     assert (exported / "manifest.json").exists()
+    manifest = json.loads((exported / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["run_dir"] == "run_1"
+
+
+def test_export_standalone_report_escapes_run_name_in_html(temp_dir) -> None:
+    run_name = "<script>alert(1)</script>"
+    run_dir = temp_dir / run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "events.jsonl").write_text(
+        json.dumps(
+            {
+                "schema_version": "2.1",
+                "sequence": 1,
+                "run_id": run_name,
+                "timestamp": "2026-01-01T00:00:00Z",
+                "type": "run_started",
+                "payload": {"run_name": run_name},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exported = export_dashboard_snapshot(run_dir, temp_dir / "exported_xss")
+    index_html = (exported / "index.html").read_text(encoding="utf-8")
+    assert "<script>alert(1)</script>" not in index_html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in index_html
 
 
 def test_export_with_frontend_generates_single_index_with_visual_sections(temp_dir) -> None:

--- a/tests/test_dashboard_export.py
+++ b/tests/test_dashboard_export.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from bnnr.dashboard.exporter import export_dashboard_snapshot
+from bnnr.dashboard.exporter import _standalone_report_html, export_dashboard_snapshot
 
 
 def test_export_dashboard_snapshot_creates_static_bundle(temp_dir) -> None:
@@ -40,29 +40,11 @@ def test_export_dashboard_snapshot_creates_static_bundle(temp_dir) -> None:
     assert manifest["run_dir"] == "run_1"
 
 
-def test_export_standalone_report_escapes_run_name_in_html(temp_dir) -> None:
+def test_standalone_report_html_escapes_run_name() -> None:
     run_name = "<script>alert(1)</script>"
-    run_dir = temp_dir / run_name
-    run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "events.jsonl").write_text(
-        json.dumps(
-            {
-                "schema_version": "2.1",
-                "sequence": 1,
-                "run_id": run_name,
-                "timestamp": "2026-01-01T00:00:00Z",
-                "type": "run_started",
-                "payload": {"run_name": run_name},
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-    exported = export_dashboard_snapshot(run_dir, temp_dir / "exported_xss")
-    index_html = (exported / "index.html").read_text(encoding="utf-8")
+    index_html = _standalone_report_html({"metrics_timeline": []}, run_name)
     assert '<div class="run-id">&lt;script&gt;alert(1)&lt;/script&gt;</div>' in index_html
-    assert f"<title>BNNR Report — &lt;script&gt;alert(1)&lt;/script&gt;</title>" in index_html
+    assert "<title>BNNR Report — &lt;script&gt;alert(1)&lt;/script&gt;</title>" in index_html
 
 
 def test_export_with_frontend_generates_single_index_with_visual_sections(temp_dir) -> None:

--- a/tests/test_dashboard_export.py
+++ b/tests/test_dashboard_export.py
@@ -61,8 +61,8 @@ def test_export_standalone_report_escapes_run_name_in_html(temp_dir) -> None:
 
     exported = export_dashboard_snapshot(run_dir, temp_dir / "exported_xss")
     index_html = (exported / "index.html").read_text(encoding="utf-8")
-    assert "<script>alert(1)</script>" not in index_html
-    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in index_html
+    assert '<div class="run-id">&lt;script&gt;alert(1)&lt;/script&gt;</div>' in index_html
+    assert f"<title>BNNR Report — &lt;script&gt;alert(1)&lt;/script&gt;</title>" in index_html
 
 
 def test_export_with_frontend_generates_single_index_with_visual_sections(temp_dir) -> None:


### PR DESCRIPTION
## Summary
- `manifest.json`: store `trusted_run.name` instead of full resolved path (#106).
- Offline report HTML: `html.escape` for run name in title/header (#105).
- Tests for manifest basename and HTML escaping.
- Supersedes draft PRs #34 and #35.

## Test plan
- [ ] CI + CodeQL green

Made with [Cursor](https://cursor.com)