### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/bnnr/detection_augmentations.py
+++ b/src/bnnr/detection_augmentations.py
@@ -76,7 +76,7 @@ class BboxAwareAugmentation(BaseAugmentation, abc.ABC):
         -------
         (augmented_image, augmented_target)
         """
-        ...
+        raise NotImplementedError
 
     def apply(self, image: np.ndarray) -> np.ndarray:
         """Image-only fallback (boxes are not updated)."""


### PR DESCRIPTION
To fix this class of issue, replace no-op placeholder expression statements (like `...`) in executable code blocks with a meaningful statement (`pass` for intentional no-op, or `raise NotImplementedError` for unimplemented APIs).  
Here, the best fix is to change the abstract method body in `src/bnnr/detection_augmentations.py` so it raises `NotImplementedError`. This preserves abstract-method intent, improves clarity if somehow invoked, and removes the “no effect” statement.

Change region:
- File: `src/bnnr/detection_augmentations.py`
- Method: `BboxAwareAugmentation.apply_with_targets`
- Replace line `...` with `raise NotImplementedError`

No imports, new methods, or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._