### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/dashboard/serve.py
+++ b/src/bnnr/dashboard/serve.py
@@ -94,6 +94,8 @@ def _dist_build_mtime(dist_dir: Path) -> float:
             if path.is_file():
                 newest = max(newest, path.stat().st_mtime)
     except OSError:
+        # Best-effort scan: ignore transient filesystem/permission errors
+        # and return the newest timestamp collected so far.
         pass
     return newest
 


### PR DESCRIPTION
Keep current functionality (best-effort mtime scan) but add an explanatory comment inside the `except OSError` block in `src/bnnr/dashboard/serve.py` within `_dist_build_mtime`.  
This is the minimal, safest fix: no control flow changes, no new imports, no changed return values—just explicit rationale for intentionally ignoring scan errors (e.g., transient file disappearance/permissions) and returning the best-known timestamp.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._