### PR TITLE
Fix for Comparison of identical values

### DIFF
--- a/tests/test_ultralytics_detection_train_integration.py
+++ b/tests/test_ultralytics_detection_train_integration.py
@@ -10,6 +10,7 @@ exercises BNNR + YOLO26 when this file runs (see ``pytest`` in ``.github/workflo
 
 from __future__ import annotations
 
+import math
 import os
 
 import pytest
@@ -129,7 +130,7 @@ def test_many_train_steps_all_finite(yolo_cpu_adapter) -> None:
         assert metrics.get("loss_yolo_pred_format_error") is None
         assert metrics.get("loss_yolo_fused_head") is None
         loss = float(metrics["loss"])
-        assert loss == loss
+        assert math.isfinite(loss)
         assert loss >= 0.0
 
 
@@ -143,7 +144,7 @@ def test_extreme_class_ids_are_clamped_and_run(yolo_cpu_adapter) -> None:
     m = yolo_cpu_adapter.train_step((images, targets))
     assert m.get("loss_yolo_index_error") is None
     assert m.get("loss_yolo_pred_format_error") is None
-    assert float(m["loss"]) == float(m["loss"])
+    assert math.isfinite(float(m["loss"]))
 
 
 @pytest.mark.yolo26


### PR DESCRIPTION
Use explicit numeric validity checks instead of self-comparison. The best fix is to import Python’s standard `math` module and replace `loss == loss`-style checks with `math.isfinite(loss)`, which clearly enforces “not NaN and not +/-inf” and preserves test intent (“all finite”).

In `tests/test_ultralytics_detection_train_integration.py`:
- Add `import math` near the other imports.
- Replace line 132 `assert loss == loss` with `assert math.isfinite(loss)`.
- Replace line 146 `assert float(m["loss"]) == float(m["loss"])` with `assert math.isfinite(float(m["loss"]))`.

No functionality change beyond making the check explicit and stricter in a desirable way (also rejects infinities, matching the test name “all finite”).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._