### PR TITLE
Fix for Comparison of identical values

### DIFF
--- a/tests/test_ultralytics_detection_train_integration.py
+++ b/tests/test_ultralytics_detection_train_integration.py
@@ -10,6 +10,7 @@ exercises BNNR + YOLO26 when this file runs (see ``pytest`` in ``.github/workflo
 
 from __future__ import annotations
 
+import math
 import os
 
 import pytest
@@ -183,5 +184,5 @@ def test_yolo26_multiple_train_steps_finite(yolo26_cpu_adapter) -> None:
         assert metrics.get("loss_yolo_pred_format_error") is None
         assert metrics.get("loss_yolo_fused_head") is None
         loss = float(metrics["loss"])
-        assert loss == loss
+        assert math.isfinite(loss)
         assert loss >= 0.0


### PR DESCRIPTION
Use explicit numeric validity checks instead of self-comparison.  
Best fix: replace `assert loss == loss` with `assert math.isfinite(loss)` (or `assert not math.isnan(loss)`) and add `import math` at the top of the test file. `math.isfinite` is preferable because it also rejects infinities, which aligns with “finite loss” wording in test docstrings.

Edit only `tests/test_ultralytics_detection_train_integration.py`:
- Add `import math` with other imports.
- Replace the flagged assertion at line 186 (`assert loss == loss`) with `assert math.isfinite(loss)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._