### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/bnnr/events.py
+++ b/src/bnnr/events.py
@@ -59,7 +59,7 @@ class EventSink(Protocol):
         ...
 
     def close(self) -> None:
-        ...
+        pass
 
 
 def _utc_now_iso() -> str:


### PR DESCRIPTION
Use `pass` instead of `...` in the `EventSink.close` method body.

Best fix in this file:
- Edit `src/bnnr/events.py` in `class EventSink(Protocol)`.
- Replace the `...` body of `close(self) -> None` with `pass`.
- No imports, new methods, or dependency changes are needed.

This preserves functionality (still a no-op placeholder) while removing the “statement has no effect” warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._