### PR TITLE
Fix for Comparison of identical values

### DIFF
--- a/tests/test_ultralytics_detection_train_integration.py
+++ b/tests/test_ultralytics_detection_train_integration.py
@@ -10,6 +10,7 @@ exercises BNNR + YOLO26 when this file runs (see ``pytest`` in ``.github/workflo
 
 from __future__ import annotations
 
+import math
 import os
 
 import pytest
@@ -162,7 +163,7 @@ def test_yolo26_one_train_step_finite(yolo26_cpu_adapter) -> None:
     assert metrics.get("loss_yolo_pred_format_error") is None
     assert metrics.get("loss_yolo_fused_head") is None
     loss = float(metrics["loss"])
-    assert loss == loss
+    assert not math.isnan(loss)
     assert loss >= 0.0
 
 


### PR DESCRIPTION
Use an explicit NaN check instead of self-comparison.

Best fix in this file:  
- Add `import math` near the top-level imports.
- Replace `assert loss == loss` with `assert not math.isnan(loss)` in the affected test (line 165 in the snippet).  
This keeps functionality unchanged (still asserting finite/non-NaN loss intent) while making the check clear and CodeQL-compliant.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._