### PR TITLE
Fix for Implicit string concatenation in a list

### DIFF
--- a/src/bnnr/analysis/html_report.py
+++ b/src/bnnr/analysis/html_report.py
@@ -1430,7 +1430,7 @@ def render_analysis_html(
         *(
             [
                 '<div style="font-size:12px;color:var(--muted);margin-bottom:12px;padding:8px 12px;'
-                'background:var(--card);border-radius:6px;">',
+                + 'background:var(--card);border-radius:6px;">',
                 f'<strong>Note:</strong> {_esc(scope_notes)}',
                 "</div>",
             ]


### PR DESCRIPTION
To fix this, keep the HTML output identical but remove implicit literal adjacency in the list element.

Best fix here: in `src/bnnr/analysis/html_report.py`, in the `lines` list near line 1432, replace the adjacent literals with a single explicit string expression (using `+`) so it is unmistakably one list item. This avoids accidental missing-comma bugs and satisfies CodeQL without changing rendered output.

No new methods/imports/definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._