### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/evaluation.py
+++ b/src/bnnr/evaluation.py
@@ -206,7 +206,8 @@ def _run_evaluation_multilabel(
             try:
                 result_metrics[name] = float(fn(last_eval_preds, last_eval_labels))
             except Exception:
-                pass
+                # Custom metric failures are non-fatal; mark metric as invalid.
+                result_metrics[name] = float("nan")
 
     if last_eval_preds is None or last_eval_labels is None:
         return result_metrics, {}, {}, None, None


### PR DESCRIPTION
Keep the current functionality (don’t crash evaluation if a custom metric fails), but replace the silent `pass` with a minimal explanatory comment and lightweight logging/visibility.  
Best single fix in this snippet: in `src/bnnr/evaluation.py`, update the `except Exception:` block around line 208 so it stores a fallback value (e.g., `nan`) for the failing metric instead of doing nothing. This preserves non-fatal behavior, avoids silent failure, and makes downstream outputs indicate that metric computation failed.

No new imports or dependencies are required because `float("nan")` is built-in.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._