### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/reporting.py
+++ b/src/bnnr/reporting.py
@@ -42,6 +42,7 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
             try:
                 tmp_path.unlink(missing_ok=True)
             except OSError:
+                # Best-effort cleanup: don't mask the original write/replace failure.
                 pass
         raise
 


### PR DESCRIPTION
To fix this without changing functionality, keep suppressing `OSError` in the temp-file cleanup path, but add an explanatory comment inside the `except OSError:` block clarifying that cleanup failure is non-fatal and must not override the original exception from the atomic write attempt.

Best single fix in `src/bnnr/reporting.py` (around lines 42–45): replace the bare `pass` with a short explanatory comment plus `pass`. No imports, new methods, or structural changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._