### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/bnnr/adapter.py
+++ b/src/bnnr/adapter.py
@@ -22,7 +22,7 @@ class ModelAdapter(Protocol):
         ...
 
     def load_state_dict(self, state: dict[str, Any]) -> None:
-        ...
+        pass
 
 
 @runtime_checkable


### PR DESCRIPTION
To fix this without changing functionality, replace the no-op ellipsis statement in the flagged protocol method body with `pass`, which is the canonical no-op statement and typically not flagged by this rule.

Best targeted fix:
- File: `src/bnnr/adapter.py`
- Region: `ModelAdapter.load_state_dict` method body (line 25 in the provided snippet)
- Change: replace `...` with `pass`
- No imports, helper methods, or extra definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._