### PR TITLE
Fix for Illegal raise

### DIFF
--- a/src/bnnr/augmentation_runner.py
+++ b/src/bnnr/augmentation_runner.py
@@ -187,14 +187,16 @@ class AugmentationRunner:
 
         try:
             while True:
-                if self._worker_exception is not None:
-                    raise self._worker_exception  # type: ignore[misc]
+                worker_exc = self._worker_exception
+                if worker_exc is not None:
+                    raise worker_exc
 
                 batch = self._prefetch_queue.get()
                 if batch is None:
                     # Worker is done
-                    if self._worker_exception is not None:
-                        raise self._worker_exception  # type: ignore[misc]
+                    worker_exc = self._worker_exception
+                    if worker_exc is not None:
+                        raise worker_exc
                     break
 
                 images, labels = batch


### PR DESCRIPTION
Use a local variable to snapshot `self._worker_exception` before each raise site, then raise only if that local variable is not `None`. This is the cleanest fix because it preserves behavior, improves thread-safety clarity, and gives static analysis a clear non-optional exception object at the `raise` statement.

In `src/bnnr/augmentation_runner.py`, inside `iter_augmented(...)`:
- Replace both direct `raise self._worker_exception` statements (lines corresponding to current 191 and 197) with:
  - assign `worker_exc = self._worker_exception`
  - check `if worker_exc is not None: raise worker_exc`

No import changes or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._