### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -73,6 +73,7 @@ def _print_pipeline_summary(
     try:
         val_samples = len(val_loader.dataset)  # type: ignore[arg-type]
     except (TypeError, AttributeError):
+        # Some loader/dataset wrappers are not sized or don't expose `.dataset`; keep "?" fallback.
         pass
 
     # Optimizer & scheduler


### PR DESCRIPTION
To fix this without changing functionality, keep the exception swallowing behavior but add an explanatory comment inside the flagged `except` clause to document why ignoring these exceptions is intentional.

Best targeted change in `src/bnnr/cli.py`:
- In `_print_pipeline_summary`, at the `except (TypeError, AttributeError):` handling for `val_samples`, replace `pass` with a short comment plus `pass` (or just a comment if syntactically valid with another statement).  
- This satisfies the rule by making intent explicit: some loader wrappers may not expose a sized dataset, so `"?"` remains as fallback.

No imports, new methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._