### PR TITLE
chore: repo hardening — dependabot, dependency review, CodeQL fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for review (adjust when the core team grows).
+* @mateuszwalo
+/.github/ @mateuszwalo

--- a/.github/MAINTAINER_SETUP.md
+++ b/.github/MAINTAINER_SETUP.md
@@ -41,3 +41,38 @@ gh release create v0.4.8 --title "v0.4.8" --notes-file CHANGELOG.md
 ```
 
 (Trim to the section for that version before publishing, or copy the relevant block into the release body.)
+
+### 5. Branch protection (`main`)
+
+**Settings → Branches → Add rule** for `main`:
+
+- Require a pull request before merging
+- Require status checks to pass:
+  - `quality-linux`
+  - `test-ubuntu (3.10)` / `test-ubuntu (3.11)` / `test-ubuntu (3.12)` (or require the `test-ubuntu` check group if available)
+  - `test` (matrix jobs on Windows/macOS)
+  - `dependency-review`
+  - `notebooks-smoke`
+- Do not require `publish-pypi` (runs only on version tags)
+
+### 6. Dependabot
+
+- [`.github/dependabot.yml`](dependabot.yml) covers pip, GitHub Actions, and `dashboard_web` npm.
+- Enable **Dependabot security updates** under **Settings → Code security and analysis**.
+
+### 7. Code scanning autofix
+
+To avoid dozens of one-alert PRs (CodeQL / Copilot autofix):
+
+**Settings → Code security and analysis → Code scanning** — disable automatic PR creation per finding, or use batch fixes on a maintainer branch.
+
+Consolidated quality fixes belong in normal PRs with full CI, not in parallel autofix branches.
+
+## Repo automation summary
+
+| Workflow | Purpose |
+|----------|---------|
+| [`ci.yml`](workflows/ci.yml) | ruff, mypy, pytest matrix, build wheel, PyPI on `v*` tags |
+| [`dependency-review.yml`](workflows/dependency-review.yml) | Block PRs that introduce known-vulnerable dependencies |
+| CodeQL (default setup) | Security analysis (weekly) |
+| Dependabot | Weekly dependency PRs |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: "/dashboard_web"
+    schedule:
+      interval: weekly

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ pre-commit run --all-files
 3. Add or update tests for behavior changes.
 4. Update docs (`README.md`, `docs/`) when CLI or user-facing behavior changes.
 5. Ensure `pytest` and `ruff check` pass locally.
-6. Open a PR with a clear summary and test plan.
+6. Open a PR with a clear summary and test plan. PRs must pass CI and [Dependency Review](.github/workflows/dependency-review.yml).
 
 ## Good first issues
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,4 +18,4 @@ The public table compares **different training budgets**:
 - **`no_bnnr` and `randaugment`:** fixed **5 epochs** on the demo CNN — fast baselines, no branch search.
 - **`bnnr_branch_search`:** full BNNR pipeline (baseline phase + screening branches with ICD/AICD) — **more wall-clock and more epochs** on the winning path.
 
-So the Δaccuracy is **illustrative** (product vs simple baselines), not a equal-compute SOTA claim. Hardware, seeds, and full methodology: [`benchmarks/README.md`](../benchmarks/README.md#results-2026-05-28-seeds-4244-cpu).
+So the Δaccuracy is **illustrative** (product vs simple baselines), not an equal-compute SOTA claim. Hardware, seeds, and full methodology: [`benchmarks/README.md`](../benchmarks/README.md#results-2026-05-28-seeds-4244-cpu).

--- a/src/bnnr/adapter.py
+++ b/src/bnnr/adapter.py
@@ -22,7 +22,7 @@ class ModelAdapter(Protocol):
         ...
 
     def load_state_dict(self, state: dict[str, Any]) -> None:
-        ...
+        pass
 
 
 @runtime_checkable
@@ -31,7 +31,7 @@ class XAICapableModel(ModelAdapter, Protocol):
         ...
 
     def get_model(self) -> nn.Module:
-        ...
+        pass
 
 
 class SimpleTorchAdapter:

--- a/src/bnnr/analysis/class_diagnostics.py
+++ b/src/bnnr/analysis/class_diagnostics.py
@@ -182,7 +182,7 @@ def compute_multilabel_label_diagnostics(
         prec = tp / pred_as_pos if pred_as_pos > 0 else 0.0
         rec = tp / support if support > 0 else 0.0
         f1 = 2 * prec * rec / (prec + rec) if (prec + rec) > 0 else 0.0
-        acc = (tp + tn) / n_samples if n_samples > 0 else 0.0
+        acc = (tp + tn) / n_samples
 
         # Rows/cols: negative vs positive (true × pred) for Cohen's kappa
         binary = np.array([[tn, fp], [fn, tp]], dtype=np.int64)

--- a/src/bnnr/analysis/html_report.py
+++ b/src/bnnr/analysis/html_report.py
@@ -1419,8 +1419,10 @@ def render_analysis_html(
         '</div></div></div>',
         *(
             [
-                '<div class="confidence-legend" style="margin-bottom:12px;background:rgba(234,179,8,0.12);'
-                'border:1px solid rgba(234,179,8,0.35);border-radius:8px;padding:10px 14px;">',
+                (
+                    '<div class="confidence-legend" style="margin-bottom:12px;background:rgba(234,179,8,0.12);'
+                    + 'border:1px solid rgba(234,179,8,0.35);border-radius:8px;padding:10px 14px;">'
+                ),
                 f'<strong>Scope:</strong> {_esc(scope_reason)}',
                 "</div>",
             ]
@@ -1430,7 +1432,7 @@ def render_analysis_html(
         *(
             [
                 '<div style="font-size:12px;color:var(--muted);margin-bottom:12px;padding:8px 12px;'
-                'background:var(--card);border-radius:6px;">',
+                + 'background:var(--card);border-radius:6px;">',
                 f'<strong>Note:</strong> {_esc(scope_notes)}',
                 "</div>",
             ]

--- a/src/bnnr/augmentation_runner.py
+++ b/src/bnnr/augmentation_runner.py
@@ -187,14 +187,24 @@ class AugmentationRunner:
 
         try:
             while True:
-                if self._worker_exception is not None:
-                    raise self._worker_exception  # type: ignore[misc]
+                exc = self._worker_exception
+                if exc is not None:
+                    if isinstance(exc, BaseException):
+                        raise exc
+                    raise RuntimeError(
+                        f"Prefetch worker failed with non-exception payload: {type(exc).__name__}"
+                    )
 
                 batch = self._prefetch_queue.get()
                 if batch is None:
                     # Worker is done
-                    if self._worker_exception is not None:
-                        raise self._worker_exception  # type: ignore[misc]
+                    exc = self._worker_exception
+                    if exc is not None:
+                        if isinstance(exc, BaseException):
+                            raise exc
+                        raise RuntimeError(
+                            f"Prefetch worker failed with non-exception payload: {type(exc).__name__}"
+                        )
                     break
 
                 images, labels = batch

--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -68,11 +68,13 @@ def _print_pipeline_summary(
     try:
         train_samples = len(train_loader.dataset)  # type: ignore[arg-type]
     except (TypeError, AttributeError):
+        # Some loader wrappers do not expose a sized dataset; keep fallback "?".
         pass
     val_samples: Union[int, str] = "?"
     try:
         val_samples = len(val_loader.dataset)  # type: ignore[arg-type]
     except (TypeError, AttributeError):
+        # Some loader wrappers do not expose a sized dataset; keep fallback "?".
         pass
 
     # Optimizer & scheduler
@@ -85,6 +87,7 @@ def _print_pipeline_summary(
             try:
                 lr = opt.param_groups[0]["lr"]
             except (IndexError, KeyError, AttributeError):
+                # Optimizer structure can vary; keep default "?" when LR is unavailable.
                 pass
             break
     sched_name = "none"
@@ -849,6 +852,7 @@ def list_augmentations(verbose: bool = typer.Option(False, "--verbose", "-v")) -
     try:
         import bnnr.kornia_aug  # noqa: F401
     except ImportError:
+        # Optional dependency: listing should still work without Kornia augmentations.
         pass
 
     names = AugmentationRegistry.list_all()

--- a/src/bnnr/dashboard/__init__.py
+++ b/src/bnnr/dashboard/__init__.py
@@ -3,13 +3,19 @@
 __all__ = ["create_dashboard_app", "list_runs", "start_dashboard"]
 
 
-def __getattr__(name: str):
-    if name in {"create_dashboard_app", "list_runs"}:
-        from bnnr.dashboard.backend import create_dashboard_app, list_runs
+def create_dashboard_app(*args, **kwargs):
+    from bnnr.dashboard.backend import create_dashboard_app as _create_dashboard_app
 
-        return {"create_dashboard_app": create_dashboard_app, "list_runs": list_runs}[name]
-    if name == "start_dashboard":
-        from bnnr.dashboard.serve import start_dashboard
+    return _create_dashboard_app(*args, **kwargs)
 
-        return start_dashboard
-    raise AttributeError(name)
+
+def list_runs(*args, **kwargs):
+    from bnnr.dashboard.backend import list_runs as _list_runs
+
+    return _list_runs(*args, **kwargs)
+
+
+def start_dashboard(*args, **kwargs):
+    from bnnr.dashboard.serve import start_dashboard as _start_dashboard
+
+    return _start_dashboard(*args, **kwargs)

--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -101,7 +101,7 @@ def _standalone_report_html(state: dict, run_name: str) -> str:
     decisions = state.get("decision_history", [])
     selected_path = state.get("selected_path", ["baseline"])
     branches = state.get("branches", {})
-    state.get("xai", [])  # reserved for future use
+    _xai = state.get("xai", [])  # reserved for future use
     sample_timelines = state.get("sample_timelines", {})
     task = state.get("task")
     if not isinstance(task, str):
@@ -208,6 +208,7 @@ def _standalone_report_html(state: dict, run_name: str) -> str:
                 if 0 <= class_idx < len(class_names):
                     class_name = str(class_names[class_idx])
             except (TypeError, ValueError):
+                # Non-numeric class IDs are valid; keep fallback string(class_id).
                 pass
 
             support = latest.get("support")

--- a/src/bnnr/dashboard/serve.py
+++ b/src/bnnr/dashboard/serve.py
@@ -94,6 +94,7 @@ def _dist_build_mtime(dist_dir: Path) -> float:
             if path.is_file():
                 newest = max(newest, path.stat().st_mtime)
     except OSError:
+        # Best-effort scan: ignore transient filesystem/permission errors.
         pass
     return newest
 

--- a/src/bnnr/detection_augmentations.py
+++ b/src/bnnr/detection_augmentations.py
@@ -76,7 +76,7 @@ class BboxAwareAugmentation(BaseAugmentation, abc.ABC):
         -------
         (augmented_image, augmented_target)
         """
-        ...
+        raise NotImplementedError
 
     def apply(self, image: np.ndarray) -> np.ndarray:
         """Image-only fallback (boxes are not updated)."""
@@ -635,6 +635,7 @@ def get_detection_preset(
                 )
             )
         except ImportError:
+            # Albumentations optional; preset falls back to transforms already added.
             pass
         return augs
 

--- a/src/bnnr/evaluation.py
+++ b/src/bnnr/evaluation.py
@@ -126,7 +126,8 @@ def _run_evaluation_classification(
             try:
                 result_metrics[name] = float(fn(last_eval_preds, last_eval_labels))
             except Exception:
-                pass
+                # Custom metric failures are non-fatal; mark metric as invalid.
+                result_metrics[name] = float("nan")
 
     if last_eval_preds is None or last_eval_labels is None:
         return result_metrics, {}, {}, None, None
@@ -206,7 +207,8 @@ def _run_evaluation_multilabel(
             try:
                 result_metrics[name] = float(fn(last_eval_preds, last_eval_labels))
             except Exception:
-                pass
+                # Custom metric failures are non-fatal; mark metric as invalid.
+                result_metrics[name] = float("nan")
 
     if last_eval_preds is None or last_eval_labels is None:
         return result_metrics, {}, {}, None, None

--- a/src/bnnr/events.py
+++ b/src/bnnr/events.py
@@ -59,7 +59,7 @@ class EventSink(Protocol):
         ...
 
     def close(self) -> None:
-        ...
+        pass
 
 
 def _utc_now_iso() -> str:
@@ -259,7 +259,6 @@ def _apply_events_to_state(
     xai_insights_timeline = acc.xai_insights_timeline
     branch_graph_nodes = acc.branch_graph_nodes
     branch_graph_edges = acc.branch_graph_edges
-    probe_set = acc.probe_set
     decision_history = acc.decision_history
     sample_branch_snapshots = acc.sample_branch_snapshots
 
@@ -378,7 +377,8 @@ def _apply_events_to_state(
                     try:
                         row[mk] = float(mv)
                     except (TypeError, ValueError):
-                        pass
+                        # Ignore non-numeric optional metrics during event replay.
+                        continue
             metrics_timeline.append(row)
             per_class = payload.get("per_class_accuracy", {})
             xai_insights_raw = payload.get("xai_insights", {})

--- a/src/bnnr/pipelines.py
+++ b/src/bnnr/pipelines.py
@@ -980,10 +980,11 @@ def build_yolo_pipeline(
     )
 
     if num_classes is None:
+        class_offset = 1 if torchvision_label_offset else 0
         if isinstance(spec.get("names"), list):
-            num_classes = len(spec["names"]) + 1  # + background
+            num_classes = len(spec["names"]) + class_offset
         elif isinstance(spec.get("nc"), int):
-            num_classes = int(spec["nc"]) + 1
+            num_classes = int(spec["nc"]) + class_offset
         else:
             raise ValueError("Could not infer class count from YOLO data.yaml ('names' or 'nc').")
 

--- a/src/bnnr/presets.py
+++ b/src/bnnr/presets.py
@@ -217,8 +217,11 @@ def auto_select_augmentations(
             if kornia_available():
                 logger.info("Auto-select: Using Kornia GPU augmentations (CUDA + kornia available)")
                 return _build_kornia_preset(random_state)
-        except ImportError:
-            pass
+        except ImportError as exc:
+            logger.debug(
+                "Auto-select: Kornia integration unavailable, falling back to built-in GPU augmentations: %s",
+                exc,
+            )
 
         # Fall back to built-in GPU-native augmentations
         logger.info("Auto-select: Using GPU-native built-in augmentations (CUDA available)")

--- a/src/bnnr/reporting.py
+++ b/src/bnnr/reporting.py
@@ -42,6 +42,7 @@ def _atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> Non
             try:
                 tmp_path.unlink(missing_ok=True)
             except OSError:
+                # Best-effort cleanup: don't mask the original write/replace failure.
                 pass
         raise
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -178,7 +178,7 @@ def test_analyze_model_extended_report_fields(model_adapter, tmp_path: Path) -> 
 
     assert report.schema_version == __version__
     assert isinstance(report.executive_summary, dict)
-    assert "health_status" in report.executive_summary or len(report.executive_summary) >= 0
+    assert "health_status" in report.executive_summary or len(report.executive_summary) > 0
     assert isinstance(report.findings, list)
     assert isinstance(report.recommendations_structured, list)
     assert isinstance(report.class_diagnostics, list)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -21,6 +21,15 @@ def test_results_json_has_runs_for_all_conditions(benchmark_results: dict) -> No
     runs = benchmark_results.get("runs")
     assert isinstance(runs, list) and runs, "runs must be a non-empty list"
 
-    conditions = {run.get("condition") for run in runs if isinstance(run, dict)}
+    for index, run in enumerate(runs):
+        assert isinstance(run, dict), f"run at index {index} must be an object"
+        assert "condition" in run and run["condition"], (
+            f"run at index {index} is missing required 'condition'"
+        )
+        assert "val_metric" in run and run["val_metric"] is not None, (
+            f"run at index {index} is missing required 'val_metric'"
+        )
+
+    conditions = {run["condition"] for run in runs}
     missing = REQUIRED_CONDITIONS - conditions
     assert not missing, f"missing conditions in results.json: {sorted(missing)}"

--- a/tests/test_ultralytics_detection_train_integration.py
+++ b/tests/test_ultralytics_detection_train_integration.py
@@ -10,6 +10,7 @@ exercises BNNR + YOLO26 when this file runs (see ``pytest`` in ``.github/workflo
 
 from __future__ import annotations
 
+import math
 import os
 
 import pytest
@@ -129,7 +130,7 @@ def test_many_train_steps_all_finite(yolo_cpu_adapter) -> None:
         assert metrics.get("loss_yolo_pred_format_error") is None
         assert metrics.get("loss_yolo_fused_head") is None
         loss = float(metrics["loss"])
-        assert loss == loss
+        assert math.isfinite(loss)
         assert loss >= 0.0
 
 
@@ -143,7 +144,7 @@ def test_extreme_class_ids_are_clamped_and_run(yolo_cpu_adapter) -> None:
     m = yolo_cpu_adapter.train_step((images, targets))
     assert m.get("loss_yolo_index_error") is None
     assert m.get("loss_yolo_pred_format_error") is None
-    assert float(m["loss"]) == float(m["loss"])
+    assert math.isfinite(float(m["loss"]))
 
 
 @pytest.mark.yolo26
@@ -162,7 +163,7 @@ def test_yolo26_one_train_step_finite(yolo26_cpu_adapter) -> None:
     assert metrics.get("loss_yolo_pred_format_error") is None
     assert metrics.get("loss_yolo_fused_head") is None
     loss = float(metrics["loss"])
-    assert loss == loss
+    assert math.isfinite(loss)
     assert loss >= 0.0
 
 
@@ -183,5 +184,5 @@ def test_yolo26_multiple_train_steps_finite(yolo26_cpu_adapter) -> None:
         assert metrics.get("loss_yolo_pred_format_error") is None
         assert metrics.get("loss_yolo_fused_head") is None
         loss = float(metrics["loss"])
-        assert loss == loss
+        assert math.isfinite(loss)
         assert loss >= 0.0


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` (pip, GitHub Actions, `dashboard_web` npm), `dependency-review` workflow, and `CODEOWNERS`.
- Extend `MAINTAINER_SETUP.md` with branch protection, Dependabot security updates, and guidance to disable CodeQL one-alert-per-PR autofix storms.
- Consolidate CodeQL quality fixes from autofix PRs #59–#91 in one maintainer batch (rejects destructive patterns from #60/#81; keeps `_copy_logos_to()` and lazy dashboard exports).

## Test plan

- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/bnnr/`
- [ ] CI matrix (pytest) on PR
- [ ] Dependency Review check on PR

## Follow-up (after merge)

- Close PRs #59–#91 as superseded by this PR
- Apply branch protection + disable CodeQL autofix-per-alert in GitHub UI (see `MAINTAINER_SETUP.md`)


Made with [Cursor](https://cursor.com)