### PR TITLE
docs: add benchmark protocol caveat

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -10,3 +10,5 @@ python benchmarks/summarize.py --markdown
 ```
 
 Results: [`benchmarks/results.json`](../benchmarks/results.json) (CIFAR-10 medians: no BNNR **75.3%**, BNNR branch search **81.4%**, RandAugment **72.5%**, 3 seeds). Attention maps: `benchmarks/runs/*/xai/`. See protocol caveats in [`benchmarks/README.md`](../benchmarks/README.md#results-2026-05-28-seeds-4244-cpu).
+
+Protocol caveat: the `no_bnnr` and `randaugment` baselines run for a fixed **5 epochs**, while `bnnr_branch_search` includes the full BNNR pipeline (baseline training plus branch screening), so it uses more compute and a different curriculum. That makes the comparison useful for illustrating the end-to-end workflow, but not a strict apples-to-apples training-budget bakeoff. For the complete methodology and raw caveats, see [`benchmarks/README.md`](../benchmarks/README.md).


### PR DESCRIPTION
## Summary
- add a short protocol caveat paragraph to `docs/benchmarks.md`
- clarify that the fixed-epoch baselines and full BNNR pipeline use different compute budgets
- link readers to `benchmarks/README.md` for the full methodology

## Testing
- docs-only change; verified the Markdown reads cleanly in the diff

Fixes #50