### PR TITLE
feat: Faza 0 integrations (grad-cam, Ultralytics, docs hub, outreach)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `docs/plugin_icd.md` and minimal ICD plug-in example (`examples/classification/icd_plugin_minimal.py`) — saliency-guided augmentation without `BNNRTrainer`.
+- Integration examples: Grad-CAM → ICD bridge (`examples/integrations/gradcam_to_icd_loop.py`); Ultralytics YOLOv8 quickstart on COCO128 (`examples/integrations/ultralytics_yolo_quickstart.py`).
+- `docs/integrations.md` hub; optional extra `pip install "bnnr[ultralytics]"`.
+- Outreach templates: `plans/ECOSYSTEM-OUTREACH.md`.
+
+### Changed
+
+- `docs/examples.md`: separate Ultralytics SDK path from YOLO-format + torchvision `showcase_yolo_coco128.py`.
+
 ## [0.4.9] — 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ See [docs/analyze.md](docs/analyze.md) for the full workflow.
 | Colab (classification) | [Open in Colab](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/classification/bnnr_classification_demo.ipynb) |
 | API reference | [docs/api_reference.md](docs/api_reference.md) |
 | Model analysis (`bnnr analyze`) | [docs/analyze.md](docs/analyze.md) |
+| Integrations (Grad-CAM, Ultralytics YOLO) | [docs/integrations.md](docs/integrations.md) |
 | Sample analyze report (live HTML) | [raw.githack.com preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) |
 | GitHub Discussions | [Q&A and showcase](https://github.com/bnnr-team/bnnr/discussions) |
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -122,6 +122,7 @@ Real metrics from a BNNR training run — branch tree, charts, XAI previews, and
 | Colab (classification) | [Open in Colab](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/classification/bnnr_classification_demo.ipynb) |
 | API reference | [docs/api_reference.md](https://github.com/bnnr-team/bnnr/blob/main/docs/api_reference.md) |
 | Model analysis (`bnnr analyze`) | [docs/analyze.md](https://github.com/bnnr-team/bnnr/blob/main/docs/analyze.md) |
+| Integrations (Grad-CAM, Ultralytics YOLO) | [docs/integrations.md](https://github.com/bnnr-team/bnnr/blob/main/docs/integrations.md) |
 | Sample analyze report (live HTML) | [raw.githack.com preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) |
 | GitHub Discussions | [Q&A and showcase](https://github.com/bnnr-team/bnnr/discussions) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Use this as the starting point when you need the shortest path to the page relev
 - `analyze.md` — standalone model analysis (`bnnr analyze`): metrics, XAI, data quality, failure analysis
 - `golden_path.md` — integrating BNNR with your own model and dataloaders
 - `plugin_icd.md` — ICD/AICD in your own PyTorch loop (no BNNRTrainer; built on pytorch-grad-cam)
+- `integrations.md` — pytorch-grad-cam and Ultralytics YOLO integration hub + stable URLs
 - `augmentations.md` — presets and augmentation classes available in code
 - `detection.md` — object detection guide (adapters, augmentations, config, metrics, XAI)
 - `examples.md` — production usage guide for Python scripts under `examples/` (by subdirectory)

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -46,6 +46,8 @@ adapter = DetectionAdapter(
 
 ### Ultralytics YOLO
 
+For the Ultralytics SDK path (YOLOv8 weights, COCO128 quickstart, stable URLs for docs PRs), see [integrations.md](integrations.md).
+
 For YOLOv8 and compatible Ultralytics models, use `UltralyticsDetectionAdapter`:
 
 ```python

--- a/docs/ecosystem-outreach.md
+++ b/docs/ecosystem-outreach.md
@@ -1,0 +1,99 @@
+# Ecosystem outreach — grad-cam + Ultralytics (Faza 1)
+
+**Prerequisite:** Faza 0 merged on `main` (plugin ICD, integration examples, [integrations.md](integrations.md)).
+
+---
+
+## Stable URLs (copy-paste)
+
+| Asset | URL |
+|-------|-----|
+| ICD plug-in guide | https://github.com/bnnr-team/bnnr/blob/main/docs/plugin_icd.md |
+| Grad-CAM → ICD example | https://github.com/bnnr-team/bnnr/blob/main/examples/integrations/gradcam_to_icd_loop.py |
+| Ultralytics quickstart | https://github.com/bnnr-team/bnnr/blob/main/examples/integrations/ultralytics_yolo_quickstart.py |
+| Integrations hub | https://github.com/bnnr-team/bnnr/blob/main/docs/integrations.md |
+| Detection guide | https://github.com/bnnr-team/bnnr/blob/main/docs/detection.md |
+
+---
+
+## A) pytorch-grad-cam — GitHub issue
+
+**Repo:** https://github.com/jacobgil/pytorch-grad-cam  
+**When:** After Faza 0 is on `main`.
+
+**Title:** `Tutorial idea: from Grad-CAM heatmaps to saliency-guided augmentation (external example)`
+
+**Body (template):**
+
+```markdown
+Hi — BNNR (MIT, https://github.com/bnnr-team/bnnr) uses `grad-cam` as a core dependency for saliency-guided augmentations (ICD/AICD). We precompute Grad-CAM maps and apply tile-based masking during training — see our minimal plug-in doc:
+
+https://github.com/bnnr-team/bnnr/blob/main/docs/plugin_icd.md
+
+We'd like to contribute a **short tutorial link** (not vendoring code into your tree) showing the path from a familiar `GradCAM` call to actionable augmentation on the same batch:
+
+https://github.com/bnnr-team/bnnr/blob/main/examples/integrations/gradcam_to_icd_loop.py
+
+Would you prefer:
+- (a) a README bullet under Tutorials linking externally,
+- (b) a small `tutorials/bnnr_saliency_guided_augmentation.md` in your repo with links, or
+- (c) another format you recommend?
+
+Happy to open a PR once you point at the preferred option. We'll cite the pytorch-grad-cam BibTeX in our docs regardless.
+
+Thanks!
+```
+
+**Follow-up PR (after maintainer OK):** ~40-line `tutorials/bnnr_saliency_guided_augmentation.md` with disclaimer: third-party MIT project, not affiliated.
+
+---
+
+## B) Ultralytics — docs PR
+
+**Repo:** https://github.com/bnnr/ultralytics (fork `ultralytics/ultralytics`)  
+**Branch:** `docs/bnnr-integration`  
+**CLA:** required — sign when opening PR.
+
+**Title:** `Docs: Add BNNR integration guide (XAI-guided aug + UltralyticsDetectionAdapter)`
+
+**New file:** `docs/en/integrations/bnnr.md`
+
+**Outline:**
+
+1. Frontmatter (`description`, `keywords`: YOLO, XAI, augmentation, open source)
+2. What is BNNR — MIT, link repo, one paragraph
+3. What it is not — does not replace `model.train()` / `yolo` CLI
+4. Installation — `pip install ultralytics bnnr` or `pip install "bnnr[ultralytics]"`
+5. Quickstart — condensed from `ultralytics_yolo_quickstart.py` (`--quick`, COCO128)
+6. Detection augmentations — DetectionICD/AICD, bbox-aware
+7. Reports / XAI — link BNNR detection.md; note classification `bnnr analyze` separately
+8. Limitations — images `[0,1]` float; Ultralytics version; first-run weight download
+9. FAQ — adapter vs raw model; can I use `yolo train` separately; license (MIT vs AGPL)
+10. Summary + link https://github.com/bnnr-team/bnnr/blob/main/docs/integrations.md
+
+**Also edit:** `docs/en/integrations/index.md` — add BNNR row/card like other integrations.
+
+**PR body opener:**
+
+```markdown
+Adds an integration guide for BNNR's `UltralyticsDetectionAdapter`: bbox-aware XAI-guided augmentation search and training reports alongside Ultralytics YOLOv8, without replacing the native `yolo train` CLI.
+
+Runnable example: https://github.com/bnnr-team/bnnr/blob/main/examples/integrations/ultralytics_yolo_quickstart.py
+```
+
+---
+
+## Checklist before sending
+
+- [ ] Faza 0 examples run locally (`--quick` for YOLO script)
+- [ ] No “official partnership” or SOTA claims
+- [ ] Ultralytics CLA signed
+- [ ] grad-cam: issue opened **before** unsolicited large PR
+- [ ] Update [integrations.md](integrations.md) upstream status table with issue/PR numbers after submission
+
+---
+
+## After merge (BNNR repo)
+
+- GitHub Discussions post: “Integration docs ready — feedback welcome” (technical tone, link hub)
+- Track referrers: `github.com/jacobgil`, `ultralytics.com` in GitHub Insights

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -94,14 +94,32 @@ See the module docstring and inline comments for wiring; also [api_reference.md]
 
 ## 5) Detection showcases
 
-### YOLO + COCO128
+### 5a) Ultralytics YOLO (SDK)
+
+Scripts:
+- `examples/integrations/ultralytics_yolo_quickstart.py` — copy-paste CLI for maintainers
+- `examples/detection/bnnr_detection_demo.ipynb` — interactive COCO128 + YOLOv8n
+
+What they demonstrate:
+- `UltralyticsDetectionAdapter` (not `yolo train` CLI),
+- COCO128 auto-download via `bnnr.example_data.ensure_coco128_yolo`,
+- bbox-aware augmentations + DetectionICD/AICD,
+- mAP metrics and optional dashboard.
+
+```bash
+pip install "bnnr[ultralytics]"
+PYTHONPATH=src python examples/integrations/ultralytics_yolo_quickstart.py --quick
+```
+
+See also [integrations.md](integrations.md).
+
+### 5b) YOLO-format data + torchvision detector
 
 Script:
 - `examples/detection/showcase_yolo_coco128.py`
 
 What it demonstrates:
-- YOLOv8 via `UltralyticsDetectionAdapter`,
-- COCO128 auto-download,
+- **YOLO dataset layout** (COCO128 `data.yaml`) with `build_pipeline("yolo")` → **torchvision Faster R-CNN** (not Ultralytics SDK),
 - detection-specific bbox augmentations + DetectionICD/AICD,
 - mAP tracking and dashboard.
 

--- a/docs/golden_path.md
+++ b/docs/golden_path.md
@@ -2,7 +2,7 @@
 
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/bnnr?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/bnnr)
 
-> **Start here first:** [`bnnr.quick_run()`](quickstart_api.md) for classification, or `python -m bnnr demo` for a zero-flag CLI showcase. This page is for custom adapters, multi-label, and detection.
+> **Start here first:** [`bnnr.quick_run()`](quickstart_api.md) for classification, or `python -m bnnr demo` for a zero-flag CLI showcase. This page is for custom adapters, multi-label, and detection. Third-party stacks: [integrations.md](integrations.md).
 
 ## What you will find here
 Production-style, code-first templates for the three supported tasks:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,51 @@
+# Integrations — pytorch-grad-cam, Ultralytics YOLO, and reference adapters
+
+BNNR integrates with popular PyTorch vision stacks as an **augmentation and analysis layer**, not as a replacement training framework.
+
+## Overview
+
+| Integration | Status | Install | Entry point | Example |
+|-------------|--------|---------|-------------|---------|
+| [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam) | **Supported** (core dependency) | `pip install bnnr` | ICD/AICD in your training loop | [plugin_icd.md](plugin_icd.md), [gradcam_to_icd_loop.py](../examples/integrations/gradcam_to_icd_loop.py) |
+| [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) | **Supported** (adapter) | `pip install "bnnr[ultralytics]"` | `UltralyticsDetectionAdapter` | [detection.md](detection.md), [ultralytics_yolo_quickstart.py](../examples/integrations/ultralytics_yolo_quickstart.py) |
+| PyTorch Lightning | Reference | `pip install pytorch-lightning` | `LightningAdapter` | [lightning_adapter.py](../examples/classification/lightning_adapter.py) |
+| Hugging Face Accelerate | Reference | `pip install accelerate` | `AccelerateAdapter` | [lightning_adapter.py](../examples/classification/lightning_adapter.py) |
+
+Runnable index: [examples/integrations/README.md](../examples/integrations/README.md).
+
+## Positioning
+
+**pytorch-grad-cam** answers *where the model looks*. BNNR adds **ICD/AICD** — augmentations that mask salient or background regions using those maps — plus optional `BNNRTrainer` branch search and `bnnr analyze` HTML reports. BNNR is not a second Grad-CAM library; it builds on `grad-cam` (see [plugin_icd.md](plugin_icd.md)).
+
+**Ultralytics YOLO** provides training and deployment via `yolo train` / `YOLO.predict`. BNNR wraps YOLO with [`UltralyticsDetectionAdapter`](../src/bnnr/detection_adapter.py) for **bbox-aware augmentation search**, detection XAI, and structured reports — alongside your YOLO workflow, not instead of it.
+
+## Stable URLs for maintainers
+
+Use these links in upstream docs or issues (replace `main` with a release tag when pinning versions):
+
+| Asset | URL |
+|-------|-----|
+| ICD plug-in guide | https://github.com/bnnr-team/bnnr/blob/main/docs/plugin_icd.md |
+| Grad-CAM → ICD example | https://github.com/bnnr-team/bnnr/blob/main/examples/integrations/gradcam_to_icd_loop.py |
+| Ultralytics quickstart | https://github.com/bnnr-team/bnnr/blob/main/examples/integrations/ultralytics_yolo_quickstart.py |
+| This hub | https://github.com/bnnr-team/bnnr/blob/main/docs/integrations.md |
+| Detection guide | https://github.com/bnnr-team/bnnr/blob/main/docs/detection.md |
+
+## License note
+
+BNNR is **MIT**. The [Ultralytics](https://github.com/ultralytics/ultralytics) repository is **AGPL-3.0**; using `pip install ultralytics` in your project is separate from forking Ultralytics. This documentation describes an optional adapter pattern only.
+
+## Upstream outreach status
+
+| Partner | Action | Status |
+|---------|--------|--------|
+| pytorch-grad-cam | Tutorial link / issue | Pending — see [ecosystem-outreach.md](ecosystem-outreach.md) |
+| Ultralytics | `docs/en/integrations/bnnr.md` PR | Pending — see [ecosystem-outreach.md](ecosystem-outreach.md) |
+
+## Maintainer checklist (before opening upstream PRs)
+
+- [ ] All example scripts run locally (`--quick` where available)
+- [ ] Links in this page resolve on `main`
+- [ ] No “official partnership” language in copy
+- [ ] Ultralytics CLA signed before docs PR
+- [ ] grad-cam: open a short **issue** before submitting a docs PR

--- a/examples/detection/showcase_yolo_coco128.py
+++ b/examples/detection/showcase_yolo_coco128.py
@@ -1,6 +1,10 @@
 """
 YOLO COCO128 detection showcase for BNNR with live dashboard support.
 
+Note: uses YOLO-format labels with torchvision Faster R-CNN via ``build_pipeline("yolo")`` —
+not the Ultralytics SDK. For ``UltralyticsDetectionAdapter`` + YOLOv8, see
+``examples/integrations/ultralytics_yolo_quickstart.py`` and ``docs/integrations.md``.
+
 This example is focused on lightweight, practical validation:
 - dataset: YOLO format (COCO128 by default)
 - model: Faster R-CNN pipeline via BNNR YOLO loader

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -1,6 +1,6 @@
 # BNNR integration examples (third-party stacks)
 
-Runnable scripts referenced from [docs/integrations.md](../../docs/integrations.md) (hub lands in a follow-up PR).
+Runnable scripts referenced from [docs/integrations.md](../../docs/integrations.md) (hub: [integrations.md](../../docs/integrations.md)).
 
 ## pytorch-grad-cam
 

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -10,3 +10,12 @@ Runnable scripts referenced from [docs/integrations.md](../../docs/integrations.
 pip install bnnr
 PYTHONPATH=src python examples/integrations/gradcam_to_icd_loop.py
 ```
+
+## Ultralytics YOLO
+
+- [`ultralytics_yolo_quickstart.py`](ultralytics_yolo_quickstart.py) — `UltralyticsDetectionAdapter` on COCO128 with DetectionICD/AICD (not the `yolo` CLI).
+
+```bash
+pip install "bnnr[ultralytics]"
+PYTHONPATH=src:examples/integrations python examples/integrations/ultralytics_yolo_quickstart.py --quick
+```

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -1,0 +1,12 @@
+# BNNR integration examples (third-party stacks)
+
+Runnable scripts referenced from [docs/integrations.md](../../docs/integrations.md) (hub lands in a follow-up PR).
+
+## pytorch-grad-cam
+
+- [`gradcam_to_icd_loop.py`](gradcam_to_icd_loop.py) — same CIFAR-10 batch: raw `GradCAM` overlay vs BNNR `ICD` using `gradcam` saliency. Companion doc: [plugin_icd.md](../../docs/plugin_icd.md).
+
+```bash
+pip install bnnr
+PYTHONPATH=src python examples/integrations/gradcam_to_icd_loop.py
+```

--- a/examples/integrations/coco128_ultralytics_dataset.py
+++ b/examples/integrations/coco128_ultralytics_dataset.py
@@ -87,7 +87,7 @@ class Coco128BnnrDataset(Dataset):
                     labels.append(c)
 
         if not boxes:
-            raise RuntimeError(
+            raise ValueError(
                 f"Coco128BnnrDataset: no valid xyxy boxes after resize/clip for {path}. "
                 f"Fix labels in {label_path}."
             )

--- a/examples/integrations/coco128_ultralytics_dataset.py
+++ b/examples/integrations/coco128_ultralytics_dataset.py
@@ -1,0 +1,121 @@
+"""COCO128 YOLO layout → BNNR detection batch format (for Ultralytics YOLOv8 + BNNR).
+
+Extracted from examples/detection/bnnr_detection_demo.ipynb for reuse by integration scripts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+import torchvision.transforms.functional as TF  # noqa: N812 — match notebook convention
+import yaml
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+def yolo_label_has_any_line(label_path: Path) -> bool:
+    """True if the YOLO label file has at least one ``cls cx cy w h`` row."""
+    if not label_path.is_file():
+        return False
+    for line in label_path.read_text(encoding="utf-8").splitlines():
+        parts = line.strip().split()
+        if len(parts) >= 5:
+            return True
+    return False
+
+
+def coco80_names() -> list[str]:
+    """MS COCO class names in YOLO/COCO id order 0..79 (from Ultralytics cfg)."""
+    import ultralytics
+
+    p = Path(ultralytics.__file__).resolve().parent / "cfg" / "datasets" / "coco.yaml"
+    spec = yaml.safe_load(p.read_text(encoding="utf-8"))
+    raw = spec["names"]
+    if isinstance(raw, dict):
+        return [raw[i] for i in range(80)]
+    return [str(x) for x in raw]
+
+
+class Coco128BnnrDataset(Dataset):
+    """COCO128 in YOLO txt format → BNNR ``(image, target, index)``. Labels are 0..79."""
+
+    def __init__(
+        self,
+        image_paths: list[Path],
+        coco128_root: Path,
+        target_size: int = 640,
+    ) -> None:
+        self.image_paths = image_paths
+        self.root = coco128_root
+        self.labels_dir = self.root / "labels" / "train2017"
+        self.target_size = target_size
+
+    def __len__(self) -> int:
+        return len(self.image_paths)
+
+    def __getitem__(self, index: int):
+        path = self.image_paths[index]
+        img = Image.open(path).convert("RGB")
+        w0, h0 = img.size
+        img = TF.resize(img, [self.target_size, self.target_size])
+        img_tensor = TF.to_tensor(img)
+
+        label_path = self.labels_dir / (path.stem + ".txt")
+        boxes: list[list[float]] = []
+        labels: list[int] = []
+        if label_path.is_file():
+            for line in label_path.read_text(encoding="utf-8").splitlines():
+                parts = line.strip().split()
+                if len(parts) < 5:
+                    continue
+                c = int(parts[0])
+                cx, cy, bw, bh = map(float, parts[1:5])
+                x1o = (cx - bw / 2.0) * w0
+                y1o = (cy - bh / 2.0) * h0
+                x2o = (cx + bw / 2.0) * w0
+                y2o = (cy + bh / 2.0) * h0
+                sx = self.target_size / w0
+                sy = self.target_size / h0
+                x1, y1, x2, y2 = x1o * sx, y1o * sy, x2o * sx, y2o * sy
+                x1 = max(0.0, min(float(self.target_size - 1), x1))
+                y1 = max(0.0, min(float(self.target_size - 1), y1))
+                x2 = max(0.0, min(float(self.target_size), x2))
+                y2 = max(0.0, min(float(self.target_size), y2))
+                if x2 > x1 and y2 > y1:
+                    boxes.append([x1, y1, x2, y2])
+                    labels.append(c)
+
+        if not boxes:
+            raise RuntimeError(
+                f"Coco128BnnrDataset: no valid xyxy boxes after resize/clip for {path}. "
+                f"Fix labels in {label_path}."
+            )
+
+        target = {
+            "boxes": torch.tensor(boxes, dtype=torch.float32),
+            "labels": torch.tensor(labels, dtype=torch.int64),
+        }
+        return img_tensor, target, index
+
+
+def split_coco128_paths(coco_root: Path) -> tuple[list[Path], list[Path]]:
+    """80/20 train/val split over labeled COCO128 images."""
+    img_dir = coco_root / "images" / "train2017"
+    all_jpg = sorted(img_dir.glob("*.jpg"))
+    if len(all_jpg) < 8:
+        raise RuntimeError(f"Expected COCO128 images in {img_dir}, found {len(all_jpg)}.")
+
+    labels_dir = coco_root / "labels" / "train2017"
+    n_train = max(1, int(len(all_jpg) * 0.8))
+    train_paths = [
+        p for p in all_jpg[:n_train] if yolo_label_has_any_line(labels_dir / (p.stem + ".txt"))
+    ]
+    val_paths = [
+        p for p in all_jpg[n_train:] if yolo_label_has_any_line(labels_dir / (p.stem + ".txt"))
+    ]
+    if not train_paths:
+        raise RuntimeError("No COCO128 training images with YOLO label rows.")
+    if not val_paths:
+        raise RuntimeError("No COCO128 validation images with labels.")
+    return train_paths, val_paths

--- a/examples/integrations/gradcam_to_icd_loop.py
+++ b/examples/integrations/gradcam_to_icd_loop.py
@@ -1,0 +1,155 @@
+"""Grad-CAM heatmaps → BNNR ICD on the same batch (pytorch-grad-cam integration bridge).
+
+Install:
+    pip install bnnr
+
+Run:
+    PYTHONPATH=src python examples/integrations/gradcam_to_icd_loop.py
+
+Outputs:
+    gradcam_icd_out/gradcam_overlay.png
+    gradcam_icd_out/icd_augmented.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from pytorch_grad_cam import GradCAM
+from pytorch_grad_cam.utils.image import show_cam_on_image
+from pytorch_grad_cam.utils.model_targets import ClassifierOutputTarget
+from torch.utils.data import DataLoader, Dataset, Subset
+from torchvision import datasets, transforms
+from torchvision.models import ResNet18_Weights, resnet18
+
+from bnnr.icd import ICD
+from bnnr.xai_cache import XAICache
+
+SEED = 42
+BATCH_SIZE = 4
+
+
+class IndexedDataset(Dataset):
+    def __init__(self, base: Dataset) -> None:
+        self.base = base
+
+    def __len__(self) -> int:
+        return len(self.base)  # type: ignore[arg-type]
+
+    def __getitem__(self, idx: int):
+        image, label = self.base[idx]
+        return image, label, idx
+
+
+def _rgb_float_from_tensor(image: torch.Tensor) -> np.ndarray:
+    """CHW float [0,1] → HWC float [0,1] RGB."""
+    arr = image.detach().cpu().permute(1, 2, 0).numpy()
+    if arr.shape[-1] == 1:
+        arr = np.repeat(arr, 3, axis=2)
+    return np.clip(arr, 0.0, 1.0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Grad-CAM vs BNNR ICD on one CIFAR-10 batch")
+    parser.add_argument("--output-dir", type=Path, default=Path("gradcam_icd_out"))
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    device = torch.device(
+        args.device if args.device != "auto" else ("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    transform = transforms.Compose(
+        [
+            transforms.Resize((224, 224)),
+            transforms.ToTensor(),
+        ]
+    )
+    val_set = datasets.CIFAR10(
+        root=str(args.output_dir / "cifar_data"),
+        train=False,
+        download=True,
+        transform=transform,
+    )
+    subset = Subset(val_set, range(BATCH_SIZE))
+    loader = DataLoader(IndexedDataset(subset), batch_size=BATCH_SIZE, shuffle=False)
+
+    model = resnet18(weights=ResNet18_Weights.DEFAULT).to(device)
+    model.eval()
+    target_layers = [model.layer4[-1]]
+
+    images, labels, indices = next(iter(loader))
+    images = images.to(device)
+    labels = labels.to(device)
+
+    # ── Step 1: raw pytorch-grad-cam ─────────────────────────────────────
+    targets = [ClassifierOutputTarget(int(labels[i])) for i in range(BATCH_SIZE)]
+    cam_kwargs: dict = {"model": model, "target_layers": target_layers}
+    with GradCAM(**cam_kwargs) as cam:
+        grayscale_cam = cam(input_tensor=images, targets=targets)
+    rgb = _rgb_float_from_tensor(images[0])
+    cam_image = show_cam_on_image(rgb, grayscale_cam[0], use_rgb=True)
+
+    # ── Step 2: BNNR ICD with gradcam saliency (precomputed cache) ─────
+    cache_dir = args.output_dir / "xai_cache"
+    cache = XAICache(cache_dir)
+    cache.precompute_cache(
+        model=model,
+        train_loader=loader,
+        target_layers=target_layers,
+        n_samples=BATCH_SIZE,
+        method="gradcam",
+        force_recompute=True,
+        show_progress=False,
+    )
+    icd = ICD(
+        model=model,
+        target_layers=target_layers,
+        cache=cache,
+        explainer="gradcam",
+        probability=1.0,
+        random_state=args.seed,
+    )
+    img0_uint8 = (rgb * 255.0).astype(np.uint8)
+    icd_out = icd.apply_with_label(
+        img0_uint8,
+        int(labels[0].item()),
+        sample_index=int(indices[0].item()),
+    )
+    if icd_out.ndim == 2:
+        icd_rgb = np.stack([icd_out] * 3, axis=-1)
+    elif icd_out.shape[-1] == 1:
+        icd_rgb = np.repeat(icd_out, 3, axis=2)
+    else:
+        icd_rgb = icd_out
+    icd_rgb = icd_rgb.astype(np.float32) / 255.0
+
+    # ── Save side-by-side figures ───────────────────────────────────────
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    axes[0].imshow(cam_image)
+    axes[0].set_title("Grad-CAM overlay (pytorch-grad-cam)")
+    axes[0].axis("off")
+    axes[1].imshow(np.clip(icd_rgb, 0, 1))
+    axes[1].set_title("After BNNR ICD (gradcam saliency)")
+    axes[1].axis("off")
+    fig.tight_layout()
+    overlay_path = args.output_dir / "gradcam_overlay.png"
+    icd_path = args.output_dir / "icd_augmented.png"
+    fig.savefig(overlay_path, dpi=120, bbox_inches="tight")
+    plt.close(fig)
+    plt.imsave(icd_path, np.clip(icd_rgb, 0, 1))
+
+    print(f"Saved {overlay_path}")
+    print(f"Saved {icd_path}")
+    print("See docs/plugin_icd.md for a full training-loop example.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/integrations/ultralytics_yolo_quickstart.py
+++ b/examples/integrations/ultralytics_yolo_quickstart.py
@@ -1,0 +1,208 @@
+"""BNNR + Ultralytics YOLOv8 quickstart on COCO128 (UltralyticsDetectionAdapter).
+
+This uses BNNR's Python API — not the ``yolo train`` CLI. Images stay in [0, 1] float.
+
+Install:
+    pip install "bnnr[ultralytics]"
+
+Run:
+    PYTHONPATH=src python examples/integrations/ultralytics_yolo_quickstart.py --quick
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+
+# Allow running as script from repo root
+_INTEGRATIONS = Path(__file__).resolve().parent
+if str(_INTEGRATIONS) not in sys.path:
+    sys.path.insert(0, str(_INTEGRATIONS))
+
+from coco128_ultralytics_dataset import (  # noqa: E402
+    Coco128BnnrDataset,
+    coco80_names,
+    split_coco128_paths,
+)
+
+try:
+    from bnnr import BNNRConfig, BNNRTrainer, start_dashboard
+    from bnnr.detection_adapter import UltralyticsDetectionAdapter
+    from bnnr.detection_augmentations import DetectionHorizontalFlip, DetectionRandomScale
+    from bnnr.detection_collate import detection_collate_fn_with_index
+    from bnnr.detection_icd import DetectionAICD, DetectionICD
+    from bnnr.example_data import ensure_coco128_yolo
+except ImportError as exc:
+    print(
+        'Missing dependencies. Install with:\n  pip install "bnnr[ultralytics]"',
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from exc
+
+SEED = 42
+TARGET_SIZE = 640
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="BNNR + Ultralytics YOLOv8 on COCO128 (bbox-aware aug + DetectionICD/AICD)",
+    )
+    p.add_argument("--quick", action="store_true", help="Short run for smoke tests")
+    p.add_argument("--device", default="auto", choices=("auto", "cpu", "cuda"))
+    p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--data-dir", type=Path, default=Path("data/coco128"))
+    p.add_argument("--no-auto-download", action="store_true")
+    p.add_argument("--with-dashboard", action="store_true")
+    p.add_argument(
+        "--report-dir",
+        type=Path,
+        default=Path("reports/ultralytics_yolo_quickstart"),
+    )
+    p.add_argument("--model", default="yolov8n.pt", help="Ultralytics weights path or name")
+    return p.parse_args()
+
+
+def _resolve_device(choice: str) -> str:
+    if choice == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return choice
+
+
+def _build_augmentations(quick: bool, seed: int) -> list:
+    augs = [
+        DetectionHorizontalFlip(probability=0.5, name_override="det_hflip", random_state=seed),
+        DetectionICD(
+            probability=0.5,
+            threshold_percentile=70,
+            tile_size=8,
+            fill_strategy="gaussian_blur",
+            name_override="det_icd",
+            random_state=seed + 10,
+        ),
+        DetectionAICD(
+            probability=0.5,
+            threshold_percentile=70,
+            tile_size=8,
+            fill_strategy="gaussian_blur",
+            name_override="det_aicd",
+            random_state=seed + 11,
+        ),
+    ]
+    if not quick:
+        augs.append(
+            DetectionRandomScale(
+                scale_range=(0.85, 1.15),
+                probability=0.5,
+                name_override="det_scale",
+                random_state=seed + 3,
+            ),
+        )
+    return augs
+
+
+def main() -> None:
+    args = parse_args()
+    device = _resolve_device(args.device)
+
+    print()
+    print("=" * 68)
+    print("  BNNR + Ultralytics YOLOv8 (not yolo CLI). Images stay in [0, 1] float.")
+    print("=" * 68)
+
+    coco_root = args.data_dir.resolve()
+    if not args.no_auto_download:
+        ensure_coco128_yolo(coco_root)
+    elif not (coco_root / "data.yaml").is_file():
+        print(
+            f"[error] Missing {coco_root / 'data.yaml'} (drop --no-auto-download to fetch COCO128)"
+        )
+        raise SystemExit(2)
+
+    train_paths, val_paths = split_coco128_paths(coco_root)
+    if args.quick:
+        train_paths = train_paths[:32]
+        val_paths = val_paths[:16]
+
+    train_ds = Coco128BnnrDataset(train_paths, coco_root, target_size=TARGET_SIZE)
+    val_ds = Coco128BnnrDataset(val_paths, coco_root, target_size=TARGET_SIZE)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        collate_fn=detection_collate_fn_with_index,
+        num_workers=0,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=args.batch_size,
+        shuffle=False,
+        collate_fn=detection_collate_fn_with_index,
+        num_workers=0,
+    )
+
+    class_names = coco80_names()
+    adapter = UltralyticsDetectionAdapter(
+        model_name=args.model,
+        device=device,
+        num_classes=80,
+        lr=1e-3,
+    )
+
+    overrides: dict = {
+        "task": "detection",
+        "device": device,
+        "detection_class_names": class_names,
+        "report_dir": str(args.report_dir),
+        "event_log_enabled": args.with_dashboard,
+        "xai_enabled": True,
+        "detection_xai_method": "activation",
+        "save_checkpoints": False,
+        "seed": SEED,
+    }
+    if args.quick:
+        overrides.update(
+            {
+                "m_epochs": 1,
+                "max_iterations": 1,
+                "candidate_pruning_enabled": True,
+                "candidate_pruning_warmup_epochs": 1,
+            }
+        )
+    else:
+        overrides.update(
+            {
+                "m_epochs": 2,
+                "max_iterations": 2,
+                "candidate_pruning_enabled": True,
+                "candidate_pruning_warmup_epochs": 1,
+            }
+        )
+
+    config = BNNRConfig(**overrides)
+    augmentations = _build_augmentations(args.quick, SEED)
+
+    dashboard_url: str | None = None
+    if args.with_dashboard:
+        dashboard_url = start_dashboard(config.report_dir)
+
+    print(f"  Device:     {device}")
+    print(f"  Model:      {args.model}")
+    print(f"  Train/val:  {len(train_ds)} / {len(val_ds)} images")
+    print(f"  Report:     {config.report_dir}")
+    if dashboard_url:
+        print(f"  Dashboard:  {dashboard_url}")
+    print()
+
+    trainer = BNNRTrainer(adapter, train_loader, val_loader, augmentations, config)
+    result = trainer.run()
+
+    print(f"Done. best_metrics={result.best_metrics}")
+    print(f"Report: {result.report_json_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ gpu = [
 albumentations = [
   "albumentations>=1.3.0,<3.0",
 ]
+ultralytics = [
+  "ultralytics>=8.3.0,<9.0",
+]
 dashboard = [
   "fastapi>=0.115.0",
   "uvicorn>=0.30.0",

--- a/tests/test_gradcam_to_icd_loop.py
+++ b/tests/test_gradcam_to_icd_loop.py
@@ -1,0 +1,37 @@
+"""Smoke test for examples/integrations/gradcam_to_icd_loop.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "examples" / "integrations" / "gradcam_to_icd_loop.py"
+
+
+def test_gradcam_to_icd_loop_smoke(tmp_path: Path) -> None:
+    out_dir = tmp_path / "gradcam_out"
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--output-dir",
+            str(out_dir),
+            "--device",
+            "cpu",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    for name in ("gradcam_overlay.png", "icd_augmented.png"):
+        path = out_dir / name
+        assert path.is_file(), f"missing {name}"
+        assert path.stat().st_size > 1024

--- a/tests/test_gradcam_to_icd_loop.py
+++ b/tests/test_gradcam_to_icd_loop.py
@@ -6,8 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "examples" / "integrations" / "gradcam_to_icd_loop.py"
 

--- a/tests/test_ultralytics_yolo_quickstart.py
+++ b/tests/test_ultralytics_yolo_quickstart.py
@@ -1,0 +1,47 @@
+"""Smoke test for examples/integrations/ultralytics_yolo_quickstart.py."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("ultralytics")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "examples" / "integrations" / "ultralytics_yolo_quickstart.py"
+
+
+def test_ultralytics_yolo_quickstart_smoke(tmp_path: Path) -> None:
+    report_dir = tmp_path / "report"
+    data_dir = tmp_path / "coco128"
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            [str(REPO_ROOT / "src"), str(REPO_ROOT / "examples" / "integrations")]
+        ),
+    }
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--quick",
+            "--device",
+            "cpu",
+            "--report-dir",
+            str(report_dir),
+            "--data-dir",
+            str(data_dir),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    report_jsons = sorted(report_dir.glob("run_*/report.json"))
+    assert report_jsons, f"missing run_*/report.json under {report_dir}"


### PR DESCRIPTION
## Summary
Completes Faza 0 ecosystem prep (PRs 2–6 of the stack) after #107 merged:

- Grad-CAM → ICD bridge example + smoke test
- Ultralytics YOLOv8 quickstart + `bnnr[ultralytics]` extra
- `docs/integrations.md` hub + README links
- YOLO-format vs Ultralytics SDK doc clarification
- `docs/ecosystem-outreach.md` + CHANGELOG [Unreleased]

Supersedes stacked PRs #108–#112 (base-branch conflicts after #107 merge).

## Test plan
- [x] `pytest tests/test_icd_plugin_minimal.py tests/test_gradcam_to_icd_loop.py tests/test_ultralytics_yolo_quickstart.py`
- [x] CI green on #107 stack fixes (ruff, Windows console)


Made with [Cursor](https://cursor.com)