### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -849,6 +849,7 @@ def list_augmentations(verbose: bool = typer.Option(False, "--verbose", "-v")) -
     try:
         import bnnr.kornia_aug  # noqa: F401
     except ImportError:
+        # Optional dependency: listing should still work without Kornia augmentations.
         pass
 
     names = AugmentationRegistry.list_all()


### PR DESCRIPTION
To fix this without changing functionality, keep catching `ImportError` but document why it is intentionally ignored.  
In `src/bnnr/cli.py`, inside `list_augmentations` at the `except ImportError:` block (around lines 851–852), replace bare `pass` with a short explanatory comment plus `pass`.

This satisfies the CodeQL rule while preserving current behavior (optional Kornia augmentations are skipped when unavailable).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._