### PR TITLE
Fix for Explicit export is not defined

### DIFF
--- a/src/bnnr/dashboard/__init__.py
+++ b/src/bnnr/dashboard/__init__.py
@@ -3,13 +3,19 @@
 __all__ = ["create_dashboard_app", "list_runs", "start_dashboard"]
 
 
-def __getattr__(name: str):
-    if name in {"create_dashboard_app", "list_runs"}:
-        from bnnr.dashboard.backend import create_dashboard_app, list_runs
+def create_dashboard_app(*args, **kwargs):
+    from bnnr.dashboard.backend import create_dashboard_app as _create_dashboard_app
 
-        return {"create_dashboard_app": create_dashboard_app, "list_runs": list_runs}[name]
-    if name == "start_dashboard":
-        from bnnr.dashboard.serve import start_dashboard
+    return _create_dashboard_app(*args, **kwargs)
 
-        return start_dashboard
-    raise AttributeError(name)
+
+def list_runs(*args, **kwargs):
+    from bnnr.dashboard.backend import list_runs as _list_runs
+
+    return _list_runs(*args, **kwargs)
+
+
+def start_dashboard(*args, **kwargs):
+    from bnnr.dashboard.serve import start_dashboard as _start_dashboard
+
+    return _start_dashboard(*args, **kwargs)


### PR DESCRIPTION
To fix this without changing functionality, define the exported names explicitly in `src/bnnr/dashboard/__init__.py` as lazy wrapper functions. This keeps imports deferred until call time (preserving the existing lazy behavior and avoiding eager heavy imports), while ensuring `create_dashboard_app`, `list_runs`, and `start_dashboard` are truly defined symbols that match `__all__`.

Best single fix:
- Replace module `__getattr__`-based export resolution with explicit wrapper function definitions for the three exports.
- Keep `__all__` unchanged.
- No new imports are required at module top-level; each wrapper imports its target locally and forwards arguments/return values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._