### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/bnnr/adapter.py
+++ b/src/bnnr/adapter.py
@@ -31,7 +31,7 @@ class XAICapableModel(ModelAdapter, Protocol):
         ...
 
     def get_model(self) -> nn.Module:
-        ...
+        pass
 
 
 class SimpleTorchAdapter:


### PR DESCRIPTION
Use `pass` instead of `...` in protocol method stubs so method bodies are explicit no-ops that static analyzers generally accept.

Best single fix in `src/bnnr/adapter.py`: update the `get_model` method body in `XAICapableModel` (line 34 region) from `...` to `pass`. This preserves behavior and typing intent, avoids introducing new imports/dependencies, and addresses the CodeQL finding directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._