### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/events.py
+++ b/src/bnnr/events.py
@@ -378,7 +378,9 @@ def _apply_events_to_state(
                     try:
                         row[mk] = float(mv)
                     except (TypeError, ValueError):
-                        pass
+                        # Ignore non-numeric optional metrics so malformed extras
+                        # do not break replay/state reconstruction.
+                        continue
             metrics_timeline.append(row)
             per_class = payload.get("per_class_accuracy", {})
             xai_insights_raw = payload.get("xai_insights", {})


### PR DESCRIPTION
To fix this without changing functionality, keep catching `TypeError`/`ValueError` and still skip invalid extra metric values, but replace the empty `pass` with an explanatory comment (and optionally `continue`) so the suppression is explicit and compliant with the rule.

In `src/bnnr/events.py`, inside `_apply_events_to_state` under the `"epoch_end"` branch where additional metrics are forwarded, update the `except (TypeError, ValueError):` block (around lines 378–381) to include a clear reason why failures are ignored. No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._