### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -208,6 +208,7 @@ def _standalone_report_html(state: dict, run_name: str) -> str:
                 if 0 <= class_idx < len(class_names):
                     class_name = str(class_names[class_idx])
             except (TypeError, ValueError):
+                # Non-numeric class IDs are valid; keep fallback string(class_id).
                 pass
 
             support = latest.get("support")


### PR DESCRIPTION
The best fix is to keep existing behavior (fallback to `str(class_id)` when `class_id` is non-numeric) while making the intent explicit in the `except` block.  
In `src/bnnr/dashboard/exporter.py`, at the `except (TypeError, ValueError):` block around line 210, replace the bare `pass` with a short explanatory comment plus `pass`. This satisfies CodeQL without changing functionality.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._