### PR TITLE
docs: add GitHub Discussions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ See [docs/analyze.md](docs/analyze.md) for the full workflow.
 | Colab (classification) | [Open in Colab](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/classification/bnnr_classification_demo.ipynb) |
 | API reference | [docs/api_reference.md](docs/api_reference.md) |
 | Model analysis (`bnnr analyze`) | [docs/analyze.md](docs/analyze.md) |
+| GitHub Discussions | [bnnr-team/bnnr discussions](https://github.com/bnnr-team/bnnr/discussions) |
 | Sample analyze report (live HTML) | [raw.githack.com preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) |
 
 ---

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -122,6 +122,7 @@ Real metrics from a BNNR training run — branch tree, charts, XAI previews, and
 | Colab (classification) | [Open in Colab](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/classification/bnnr_classification_demo.ipynb) |
 | API reference | [docs/api_reference.md](https://github.com/bnnr-team/bnnr/blob/main/docs/api_reference.md) |
 | Model analysis (`bnnr analyze`) | [docs/analyze.md](https://github.com/bnnr-team/bnnr/blob/main/docs/analyze.md) |
+| GitHub Discussions | [bnnr-team/bnnr discussions](https://github.com/bnnr-team/bnnr/discussions) |
 | Sample analyze report (live HTML) | [raw.githack.com preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) |
 
 ---


### PR DESCRIPTION
## Summary
- add the GitHub Discussions row to the README Links table
- mirror the same row in `README.pypi.md`

## Testing
- docs-only change; verified the table formatting in the diff

Fixes #48