### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/detection_augmentations.py
+++ b/src/bnnr/detection_augmentations.py
@@ -635,7 +635,9 @@ def get_detection_preset(
                 )
             )
         except ImportError:
-            pass
+            logger.debug(
+                "albumentations is not installed; skipping optional detection color jitter augmentation."
+            )
         return augs
 
     if preset_name == "aggressive":


### PR DESCRIPTION
The best fix is to keep the optional import behavior but replace the bare `pass` with explicit handling that documents intent and aids diagnostics.

In `src/bnnr/detection_augmentations.py`, inside `get_detection_preset` under the `"standard"` preset, update the `except ImportError:` block (around lines 637–638) to emit a debug log stating that `albumentations` is unavailable and that color jitter augmentation is being skipped. This preserves existing functionality (no exception raised, same returned augmentations minus optional one) while satisfying CodeQL by making the `except` meaningful.

No new imports are needed because `logger` is already defined in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._