### PR TITLE
test: guard benchmark result coverage

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+RESULTS_PATH = Path(__file__).resolve().parents[1] / "benchmarks" / "results.json"
+REQUIRED_CONDITIONS = {"no_bnnr", "randaugment", "bnnr_branch_search"}
+
+
+def test_benchmark_results_cover_all_conditions() -> None:
+    data = json.loads(RESULTS_PATH.read_text(encoding="utf-8"))
+    runs = data.get("runs") or []
+
+    assert runs, "benchmarks/results.json should include at least one run"
+
+    seen_conditions = {run["condition"] for run in runs}
+    assert REQUIRED_CONDITIONS.issubset(seen_conditions)


### PR DESCRIPTION
## Summary
- add a regression test for `benchmarks/results.json`
- assert the fixture contains runs for `no_bnnr`, `randaugment`, and `bnnr_branch_search`

## Testing
- `PYTHONPATH=src python3 -m pytest --noconftest tests/test_benchmarks.py`

Fixes #49