### PR TITLE
examples: Ultralytics YOLOv8 quickstart on COCO128 + optional extra

### DIFF
--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -10,3 +10,12 @@ Runnable scripts referenced from [docs/integrations.md](../../docs/integrations.
 pip install bnnr
 PYTHONPATH=src python examples/integrations/gradcam_to_icd_loop.py
 ```
+
+## Ultralytics YOLO
+
+- [`ultralytics_yolo_quickstart.py`](ultralytics_yolo_quickstart.py) — `UltralyticsDetectionAdapter` on COCO128 with DetectionICD/AICD (not the `yolo` CLI).
+
+```bash
+pip install "bnnr[ultralytics]"
+PYTHONPATH=src:examples/integrations python examples/integrations/ultralytics_yolo_quickstart.py --quick
+```

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -1,0 +1,12 @@
+# BNNR integration examples (third-party stacks)
+
+Runnable scripts referenced from [docs/integrations.md](../../docs/integrations.md) (hub lands in a follow-up PR).
+
+## pytorch-grad-cam
+
+- [`gradcam_to_icd_loop.py`](gradcam_to_icd_loop.py) — same CIFAR-10 batch: raw `GradCAM` overlay vs BNNR `ICD` using `gradcam` saliency. Companion doc: [plugin_icd.md](../../docs/plugin_icd.md).
+
+```bash
+pip install bnnr
+PYTHONPATH=src python examples/integrations/gradcam_to_icd_loop.py
+```

--- a/examples/integrations/coco128_ultralytics_dataset.py
+++ b/examples/integrations/coco128_ultralytics_dataset.py
@@ -1,0 +1,121 @@
+"""COCO128 YOLO layout → BNNR detection batch format (for Ultralytics YOLOv8 + BNNR).
+
+Extracted from examples/detection/bnnr_detection_demo.ipynb for reuse by integration scripts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+import torchvision.transforms.functional as TF  # noqa: N812 — match notebook convention
+import yaml
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+def yolo_label_has_any_line(label_path: Path) -> bool:
+    """True if the YOLO label file has at least one ``cls cx cy w h`` row."""
+    if not label_path.is_file():
+        return False
+    for line in label_path.read_text(encoding="utf-8").splitlines():
+        parts = line.strip().split()
+        if len(parts) >= 5:
+            return True
+    return False
+
+
+def coco80_names() -> list[str]:
+    """MS COCO class names in YOLO/COCO id order 0..79 (from Ultralytics cfg)."""
+    import ultralytics
+
+    p = Path(ultralytics.__file__).resolve().parent / "cfg" / "datasets" / "coco.yaml"
+    spec = yaml.safe_load(p.read_text(encoding="utf-8"))
+    raw = spec["names"]
+    if isinstance(raw, dict):
+        return [raw[i] for i in range(80)]
+    return [str(x) for x in raw]
+
+
+class Coco128BnnrDataset(Dataset):
+    """COCO128 in YOLO txt format → BNNR ``(image, target, index)``. Labels are 0..79."""
+
+    def __init__(
+        self,
+        image_paths: list[Path],
+        coco128_root: Path,
+        target_size: int = 640,
+    ) -> None:
+        self.image_paths = image_paths
+        self.root = coco128_root
+        self.labels_dir = self.root / "labels" / "train2017"
+        self.target_size = target_size
+
+    def __len__(self) -> int:
+        return len(self.image_paths)
+
+    def __getitem__(self, index: int):
+        path = self.image_paths[index]
+        img = Image.open(path).convert("RGB")
+        w0, h0 = img.size
+        img = TF.resize(img, [self.target_size, self.target_size])
+        img_tensor = TF.to_tensor(img)
+
+        label_path = self.labels_dir / (path.stem + ".txt")
+        boxes: list[list[float]] = []
+        labels: list[int] = []
+        if label_path.is_file():
+            for line in label_path.read_text(encoding="utf-8").splitlines():
+                parts = line.strip().split()
+                if len(parts) < 5:
+                    continue
+                c = int(parts[0])
+                cx, cy, bw, bh = map(float, parts[1:5])
+                x1o = (cx - bw / 2.0) * w0
+                y1o = (cy - bh / 2.0) * h0
+                x2o = (cx + bw / 2.0) * w0
+                y2o = (cy + bh / 2.0) * h0
+                sx = self.target_size / w0
+                sy = self.target_size / h0
+                x1, y1, x2, y2 = x1o * sx, y1o * sy, x2o * sx, y2o * sy
+                x1 = max(0.0, min(float(self.target_size - 1), x1))
+                y1 = max(0.0, min(float(self.target_size - 1), y1))
+                x2 = max(0.0, min(float(self.target_size), x2))
+                y2 = max(0.0, min(float(self.target_size), y2))
+                if x2 > x1 and y2 > y1:
+                    boxes.append([x1, y1, x2, y2])
+                    labels.append(c)
+
+        if not boxes:
+            raise RuntimeError(
+                f"Coco128BnnrDataset: no valid xyxy boxes after resize/clip for {path}. "
+                f"Fix labels in {label_path}."
+            )
+
+        target = {
+            "boxes": torch.tensor(boxes, dtype=torch.float32),
+            "labels": torch.tensor(labels, dtype=torch.int64),
+        }
+        return img_tensor, target, index
+
+
+def split_coco128_paths(coco_root: Path) -> tuple[list[Path], list[Path]]:
+    """80/20 train/val split over labeled COCO128 images."""
+    img_dir = coco_root / "images" / "train2017"
+    all_jpg = sorted(img_dir.glob("*.jpg"))
+    if len(all_jpg) < 8:
+        raise RuntimeError(f"Expected COCO128 images in {img_dir}, found {len(all_jpg)}.")
+
+    labels_dir = coco_root / "labels" / "train2017"
+    n_train = max(1, int(len(all_jpg) * 0.8))
+    train_paths = [
+        p for p in all_jpg[:n_train] if yolo_label_has_any_line(labels_dir / (p.stem + ".txt"))
+    ]
+    val_paths = [
+        p for p in all_jpg[n_train:] if yolo_label_has_any_line(labels_dir / (p.stem + ".txt"))
+    ]
+    if not train_paths:
+        raise RuntimeError("No COCO128 training images with YOLO label rows.")
+    if not val_paths:
+        raise RuntimeError("No COCO128 validation images with labels.")
+    return train_paths, val_paths

--- a/examples/integrations/gradcam_to_icd_loop.py
+++ b/examples/integrations/gradcam_to_icd_loop.py
@@ -1,0 +1,155 @@
+"""Grad-CAM heatmaps → BNNR ICD on the same batch (pytorch-grad-cam integration bridge).
+
+Install:
+    pip install bnnr
+
+Run:
+    PYTHONPATH=src python examples/integrations/gradcam_to_icd_loop.py
+
+Outputs:
+    gradcam_icd_out/gradcam_overlay.png
+    gradcam_icd_out/icd_augmented.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from pytorch_grad_cam import GradCAM
+from pytorch_grad_cam.utils.image import show_cam_on_image
+from pytorch_grad_cam.utils.model_targets import ClassifierOutputTarget
+from torch.utils.data import DataLoader, Dataset, Subset
+from torchvision import datasets, transforms
+from torchvision.models import ResNet18_Weights, resnet18
+
+from bnnr.icd import ICD
+from bnnr.xai_cache import XAICache
+
+SEED = 42
+BATCH_SIZE = 4
+
+
+class IndexedDataset(Dataset):
+    def __init__(self, base: Dataset) -> None:
+        self.base = base
+
+    def __len__(self) -> int:
+        return len(self.base)  # type: ignore[arg-type]
+
+    def __getitem__(self, idx: int):
+        image, label = self.base[idx]
+        return image, label, idx
+
+
+def _rgb_float_from_tensor(image: torch.Tensor) -> np.ndarray:
+    """CHW float [0,1] → HWC float [0,1] RGB."""
+    arr = image.detach().cpu().permute(1, 2, 0).numpy()
+    if arr.shape[-1] == 1:
+        arr = np.repeat(arr, 3, axis=2)
+    return np.clip(arr, 0.0, 1.0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Grad-CAM vs BNNR ICD on one CIFAR-10 batch")
+    parser.add_argument("--output-dir", type=Path, default=Path("gradcam_icd_out"))
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    device = torch.device(
+        args.device if args.device != "auto" else ("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    transform = transforms.Compose(
+        [
+            transforms.Resize((224, 224)),
+            transforms.ToTensor(),
+        ]
+    )
+    val_set = datasets.CIFAR10(
+        root=str(args.output_dir / "cifar_data"),
+        train=False,
+        download=True,
+        transform=transform,
+    )
+    subset = Subset(val_set, range(BATCH_SIZE))
+    loader = DataLoader(IndexedDataset(subset), batch_size=BATCH_SIZE, shuffle=False)
+
+    model = resnet18(weights=ResNet18_Weights.DEFAULT).to(device)
+    model.eval()
+    target_layers = [model.layer4[-1]]
+
+    images, labels, indices = next(iter(loader))
+    images = images.to(device)
+    labels = labels.to(device)
+
+    # ── Step 1: raw pytorch-grad-cam ─────────────────────────────────────
+    targets = [ClassifierOutputTarget(int(labels[i])) for i in range(BATCH_SIZE)]
+    cam_kwargs: dict = {"model": model, "target_layers": target_layers}
+    with GradCAM(**cam_kwargs) as cam:
+        grayscale_cam = cam(input_tensor=images, targets=targets)
+    rgb = _rgb_float_from_tensor(images[0])
+    cam_image = show_cam_on_image(rgb, grayscale_cam[0], use_rgb=True)
+
+    # ── Step 2: BNNR ICD with gradcam saliency (precomputed cache) ─────
+    cache_dir = args.output_dir / "xai_cache"
+    cache = XAICache(cache_dir)
+    cache.precompute_cache(
+        model=model,
+        train_loader=loader,
+        target_layers=target_layers,
+        n_samples=BATCH_SIZE,
+        method="gradcam",
+        force_recompute=True,
+        show_progress=False,
+    )
+    icd = ICD(
+        model=model,
+        target_layers=target_layers,
+        cache=cache,
+        explainer="gradcam",
+        probability=1.0,
+        random_state=args.seed,
+    )
+    img0_uint8 = (rgb * 255.0).astype(np.uint8)
+    icd_out = icd.apply_with_label(
+        img0_uint8,
+        int(labels[0].item()),
+        sample_index=int(indices[0].item()),
+    )
+    if icd_out.ndim == 2:
+        icd_rgb = np.stack([icd_out] * 3, axis=-1)
+    elif icd_out.shape[-1] == 1:
+        icd_rgb = np.repeat(icd_out, 3, axis=2)
+    else:
+        icd_rgb = icd_out
+    icd_rgb = icd_rgb.astype(np.float32) / 255.0
+
+    # ── Save side-by-side figures ───────────────────────────────────────
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    axes[0].imshow(cam_image)
+    axes[0].set_title("Grad-CAM overlay (pytorch-grad-cam)")
+    axes[0].axis("off")
+    axes[1].imshow(np.clip(icd_rgb, 0, 1))
+    axes[1].set_title("After BNNR ICD (gradcam saliency)")
+    axes[1].axis("off")
+    fig.tight_layout()
+    overlay_path = args.output_dir / "gradcam_overlay.png"
+    icd_path = args.output_dir / "icd_augmented.png"
+    fig.savefig(overlay_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    plt.imsave(icd_path, np.clip(icd_rgb, 0, 1))
+
+    print(f"Saved {overlay_path}")
+    print(f"Saved {icd_path}")
+    print("See docs/plugin_icd.md for a full training-loop example.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/integrations/ultralytics_yolo_quickstart.py
+++ b/examples/integrations/ultralytics_yolo_quickstart.py
@@ -1,0 +1,208 @@
+"""BNNR + Ultralytics YOLOv8 quickstart on COCO128 (UltralyticsDetectionAdapter).
+
+This uses BNNR's Python API — not the ``yolo train`` CLI. Images stay in [0, 1] float.
+
+Install:
+    pip install "bnnr[ultralytics]"
+
+Run:
+    PYTHONPATH=src python examples/integrations/ultralytics_yolo_quickstart.py --quick
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+
+# Allow running as script from repo root
+_INTEGRATIONS = Path(__file__).resolve().parent
+if str(_INTEGRATIONS) not in sys.path:
+    sys.path.insert(0, str(_INTEGRATIONS))
+
+from coco128_ultralytics_dataset import (  # noqa: E402
+    Coco128BnnrDataset,
+    coco80_names,
+    split_coco128_paths,
+)
+
+try:
+    from bnnr import BNNRConfig, BNNRTrainer, start_dashboard
+    from bnnr.detection_adapter import UltralyticsDetectionAdapter
+    from bnnr.detection_augmentations import DetectionHorizontalFlip, DetectionRandomScale
+    from bnnr.detection_collate import detection_collate_fn_with_index
+    from bnnr.detection_icd import DetectionAICD, DetectionICD
+    from bnnr.example_data import ensure_coco128_yolo
+except ImportError as exc:
+    print(
+        'Missing dependencies. Install with:\n  pip install "bnnr[ultralytics]"',
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from exc
+
+SEED = 42
+TARGET_SIZE = 640
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="BNNR + Ultralytics YOLOv8 on COCO128 (bbox-aware aug + DetectionICD/AICD)",
+    )
+    p.add_argument("--quick", action="store_true", help="Short run for smoke tests")
+    p.add_argument("--device", default="auto", choices=("auto", "cpu", "cuda"))
+    p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--data-dir", type=Path, default=Path("data/coco128"))
+    p.add_argument("--no-auto-download", action="store_true")
+    p.add_argument("--with-dashboard", action="store_true")
+    p.add_argument(
+        "--report-dir",
+        type=Path,
+        default=Path("reports/ultralytics_yolo_quickstart"),
+    )
+    p.add_argument("--model", default="yolov8n.pt", help="Ultralytics weights path or name")
+    return p.parse_args()
+
+
+def _resolve_device(choice: str) -> str:
+    if choice == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return choice
+
+
+def _build_augmentations(quick: bool, seed: int) -> list:
+    augs = [
+        DetectionHorizontalFlip(probability=0.5, name_override="det_hflip", random_state=seed),
+        DetectionICD(
+            probability=0.5,
+            threshold_percentile=70,
+            tile_size=8,
+            fill_strategy="gaussian_blur",
+            name_override="det_icd",
+            random_state=seed + 10,
+        ),
+        DetectionAICD(
+            probability=0.5,
+            threshold_percentile=70,
+            tile_size=8,
+            fill_strategy="gaussian_blur",
+            name_override="det_aicd",
+            random_state=seed + 11,
+        ),
+    ]
+    if not quick:
+        augs.append(
+            DetectionRandomScale(
+                scale_range=(0.85, 1.15),
+                probability=0.5,
+                name_override="det_scale",
+                random_state=seed + 3,
+            ),
+        )
+    return augs
+
+
+def main() -> None:
+    args = parse_args()
+    device = _resolve_device(args.device)
+
+    print()
+    print("=" * 68)
+    print("  BNNR + Ultralytics YOLOv8 (not yolo CLI). Images stay in [0, 1] float.")
+    print("=" * 68)
+
+    coco_root = args.data_dir.resolve()
+    if not args.no_auto_download:
+        ensure_coco128_yolo(coco_root)
+    elif not (coco_root / "data.yaml").is_file():
+        print(
+            f"[error] Missing {coco_root / 'data.yaml'} (drop --no-auto-download to fetch COCO128)"
+        )
+        raise SystemExit(2)
+
+    train_paths, val_paths = split_coco128_paths(coco_root)
+    if args.quick:
+        train_paths = train_paths[:32]
+        val_paths = val_paths[:16]
+
+    train_ds = Coco128BnnrDataset(train_paths, coco_root, target_size=TARGET_SIZE)
+    val_ds = Coco128BnnrDataset(val_paths, coco_root, target_size=TARGET_SIZE)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        collate_fn=detection_collate_fn_with_index,
+        num_workers=0,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=args.batch_size,
+        shuffle=False,
+        collate_fn=detection_collate_fn_with_index,
+        num_workers=0,
+    )
+
+    class_names = coco80_names()
+    adapter = UltralyticsDetectionAdapter(
+        model_name=args.model,
+        device=device,
+        num_classes=80,
+        lr=1e-3,
+    )
+
+    overrides: dict = {
+        "task": "detection",
+        "device": device,
+        "detection_class_names": class_names,
+        "report_dir": str(args.report_dir),
+        "event_log_enabled": args.with_dashboard,
+        "xai_enabled": True,
+        "detection_xai_method": "activation",
+        "save_checkpoints": False,
+        "seed": SEED,
+    }
+    if args.quick:
+        overrides.update(
+            {
+                "m_epochs": 1,
+                "max_iterations": 1,
+                "candidate_pruning_enabled": True,
+                "candidate_pruning_warmup_epochs": 1,
+            }
+        )
+    else:
+        overrides.update(
+            {
+                "m_epochs": 2,
+                "max_iterations": 2,
+                "candidate_pruning_enabled": True,
+                "candidate_pruning_warmup_epochs": 1,
+            }
+        )
+
+    config = BNNRConfig(**overrides)
+    augmentations = _build_augmentations(args.quick, SEED)
+
+    dashboard_url: str | None = None
+    if args.with_dashboard:
+        dashboard_url = start_dashboard(config.report_dir)
+
+    print(f"  Device:     {device}")
+    print(f"  Model:      {args.model}")
+    print(f"  Train/val:  {len(train_ds)} / {len(val_ds)} images")
+    print(f"  Report:     {config.report_dir}")
+    if dashboard_url:
+        print(f"  Dashboard:  {dashboard_url}")
+    print()
+
+    trainer = BNNRTrainer(adapter, train_loader, val_loader, augmentations, config)
+    result = trainer.run()
+
+    print(f"Done. best_metrics={result.best_metrics}")
+    print(f"Report: {result.report_json_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ gpu = [
 albumentations = [
   "albumentations>=1.3.0,<3.0",
 ]
+ultralytics = [
+  "ultralytics>=8.3.0,<9.0",
+]
 dashboard = [
   "fastapi>=0.115.0",
   "uvicorn>=0.30.0",

--- a/tests/test_gradcam_to_icd_loop.py
+++ b/tests/test_gradcam_to_icd_loop.py
@@ -1,0 +1,37 @@
+"""Smoke test for examples/integrations/gradcam_to_icd_loop.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "examples" / "integrations" / "gradcam_to_icd_loop.py"
+
+
+def test_gradcam_to_icd_loop_smoke(tmp_path: Path) -> None:
+    out_dir = tmp_path / "gradcam_out"
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--output-dir",
+            str(out_dir),
+            "--device",
+            "cpu",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    for name in ("gradcam_overlay.png", "icd_augmented.png"):
+        path = out_dir / name
+        assert path.is_file(), f"missing {name}"
+        assert path.stat().st_size > 1024

--- a/tests/test_ultralytics_yolo_quickstart.py
+++ b/tests/test_ultralytics_yolo_quickstart.py
@@ -1,0 +1,47 @@
+"""Smoke test for examples/integrations/ultralytics_yolo_quickstart.py."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("ultralytics")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "examples" / "integrations" / "ultralytics_yolo_quickstart.py"
+
+
+def test_ultralytics_yolo_quickstart_smoke(tmp_path: Path) -> None:
+    report_dir = tmp_path / "report"
+    data_dir = tmp_path / "coco128"
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            [str(REPO_ROOT / "src"), str(REPO_ROOT / "examples" / "integrations")]
+        ),
+    }
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--quick",
+            "--device",
+            "cpu",
+            "--report-dir",
+            str(report_dir),
+            "--data-dir",
+            str(data_dir),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    report_jsons = sorted(report_dir.glob("run_*/report.json"))
+    assert report_jsons, f"missing run_*/report.json under {report_dir}"


### PR DESCRIPTION
## Summary
- Adds `UltralyticsDetectionAdapter` quickstart on COCO128 (`--quick` for smoke).
- Adds `pip install "bnnr[ultralytics]"` optional extra in `pyproject.toml`.

## Test plan
- [x] `pytest tests/test_ultralytics_yolo_quickstart.py -q`

**Stack:** PR 3/6 — merge after PR 2

Made with [Cursor](https://cursor.com)