### PR TITLE
Fix for Redundant comparison

### DIFF
--- a/src/bnnr/analysis/class_diagnostics.py
+++ b/src/bnnr/analysis/class_diagnostics.py
@@ -182,7 +182,7 @@ def compute_multilabel_label_diagnostics(
         prec = tp / pred_as_pos if pred_as_pos > 0 else 0.0
         rec = tp / support if support > 0 else 0.0
         f1 = 2 * prec * rec / (prec + rec) if (prec + rec) > 0 else 0.0
-        acc = (tp + tn) / n_samples if n_samples > 0 else 0.0
+        acc = (tp + tn) / n_samples
 
         # Rows/cols: negative vs positive (true × pred) for Cohen's kappa
         binary = np.array([[tn, fp], [fn, tp]], dtype=np.int64)


### PR DESCRIPTION
The best fix is to remove the redundant ternary condition at line 185 and compute accuracy directly, since `n_samples` is already guaranteed positive by the earlier return guard.

In `src/bnnr/analysis/class_diagnostics.py`, inside `compute_multilabel_label_diagnostics`, replace:

- `acc = (tp + tn) / n_samples if n_samples > 0 else 0.0`

with:

- `acc = (tp + tn) / n_samples`

No imports, helper methods, or additional definitions are required. This preserves behavior because `n_samples <= 0` paths already return before the loop.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._