### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+BNNR (Bulletproof Neural Network Recipe) is a Python library for automatically improving PyTorch vision models using XAI. It has a React/Vite dashboard frontend at `dashboard_web/` that gets built into the Python package at `src/bnnr/dashboard/frontend/dist/`.
+
+### Development environment
+
+- **Python 3.12** with a virtualenv at `/workspace/.venv`
+- **Node.js 22** for the dashboard frontend build
+- Activate the venv: `source /workspace/.venv/bin/activate`
+- No external services (databases, Docker, etc.) are required
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install Python deps | `pip install -e ".[dev,dashboard]"` |
+| Build dashboard frontend | `cd dashboard_web && npm ci && npm run build` |
+| Run tests | `pytest` |
+| Lint | `ruff check src tests` |
+| Type check | `mypy src` |
+| Run demo | `python -m bnnr demo` |
+| Run CLI training | `python -m bnnr train --dataset cifar10 --preset light --with-dashboard` |
+
+### Gotchas and non-obvious notes
+
+- The dashboard frontend **must be built before** the Python editable install, because `hatch` includes `src/bnnr/dashboard/frontend/dist/` in the wheel. If the dist folder is missing, the dashboard won't serve its UI.
+- `python3.12-venv` system package is required (not installed by default on the VM). The update script handles this.
+- The `bnnr demo` command auto-downloads CIFAR-10 (~170MB) on first run. Tests use synthetic data and do not require network access after initial setup.
+- dbus/GCM errors in terminal output during demo are Chrome background noise and are harmless.
+- Tests run on CPU only (`device="cpu"`); no GPU is needed.
+- pytest config is in `pyproject.toml` with `testpaths = ["tests"]` and coverage reporting enabled.
+- Tests marked `yolo26` may require large model downloads; they are safe to skip locally.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions, including environment setup notes, key commands, and non-obvious gotchas for future cloud agents.

## Related issue

N/A — development environment setup documentation.

## Checklist

- [x] `pytest` passes locally (955 passed, 19 skipped)
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed — N/A (no code changes)
- [x] Dashboard UI rebuilt if `dashboard_web/` changed — N/A (no dashboard changes)

## Evidence

[BNNR Dashboard showing completed training run](https://cursor.com/agents/bc-1c898871-7c25-4659-9455-e84ddad16abd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbnnr_dashboard.webp)

See [CONTRIBUTING.md](../CONTRIBUTING.md) for full setup and style guidelines.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c898871-7c25-4659-9455-e84ddad16abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c898871-7c25-4659-9455-e84ddad16abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

