### PR TITLE
Fix for Explicit export is not defined

### DIFF
--- a/src/bnnr/dashboard/__init__.py
+++ b/src/bnnr/dashboard/__init__.py
@@ -3,13 +3,19 @@
 __all__ = ["create_dashboard_app", "list_runs", "start_dashboard"]
 
 
-def __getattr__(name: str):
-    if name in {"create_dashboard_app", "list_runs"}:
-        from bnnr.dashboard.backend import create_dashboard_app, list_runs
+def create_dashboard_app(*args, **kwargs):
+    from bnnr.dashboard.backend import create_dashboard_app as _create_dashboard_app
 
-        return {"create_dashboard_app": create_dashboard_app, "list_runs": list_runs}[name]
-    if name == "start_dashboard":
-        from bnnr.dashboard.serve import start_dashboard
+    return _create_dashboard_app(*args, **kwargs)
 
-        return start_dashboard
-    raise AttributeError(name)
+
+def list_runs(*args, **kwargs):
+    from bnnr.dashboard.backend import list_runs as _list_runs
+
+    return _list_runs(*args, **kwargs)
+
+
+def start_dashboard(*args, **kwargs):
+    from bnnr.dashboard.serve import start_dashboard as _start_dashboard
+
+    return _start_dashboard(*args, **kwargs)


### PR DESCRIPTION
To fix this without changing functionality, define explicit module-level wrapper functions for the exported names and keep lazy imports inside those wrappers. This ensures every name in `__all__` is genuinely defined, while preserving deferred importing behavior.

Best change in `src/bnnr/dashboard/__init__.py`:
- Add `create_dashboard_app`, `list_runs`, and `start_dashboard` functions at module scope.
- Each wrapper imports and calls the real implementation inside the function body.
- Remove the now-unnecessary module `__getattr__`.

This resolves the CodeQL finding for `"start_dashboard"` (and prevents similar findings for the other exported names), preserves public API names, and keeps lazy loading semantics.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._