### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/src/bnnr/events.py
+++ b/src/bnnr/events.py
@@ -259,7 +259,6 @@ def _apply_events_to_state(
     xai_insights_timeline = acc.xai_insights_timeline
     branch_graph_nodes = acc.branch_graph_nodes
     branch_graph_edges = acc.branch_graph_edges
-    probe_set = acc.probe_set
     decision_history = acc.decision_history
     sample_branch_snapshots = acc.sample_branch_snapshots
 


### PR DESCRIPTION
The best fix is to remove the unnecessary initial assignment to `probe_set` so the variable is only defined where it is actually needed. This preserves behavior and eliminates the dead store warning.

In `src/bnnr/events.py`, inside `_apply_events_to_state(...)`, update the local alias setup block near lines 255–265 by deleting only:

- `probe_set = acc.probe_set`

No import or dependency changes are required. This is the safest single change because it does not alter event processing logic; it only removes an unused/redundant assignment that CodeQL flagged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._