### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -68,11 +68,13 @@ def _print_pipeline_summary(
     try:
         train_samples = len(train_loader.dataset)  # type: ignore[arg-type]
     except (TypeError, AttributeError):
+        # Some loader wrappers do not expose a sized dataset; keep fallback "?".
         pass
     val_samples: Union[int, str] = "?"
     try:
         val_samples = len(val_loader.dataset)  # type: ignore[arg-type]
     except (TypeError, AttributeError):
+        # Some loader wrappers do not expose a sized dataset; keep fallback "?".
         pass
 
     # Optimizer & scheduler


### PR DESCRIPTION
Keep behavior identical (fallback to `"?"` when sample count cannot be determined), but add an explanatory comment inside each `except ...: pass` block to document intentional suppression.

Best fix in `src/bnnr/cli.py`:
- In `_print_pipeline_summary`, for the two handlers:
  - `except (TypeError, AttributeError):` after `len(train_loader.dataset)`
  - `except (TypeError, AttributeError):` after `len(val_loader.dataset)`
- Replace bare `pass` with a comment plus `pass`, e.g.:
  - `# Some loaders/wrappers do not expose a sized dataset; keep fallback "?".`
  - `pass`

No imports, new methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._