### PR TITLE
docs+test: close good-first issues #47–#51

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ See [docs/analyze.md](docs/analyze.md) for the full workflow.
 | API reference | [docs/api_reference.md](docs/api_reference.md) |
 | Model analysis (`bnnr analyze`) | [docs/analyze.md](docs/analyze.md) |
 | Sample analyze report (live HTML) | [raw.githack.com preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) |
+| GitHub Discussions | [Q&A and showcase](https://github.com/bnnr-team/bnnr/discussions) |
 
 ---
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -123,6 +123,7 @@ Real metrics from a BNNR training run — branch tree, charts, XAI previews, and
 | API reference | [docs/api_reference.md](https://github.com/bnnr-team/bnnr/blob/main/docs/api_reference.md) |
 | Model analysis (`bnnr analyze`) | [docs/analyze.md](https://github.com/bnnr-team/bnnr/blob/main/docs/analyze.md) |
 | Sample analyze report (live HTML) | [raw.githack.com preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) |
+| GitHub Discussions | [Q&A and showcase](https://github.com/bnnr-team/bnnr/discussions) |
 
 ---
 

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -7,7 +7,9 @@ import argparse
 import json
 import statistics
 from collections import defaultdict
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 BENCHMARKS_DIR = Path(__file__).resolve().parent
 DEFAULT_RESULTS = BENCHMARKS_DIR / "results.json"
@@ -19,7 +21,7 @@ DISPLAY = {
 }
 
 
-def _agg(values: list[float], fn) -> float | None:
+def _agg(values: list[float], fn: Callable[[list[float]], float]) -> float | None:
     return fn(values) if values else None
 
 
@@ -40,7 +42,7 @@ def main() -> None:
 
     agg_fn = statistics.median if args.aggregate == "median" else statistics.mean
 
-    by_cond: dict[str, list[dict]] = defaultdict(list)
+    by_cond: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for r in runs:
         by_cond[r["condition"]].append(r)
 
@@ -53,7 +55,7 @@ def main() -> None:
     for comp in data.get("comparisons") or []:
         print(f"- **{comp['label']}**: {', '.join(comp['conditions'])}")
 
-    rows: list[tuple[str, str, str, str, str, str]] = []
+    rows: list[tuple[str, str, str, str, str, str, str]] = []
     for cid in DISPLAY:
         if cid not in by_cond:
             continue
@@ -71,7 +73,7 @@ def main() -> None:
         edge_s = f"{agg_fn(edges):.2f}" if edges else "—"
 
         per_seed = ", ".join(f"{v*100:.1f}%" for v in accs)
-        xai = rs[-1].get("xai_dir") or "—"
+        xai = str(rs[-1].get("xai_dir") or "—")
         rows.append((DISPLAY[cid], acc_s, delta, cov_s, edge_s, per_seed, xai))
 
     if args.markdown:

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -6,7 +6,7 @@
 
 How to run **zero-friction diagnostics** on a trained model without running full BNNR training: metrics, XAI, data quality, failure analysis, patterns, and recommendations.
 
-**Preview:** open the [sample HTML report](../assets/analyze-report-sample.html) (MNIST checkpoint, no install required).
+**Preview (live in browser, no install):** [sample HTML report on raw.githack.com](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) — MNIST checkpoint, self-contained report.
 
 ## When to use this page
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,4 +9,13 @@ python benchmarks/run.py --seeds 42 --device cpu
 python benchmarks/summarize.py --markdown
 ```
 
-Results: [`benchmarks/results.json`](../benchmarks/results.json) (CIFAR-10 medians: no BNNR **75.3%**, BNNR branch search **81.4%**, RandAugment **72.5%**, 3 seeds). Attention maps: `benchmarks/runs/*/xai/`. See protocol caveats in [`benchmarks/README.md`](../benchmarks/README.md#results-2026-05-28-seeds-4244-cpu).
+Results: [`benchmarks/results.json`](../benchmarks/results.json) (CIFAR-10 medians: no BNNR **75.3%**, BNNR branch search **81.4%**, RandAugment **72.5%**, 3 seeds). Attention maps: `benchmarks/runs/*/xai/`.
+
+## Protocol caveat (read before comparing numbers)
+
+The public table compares **different training budgets**:
+
+- **`no_bnnr` and `randaugment`:** fixed **5 epochs** on the demo CNN — fast baselines, no branch search.
+- **`bnnr_branch_search`:** full BNNR pipeline (baseline phase + screening branches with ICD/AICD) — **more wall-clock and more epochs** on the winning path.
+
+So the Δaccuracy is **illustrative** (product vs simple baselines), not a equal-compute SOTA claim. Hardware, seeds, and full methodology: [`benchmarks/README.md`](../benchmarks/README.md#results-2026-05-28-seeds-4244-cpu).

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,26 @@
+"""Regression guards for published benchmark artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+RESULTS_PATH = Path(__file__).resolve().parents[1] / "benchmarks" / "results.json"
+REQUIRED_CONDITIONS = frozenset({"no_bnnr", "randaugment", "bnnr_branch_search"})
+
+
+@pytest.fixture(name="benchmark_results")
+def fixture_benchmark_results() -> dict:
+    assert RESULTS_PATH.is_file(), f"missing {RESULTS_PATH}"
+    return json.loads(RESULTS_PATH.read_text(encoding="utf-8"))
+
+
+def test_results_json_has_runs_for_all_conditions(benchmark_results: dict) -> None:
+    runs = benchmark_results.get("runs")
+    assert isinstance(runs, list) and runs, "runs must be a non-empty list"
+
+    conditions = {run.get("condition") for run in runs if isinstance(run, dict)}
+    missing = REQUIRED_CONDITIONS - conditions
+    assert not missing, f"missing conditions in results.json: {sorted(missing)}"


### PR DESCRIPTION
## Summary

Maintainer implementation for the five `good first issue` tasks (supersedes external PRs #52–#56).

- **#47** — Replace relative analyze preview with live [raw.githack.com](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) link in `docs/analyze.md` (no duplicate links).
- **#48** — Add GitHub Discussions row to `README.md` and `README.pypi.md`.
- **#50** — Add structured **Protocol caveat** section in `docs/benchmarks.md` (training-budget differences vs `benchmarks/README.md`).
- **#49** — Add `tests/test_benchmarks.py` regression guard for all three conditions in `benchmarks/results.json`.
- **#51** — Minimal type hints in `benchmarks/summarize.py` (no behavior change).

## Test plan

- [x] `python benchmarks/summarize.py --markdown` smoke
- [x] `ruff check src/ tests/`
- [ ] CI `pytest` (including `tests/test_benchmarks.py`)

Closes #47
Closes #48
Closes #49
Closes #50
Closes #51

Made with [Cursor](https://cursor.com)