### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/evaluation.py
+++ b/src/bnnr/evaluation.py
@@ -125,8 +125,11 @@ def _run_evaluation_classification(
         for name, fn in custom_metrics.items():
             try:
                 result_metrics[name] = float(fn(last_eval_preds, last_eval_labels))
-            except Exception:
-                pass
+            except Exception as exc:
+                # Custom metrics are optional; keep evaluation non-fatal if a metric callback fails.
+                # Record NaN so consumers can detect the failure instead of silently dropping it.
+                _ = exc
+                result_metrics[name] = float("nan")
 
     if last_eval_preds is None or last_eval_labels is None:
         return result_metrics, {}, {}, None, None


### PR DESCRIPTION
To fix this without changing existing functionality, keep catching exceptions around `custom_metrics` so evaluation continues, but replace bare `pass` with explicit behavior that documents the intent and exposes failure.

Best single fix in `src/bnnr/evaluation.py` (around lines 126–129):
- Change `except Exception: pass` to `except Exception as exc:`
- Add a short explanatory comment that custom metric failures are intentionally non-fatal.
- Store a sentinel value in `result_metrics` for that metric (for example `float("nan")`) so downstream consumers can see the metric failed instead of it silently disappearing.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._