### PR TITLE
Fix for Illegal raise

### DIFF
--- a/src/bnnr/augmentation_runner.py
+++ b/src/bnnr/augmentation_runner.py
@@ -187,14 +187,24 @@ class AugmentationRunner:
 
         try:
             while True:
-                if self._worker_exception is not None:
-                    raise self._worker_exception  # type: ignore[misc]
+                exc = self._worker_exception
+                if exc is not None:
+                    if isinstance(exc, BaseException):
+                        raise exc
+                    raise RuntimeError(
+                        f"Prefetch worker failed with non-exception payload: {type(exc).__name__}"
+                    )
 
                 batch = self._prefetch_queue.get()
                 if batch is None:
                     # Worker is done
-                    if self._worker_exception is not None:
-                        raise self._worker_exception  # type: ignore[misc]
+                    exc = self._worker_exception
+                    if exc is not None:
+                        if isinstance(exc, BaseException):
+                            raise exc
+                        raise RuntimeError(
+                            f"Prefetch worker failed with non-exception payload: {type(exc).__name__}"
+                        )
                     break
 
                 images, labels = batch


### PR DESCRIPTION
The best fix is to validate and narrow the raised value to `BaseException` at the raise sites.  
In `src/bnnr/augmentation_runner.py`, replace both direct raises of `self._worker_exception` (lines 191 and 197 in the shown snippet) with a local variable check:

1. Read `exc = self._worker_exception`.
2. If `exc is not None`:
   - If `isinstance(exc, BaseException)`, `raise exc`.
   - Otherwise raise a safe fallback exception (for example `RuntimeError`) describing the invalid worker exception payload.

This preserves existing behavior for valid exceptions and prevents accidental `TypeError` if a non-exception value is stored.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._