### PR TITLE
Fix for Implicit string concatenation in a list

### DIFF
--- a/src/bnnr/analysis/html_report.py
+++ b/src/bnnr/analysis/html_report.py
@@ -1419,8 +1419,10 @@ def render_analysis_html(
         '</div></div></div>',
         *(
             [
-                '<div class="confidence-legend" style="margin-bottom:12px;background:rgba(234,179,8,0.12);'
-                'border:1px solid rgba(234,179,8,0.35);border-radius:8px;padding:10px 14px;">',
+                (
+                    '<div class="confidence-legend" style="margin-bottom:12px;background:rgba(234,179,8,0.12);'
+                    + 'border:1px solid rgba(234,179,8,0.35);border-radius:8px;padding:10px 14px;">'
+                ),
                 f'<strong>Scope:</strong> {_esc(scope_reason)}',
                 "</div>",
             ]


### PR DESCRIPTION
To fix this cleanly without changing functionality, make the concatenation explicit so it is clear the two parts are one string by design.  
Best fix: wrap the split string in parentheses and use `+` between the two string fragments.

Edit only `src/bnnr/analysis/html_report.py` at the list block around lines 1422–1423:
- Replace implicit adjacent literals with explicit concatenation:
  - from:
    - `'<div ...;'
       'border:...;">',`
  - to:
    - `('<div ...;' + 'border:...;">'),`

No imports, new methods, or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._