### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/presets.py
+++ b/src/bnnr/presets.py
@@ -217,8 +217,8 @@ def auto_select_augmentations(
             if kornia_available():
                 logger.info("Auto-select: Using Kornia GPU augmentations (CUDA + kornia available)")
                 return _build_kornia_preset(random_state)
-        except ImportError:
-            pass
+        except ImportError as exc:
+            logger.debug("Auto-select: Kornia integration unavailable, falling back to built-in GPU augmentations: %s", exc)
 
         # Fall back to built-in GPU-native augmentations
         logger.info("Auto-select: Using GPU-native built-in augmentations (CUDA available)")


### PR DESCRIPTION
Replace the no-op `except ImportError: pass` with an explanatory debug log and then continue fallback behavior unchanged.

Best fix in this file/region:
- In `src/bnnr/presets.py`, inside `auto_select_augmentations`, at the `except ImportError:` block under the Kornia import probe, replace `pass` with a `logger.debug(...)` call (optionally including the exception message).
- This preserves functionality (still falls back to built-in GPU augmentations) while satisfying the rule and improving diagnostics.
- No new imports or dependencies are required since `logger` is already defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._