### PR TITLE
release: v0.4.8 — version sync and analyze report display

### DIFF
--- a/.github/MAINTAINER_SETUP.md
+++ b/.github/MAINTAINER_SETUP.md
@@ -37,7 +37,7 @@ gh issue create --title "Add type hints to a small module in src/bnnr/" \
 Use [CHANGELOG.md](../CHANGELOG.md) for GitHub Release notes:
 
 ```bash
-gh release create v0.4.7 --title "v0.4.7" --notes-file CHANGELOG.md
+gh release create v0.4.8 --title "v0.4.8" --notes-file CHANGELOG.md
 ```
 
 (Trim to the section for that version before publishing, or copy the relevant block into the release body.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.4.8] — 2026-05-28
+
+### Added
+
+- Regression test for `benchmarks/results.json` conditions (#49).
+- GitHub Discussions link in README; live githack link in `docs/analyze.md`; benchmark protocol caveat in `docs/benchmarks.md` (#47–#50).
+
+### Changed
+
+- Analyze report `schema_version` aligned with package version (0.4.8); single source in `src/bnnr/version.py`.
+- HTML report header and footer show package version, not legacy 0.2.1.
+- Type hints in `benchmarks/summarize.py` (#51).
+
+### Fixed
+
+- Version display in analyze HTML reports and regenerated sample artifact.
+
 ## [0.4.7] — 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 **BNNR automatically improves your PyTorch vision models using XAI** — find what your model gets wrong, fix it with intelligent augmentation, and prove the result with structured reports and a live dashboard.
 
-Supported tasks (**v0.4.7**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](docs/README.md) ([detection](docs/detection.md) · [analyze](docs/analyze.md) · [benchmarks](docs/benchmarks.md)).
+Supported tasks (**v0.4.8**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](docs/README.md) ([detection](docs/detection.md) · [analyze](docs/analyze.md) · [benchmarks](docs/benchmarks.md)).
 
 **Try without installing:** [sample analyze HTML report](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) (MNIST, real run — confusion pairs, XAI heatmaps, recommendations).
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -30,7 +30,7 @@
 
 **BNNR automatically improves your PyTorch vision models using XAI** — find what your model gets wrong, fix it with intelligent augmentation, and prove the result with structured reports and a live dashboard.
 
-Supported tasks (**v0.4.7**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md).
+Supported tasks (**v0.4.8**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md).
 
 **Sample analyze report (no install):** [live HTML preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,22 +16,29 @@ Fix any failures **before** tagging. Pushing `v*` triggers the **publish-pypi** 
 
 ## Version bump
 
-1. **Version** — bump `version` in `pyproject.toml` and `__version__` in `src/bnnr/__init__.py` (and dashboard `FastAPI(..., version=...)` in `src/bnnr/dashboard/backend.py` if you keep it in sync). Update `CHANGELOG.md`, `README.md` if they mention the version, `examples/detection/bnnr_detection_demo.ipynb` if the install pin changes, then `uv lock`.
+1. **Version** — bump `__version__` in [`src/bnnr/version.py`](src/bnnr/version.py) and `version` in `pyproject.toml` (must match). `src/bnnr/__init__.py` re-exports from `bnnr.version`; analyze `REPORT_SCHEMA_VERSION` follows the same value. Dashboard `FastAPI` reads `bnnr.version.__version__`. Update `CHANGELOG.md`, `README.md` / `README.pypi.md` if they mention the version, `examples/detection/bnnr_detection_demo.ipynb` if the install pin changes, then `uv lock`.
+2. **Analyze sample HTML** — after an analyze or version change affecting reports, regenerate the public preview:
 
-2. **Build** — dashboard frontend must be built (see `README.md` / CI). Then:
+   ```bash
+   .venv-uv/bin/python scripts/generate_analyze_sample_report.py
+   ```
+
+   Confirm `docs/assets/analyze-report-sample.html` shows `v<version>` (not a stale schema number) and embedded base64 images.
+
+3. **Build** — dashboard frontend must be built (see `README.md` / CI). Then:
 
    ```bash
    pip install hatch
    hatch build
    ```
 
-3. **Upload** — CI uses [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) on tag `v*`. For a manual upload:
+4. **Upload** — CI uses [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) on tag `v*`. For a manual upload:
 
    ```bash
    pip install twine
    twine upload dist/bnnr-<version>*
    ```
 
-4. **Verify** — in a clean venv: `pip install "bnnr>=<version>"`; run `pytest` or the detection notebook on Colab.
+5. **Verify** — in a clean venv: `pip install "bnnr>=<version>"`; run `pytest` or the detection notebook on Colab.
 
-5. **Tag** — after `main` contains the release commit, create and push the annotated tag (e.g. `v0.2.8`) so CI publishes the wheel.
+6. **Tag** — after `main` contains the release commit, create and push the annotated tag (e.g. `v0.4.8`) so CI publishes the wheel.

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -171,7 +171,7 @@ report.to_html("./analysis_out/report.html")
 
 - **Attributes (core)**: `metrics`, `per_class_accuracy`, `confusion`, `xai_insights`, `xai_diagnoses`, `xai_quality_summary`, `data_quality_result`, `failure_patterns`, `recommendations`.
 - **Attributes (extended v0.2)**:
-  - `schema_version` — report schema version string.
+  - `schema_version` — report schema version string (from 0.4.8 onward, matches the installed `bnnr` package version; older reports may show `0.2.1`).
   - `executive_summary` — health badge/score, key findings, top actions, critical classes.
   - `findings` — structured, root-cause oriented findings (type, evidence, interpretation, severity).
   - `recommendations_structured` — prioritized, causal recommendations linked to findings.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -44,7 +44,7 @@ When you run `bnnr analyze --model ... --data ... --output DIR`, the following a
 
 Structure of `analysis_report.json` (top-level keys, v0.2):
 
-- `schema_version` — report schema version string.
+- `schema_version` — report schema version string (aligned with package version since 0.4.8; legacy artifacts may use `0.2.1`).
 - `metrics` — e.g. `accuracy`, `f1_macro`, `loss`.
 - `per_class_accuracy` — per-class counts and accuracy.
 - `confusion` — confusion matrix (format depends on task).

--- a/docs/assets/analyze-report-sample.html
+++ b/docs/assets/analyze-report-sample.html
@@ -396,7 +396,7 @@ tr:hover td { background: rgba(240,160,105,0.03); }
 <div>
 <h1>BNNR Analysis Report</h1>
 <div class="report-meta">
-<span>v0.2.1</span>
+<span>v0.4.8</span>
 <span>Classification</span>
 <span>10 classes · 10,000 samples</span>
 </div></div></div>
@@ -436,6 +436,6 @@ tr:hover td { background: rgba(240,160,105,0.03); }
 <div class="rec-grid"><div class="rec-card"><div class="rec-header"><span class="rec-priority" style="min-width:22px;text-align:center;">1</span><span class="rec-title">Reduce top class confusions: 4, 9, 7, 5, 8, 3</span> <span class="badge badge-ok">Observed</span></div><div class="rec-why">label 4 recall=80%. label 9 recall=86%. label 7 recall=78%.</div><div class="rec-evidence" style="font-size:11px;color:var(--muted);margin-top:4px;"><strong>From this run:</strong> label 4 recall=80%; label 9 recall=86%; label 7 recall=78%; count=145; count=144</div><div class="rec-action">→ Inspect XAI overlays for both classes (see Confusion Analysis section). Pair-specific augmentation or metric learning (ArcFace; Deng et al., CVPR 2019) increases inter-class separation.</div><div style="font-size:12px;color:var(--green);margin-top:6px;padding:4px 10px;background:rgba(34,197,94,0.08);border-radius:6px;border:1px solid rgba(34,197,94,0.2);">[Observed] Literature context (not verified on this run): Targeted data collection or metric learning often reduces specific confusions; quantify with your confusion matrix after changes.</div><div style="font-size:10px;color:var(--muted);margin-top:4px;font-style:italic;">📚 Deng et al., ArcFace, CVPR 2019</div></div></div>
 </div>
 </div></div>
-<div class="footer"><div class="brand">BNNR — Train → Explain → Improve → Prove</div><div class="tagline">Helping your model earn its place in production.</div><div style="margin-top:8px;">Schema v0.2.1</div></div>
+<div class="footer"><div class="brand">BNNR — Train → Explain → Improve → Prove</div><div class="tagline">Helping your model earn its place in production.</div><div style="margin-top:8px;">BNNR v0.4.8</div></div>
 </div>
 </body></html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bnnr"
-version = "0.4.7"
+version = "0.4.8"
 description = "BNNR — Train → Explain → Improve → Prove"
 readme = "README.pypi.md"
 license = { text = "MIT" }

--- a/src/bnnr/__init__.py
+++ b/src/bnnr/__init__.py
@@ -17,7 +17,7 @@ from bnnr.quick_run import quick_run
 from bnnr.reporting import BNNRRunResult, Reporter, compare_runs, load_report
 from bnnr.xai import OptiCAMExplainer, generate_saliency_maps
 
-__version__ = '0.4.7'
+from bnnr.version import __version__
 
 # Full API available via subpackage imports (bnnr.xai, bnnr.augmentations,
 # bnnr.detection_adapter, bnnr.events, bnnr.kornia_aug, etc.).

--- a/src/bnnr/__init__.py
+++ b/src/bnnr/__init__.py
@@ -15,9 +15,8 @@ from bnnr.icd import AICD, ICD
 from bnnr.presets import auto_select_augmentations, get_preset, list_presets
 from bnnr.quick_run import quick_run
 from bnnr.reporting import BNNRRunResult, Reporter, compare_runs, load_report
-from bnnr.xai import OptiCAMExplainer, generate_saliency_maps
-
 from bnnr.version import __version__
+from bnnr.xai import OptiCAMExplainer, generate_saliency_maps
 
 # Full API available via subpackage imports (bnnr.xai, bnnr.augmentations,
 # bnnr.detection_adapter, bnnr.events, bnnr.kornia_aug, etc.).

--- a/src/bnnr/analysis/html_report.py
+++ b/src/bnnr/analysis/html_report.py
@@ -1343,7 +1343,8 @@ def render_analysis_html(
     if artifact_root is not None:
         root = Path(artifact_root)
 
-    schema_version = getattr(report, "schema_version", "0.2.1")
+    from bnnr.version import __version__
+
     metrics = getattr(report, "metrics", {}) or {}
     confusion = getattr(report, "confusion", {}) or {}
     summary = getattr(report, "executive_summary", {}) or {}
@@ -1412,7 +1413,7 @@ def render_analysis_html(
         '<div>',
         "<h1>BNNR Analysis Report</h1>",
         '<div class="report-meta">',
-        f'<span>v{_esc(schema_version)}</span>',
+        f'<span>v{_esc(__version__)}</span>',
         f'<span>{_esc(task_label.title())}</span>',
         f'<span>{num_classes} classes \u00b7 {num_samples:,} samples</span>' if num_samples else "",
         '</div></div></div>',
@@ -1523,7 +1524,7 @@ def render_analysis_html(
         '<div class="footer">'
         '<div class="brand">BNNR \u2014 Train \u2192 Explain \u2192 Improve \u2192 Prove</div>'
         '<div class="tagline">Helping your model earn its place in production.</div>'
-        f'<div style="margin-top:8px;">Schema v{_esc(schema_version)}</div>'
+        f'<div style="margin-top:8px;">BNNR v{_esc(__version__)}</div>'
         '</div>'
     )
 

--- a/src/bnnr/analysis/schema.py
+++ b/src/bnnr/analysis/schema.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
-REPORT_SCHEMA_VERSION = "0.2.1"
+from bnnr.version import __version__ as REPORT_SCHEMA_VERSION
 
 
 @dataclass

--- a/src/bnnr/analysis/schema.py
+++ b/src/bnnr/analysis/schema.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
-from bnnr.version import __version__ as REPORT_SCHEMA_VERSION
+from bnnr import version as _bnnr_version
+
+REPORT_SCHEMA_VERSION = _bnnr_version.__version__
 
 
 @dataclass

--- a/src/bnnr/analyze.py
+++ b/src/bnnr/analyze.py
@@ -55,8 +55,8 @@ class AnalysisReport:
     data_quality_result: dict[str, Any] = field(default_factory=dict)
     failure_patterns: list[dict[str, Any]] = field(default_factory=list)
     recommendations: list[str] = field(default_factory=list)
-    # Extended v0.2 schema
-    schema_version: str = "0.2.1"
+    # Extended analyze schema (version aligned with package — see bnnr.version)
+    schema_version: str = field(default_factory=lambda: REPORT_SCHEMA_VERSION)
     executive_summary: dict[str, Any] = field(default_factory=dict)
     findings: list[dict[str, Any]] = field(default_factory=list)
     recommendations_structured: list[dict[str, Any]] = field(default_factory=list)

--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -168,7 +168,9 @@ def create_dashboard_app(
         replay of completed/interrupted runs.
     """
     run_root = _normalize_run_root(run_root)
-    app = FastAPI(title="BNNR Dashboard API", version="0.4.7")
+    from bnnr.version import __version__
+
+    app = FastAPI(title="BNNR Dashboard API", version=__version__)
     state_cache: dict[str, _CacheEntry] = {}
     static_dir = static_dir.resolve() if static_dir is not None else None
 

--- a/src/bnnr/version.py
+++ b/src/bnnr/version.py
@@ -1,0 +1,3 @@
+"""Single source of truth for the BNNR package version (also used as analyze report schema version)."""
+
+__version__ = "0.4.8"

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -153,12 +153,15 @@ def test_analysis_report_to_html_embeds_overlay_images(tmp_path: Path) -> None:
 
 def test_analyze_sample_report_is_self_contained() -> None:
     """Committed sample report must not reference external artifact paths."""
+    from bnnr import __version__
+
     sample = Path(__file__).resolve().parents[1] / "docs" / "assets" / "analyze-report-sample.html"
     if not sample.exists():
         return
     html = sample.read_text(encoding="utf-8")
     assert 'src="artifacts/' not in html
     assert "data:image/png;base64," in html
+    assert f"v{__version__}" in html
 
 def test_analyze_model_extended_report_fields(model_adapter, tmp_path: Path) -> None:
     """Extended analysis populates executive_summary, findings, class_diagnostics, recommendations_structured."""
@@ -171,7 +174,9 @@ def test_analyze_model_extended_report_fields(model_adapter, tmp_path: Path) -> 
         output_dir=None,
         run_data_quality=False,
     )
-    assert report.schema_version == "0.2.1"
+    from bnnr import __version__
+
+    assert report.schema_version == __version__
     assert isinstance(report.executive_summary, dict)
     assert "health_status" in report.executive_summary or len(report.executive_summary) >= 0
     assert isinstance(report.findings, list)

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "bnnr"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "grad-cam" },


### PR DESCRIPTION
## Summary

- Single version source: `src/bnnr/version.py` (`0.4.8`)
- `REPORT_SCHEMA_VERSION` and analyze HTML header/footer aligned with package version
- Sample `docs/assets/analyze-report-sample.html` updated (`v0.4.8`, not legacy `0.2.1`)
- CHANGELOG [0.4.8], README bumps, RELEASING.md checklist

## Test plan

- [ ] CI: ruff, mypy, pytest
- [ ] `bnnr version` → 0.4.8 after PyPI publish


Made with [Cursor](https://cursor.com)