### PR TITLE
chore(release): v0.4.5 — CodeQL wave 2 completion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bnnr"
-version = "0.4.4"
+version = "0.4.5"
 description = "BNNR — Train → Explain → Improve → Prove"
 readme = "README.pypi.md"
 license = { text = "MIT" }

--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -24,13 +24,14 @@ def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path 
 
     # Build state from events
     state = replay_events(load_events(events_file))
+    run_label = str(state.get("run", {}).get("run_name") or "offline_run")
     # Always generate a single-file offline dashboard report.
     # This avoids blank-page issues from file:// + module scripts and gives
     # deterministic export UX for end users.
     _copy_logos_to(trusted_out)
     index_html = child_path(trusted_out, "index.html")
     index_html.write_text(
-        _standalone_report_html(state, trusted_run.name),
+        _standalone_report_html(state, run_label),
         encoding="utf-8",
     )
 
@@ -64,7 +65,7 @@ def export_dashboard_snapshot(run_dir: Path, out_dir: Path, frontend_dist: Path 
             {
                 "version": "1.0",
                 "mode": "offline_replay",
-                "run_dir": trusted_run.name,
+                "run_dir": run_label,
                 "has_frontend": False,
                 "files": {
                     "events": "data/events.jsonl",

--- a/src/bnnr/dashboard/serve.py
+++ b/src/bnnr/dashboard/serve.py
@@ -4,8 +4,9 @@ Every script — CLI, examples, and user-written — should call
 :func:`start_dashboard` instead of rolling its own ``uvicorn.run``
 wrapper.  This guarantees that:
 
-* The server always binds to ``0.0.0.0`` so phones on the same LAN can
-  connect.
+* The server binds to ``0.0.0.0`` so phones on the same LAN can connect
+  (intentional trade-off for local training dashboards; use
+  ``BNNR_DASHBOARD_TOKEN`` for mutating control endpoints).
 * A QR code with the LAN URL is always printed.
 * Frontend discovery / auto-build logic is consistent.
 """


### PR DESCRIPTION
## Summary
- Export manifest/HTML use `run_name` from events replay (CodeQL #105/#107).
- Document intentional `0.0.0.0` LAN bind in `serve.py` (alert #47 dismissed).
- Bump version to **0.4.5**.

## Test plan
- [ ] CI + CodeQL green

Made with [Cursor](https://cursor.com)