### PR TITLE
docs: add BNNR citation (CITATION.cff) and integration citing guide

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+title: "BNNR (Bulletproof Neural Network Recipe)"
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - family-names: Walo
+    given-names: Mateusz
+repository-code: "https://github.com/bnnr-team/bnnr"
+url: "https://github.com/bnnr-team/bnnr"
+license: MIT
+version: 0.4.10
+date-released: 2026-05-29
+
+preferred-citation:
+  type: software
+  authors:
+    - family-names: Walo
+      given-names: Mateusz
+  title: "BNNR (Bulletproof Neural Network Recipe)"
+  year: 2026
+  url: "https://github.com/bnnr-team/bnnr"
+  version: 0.4.10

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exp
 - [Notebooks](docs/notebooks.md)
 - [Artifacts](docs/artifacts.md)
 - [Benchmarks](docs/benchmarks.md)
+- [Citation](docs/citation.md)
 - [Troubleshooting](docs/troubleshooting.md)
 
 ### Requirements
@@ -225,6 +226,12 @@ python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exp
 - Dashboard extra: `fastapi`, `uvicorn`, `websockets`, `qrcode`
 
 </details>
+
+---
+
+## Citation
+
+If you use BNNR in academic work or publish an integration that builds on it, cite the repository. BibTeX and stack-specific notes (grad-cam, Ultralytics): [docs/citation.md](docs/citation.md). GitHub: **Cite this repository** (from `CITATION.cff`).
 
 ---
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -195,6 +195,12 @@ python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exp
 
 ---
 
+## Citation
+
+If you use BNNR in academic work, cite the repository: [docs/citation.md](https://github.com/bnnr-team/bnnr/blob/main/docs/citation.md) (BibTeX). GitHub: **Cite this repository** via `CITATION.cff`.
+
+---
+
 ## License
 
 MIT License — use BNNR freely in research, production, and commercial projects.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Use this as the starting point when you need the shortest path to the page relev
 - `golden_path.md` — integrating BNNR with your own model and dataloaders
 - `plugin_icd.md` — ICD/AICD in your own PyTorch loop (no BNNRTrainer; built on pytorch-grad-cam)
 - `integrations.md` — pytorch-grad-cam and Ultralytics YOLO integration hub + stable URLs
+- `citation.md` — how to cite BNNR (and grad-cam / Ultralytics stacks when applicable)
 - `augmentations.md` — presets and augmentation classes available in code
 - `detection.md` — object detection guide (adapters, augmentations, config, metrics, XAI)
 - `examples.md` — production usage guide for Python scripts under `examples/` (by subdirectory)

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,0 +1,42 @@
+# Citing BNNR
+
+If you use BNNR in research, a report, or a downstream integration guide, cite this repository. Pin a [release tag](https://github.com/bnnr-team/bnnr/releases) (for example `v0.4.10`) when you need a fixed version.
+
+## BNNR
+
+```bibtex
+@software{walo2026bnnr,
+  author = {Walo, Mateusz and Morzhak, Diana and Zydorczyk, Dominika and Saczuk, Zuzanna},
+  title = {{BNNR}: Bulletproof Neural Network Recipe},
+  year = {2026},
+  url = {https://github.com/bnnr-team/bnnr},
+  version = {0.4.10},
+  license = {MIT}
+}
+```
+
+Plain text (papers without BibTeX):
+
+> Walo, M., et al. BNNR (Bulletproof Neural Network Recipe). https://github.com/bnnr-team/bnnr (2026).
+
+## BNNR with pytorch-grad-cam (ICD / `gradcam` saliency)
+
+BNNR depends on [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam) for Grad-CAM saliency. Cite **both** BNNR and pytorch-grad-cam when you use ICD/AICD or the [grad-cam integration example](../examples/integrations/gradcam_to_icd_loop.py).
+
+```bibtex
+@misc{jacobgilpytorchcam,
+  title = {PyTorch library for CAM methods},
+  author = {Jacob Gildenblat and contributors},
+  year = {2021},
+  publisher = {GitHub},
+  howpublished = {\url{https://github.com/jacobgil/pytorch-grad-cam}},
+}
+```
+
+## BNNR with Ultralytics YOLO
+
+When you use [`UltralyticsDetectionAdapter`](../src/bnnr/detection_adapter.py) or the [Ultralytics quickstart](../examples/integrations/ultralytics_yolo_quickstart.py), cite **BNNR** and follow [Ultralytics](https://github.com/ultralytics/ultralytics) licensing and citation guidance for the YOLO stack you use.
+
+## Integration docs and examples
+
+Upstream docs (grad-cam, Ultralytics) that describe BNNR should include the BNNR entry above alongside their own project citation. Public links: [integrations.md](integrations.md), [plugin_icd.md](plugin_icd.md).

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -30,7 +30,18 @@ Use these links in upstream docs or issues (replace `main` with a release tag wh
 | Ultralytics quickstart | https://github.com/bnnr-team/bnnr/blob/main/examples/integrations/ultralytics_yolo_quickstart.py |
 | This hub | https://github.com/bnnr-team/bnnr/blob/main/docs/integrations.md |
 | Detection guide | https://github.com/bnnr-team/bnnr/blob/main/docs/detection.md |
+| Citation (BibTeX) | https://github.com/bnnr-team/bnnr/blob/main/docs/citation.md |
 
 ## License note
 
 BNNR is **MIT**. The [Ultralytics](https://github.com/ultralytics/ultralytics) repository is **AGPL-3.0**; using `pip install ultralytics` in your project is separate from forking Ultralytics. This documentation describes an optional adapter pattern only.
+
+## Citation
+
+| You use | Cite |
+|---------|------|
+| BNNR (any feature) | [BNNR](citation.md#bnnr) |
+| ICD/AICD with `gradcam` saliency | [BNNR](citation.md#bnnr) and [pytorch-grad-cam](citation.md#bnnr-with-pytorch-grad-cam-icd-gradcam-saliency) |
+| `UltralyticsDetectionAdapter` | [BNNR](citation.md#bnnr) and [Ultralytics](citation.md#bnnr-with-ultralytics-yolo) per their license |
+
+BibTeX and plain-text formats: [citation.md](citation.md). GitHub also exposes this via `CITATION.cff` at the repository root.

--- a/docs/plugin_icd.md
+++ b/docs/plugin_icd.md
@@ -65,15 +65,18 @@ Runnable script: [`examples/classification/icd_plugin_minimal.py`](../examples/c
 
 BNNR uses [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam) for saliency when `method="gradcam"` or `method="opticam"` (both route through `GradCAM` in [`src/bnnr/xai.py`](../src/bnnr/xai.py) today).
 
-If you use this work in research, please cite the Grad-CAM library:
+## Citation
+
+If you use ICD/AICD from BNNR in research, cite **BNNR** and **pytorch-grad-cam** (saliency). Full BibTeX blocks: [citation.md](citation.md).
 
 ```bibtex
-@misc{jacobgilpytorchcam,
-  title={PyTorch library for CAM methods},
-  author={Jacob Gildenblat and contributors},
-  year={2021},
-  publisher={GitHub},
-  howpublished={\url{https://github.com/jacobgil/pytorch-grad-cam}},
+@software{walo2026bnnr,
+  author = {Walo, Mateusz and Morzhak, Diana and Zydorczyk, Dominika and Saczuk, Zuzanna},
+  title = {{BNNR}: Bulletproof Neural Network Recipe},
+  year = {2026},
+  url = {https://github.com/bnnr-team/bnnr},
+  version = {0.4.10},
+  license = {MIT}
 }
 ```
 

--- a/examples/classification/icd_plugin_minimal.py
+++ b/examples/classification/icd_plugin_minimal.py
@@ -8,6 +8,8 @@ Run:
 
 Quick:
     PYTHONPATH=src python examples/classification/icd_plugin_minimal.py --epochs 1 --device cpu
+
+Citation: docs/citation.md in the bnnr repo (BNNR + pytorch-grad-cam when using gradcam).
 """
 
 from __future__ import annotations

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -19,3 +19,7 @@ PYTHONPATH=src python examples/integrations/gradcam_to_icd_loop.py
 pip install "bnnr[ultralytics]"
 PYTHONPATH=src:examples/integrations python examples/integrations/ultralytics_yolo_quickstart.py --quick
 ```
+
+## Citation
+
+If you use these examples in a paper or upstream docs, cite BNNR ([BibTeX](../../docs/citation.md)). With grad-cam saliency or Ultralytics, cite those projects as well ([details](../../docs/citation.md)).

--- a/examples/integrations/gradcam_to_icd_loop.py
+++ b/examples/integrations/gradcam_to_icd_loop.py
@@ -9,6 +9,8 @@ Run:
 Outputs:
     gradcam_icd_out/gradcam_overlay.png
     gradcam_icd_out/icd_augmented.png
+
+Citation: cite BNNR and pytorch-grad-cam — see docs/citation.md in the bnnr repo.
 """
 
 from __future__ import annotations

--- a/examples/integrations/ultralytics_yolo_quickstart.py
+++ b/examples/integrations/ultralytics_yolo_quickstart.py
@@ -7,6 +7,8 @@ Install:
 
 Run:
     PYTHONPATH=src python examples/integrations/ultralytics_yolo_quickstart.py --quick
+
+Citation: cite BNNR (and Ultralytics per their license) — see docs/citation.md in the bnnr repo.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Add `CITATION.cff` and `docs/citation.md` (BibTeX for BNNR, grad-cam, Ultralytics stacks).
- Link citation from README, integrations hub, plugin ICD, and integration examples.

## Test plan
- [x] Doc-only change

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact; only metadata consistency between CITATION.cff and BibTeX authors may need a quick editorial pass.
> 
> **Overview**
> Adds **machine-readable and human citation** paths for BNNR: a new root **`CITATION.cff`** (GitHub “Cite this repository”) and **`docs/citation.md`** with BibTeX/plain text for BNNR, plus when to also cite **pytorch-grad-cam** and **Ultralytics**.
> 
> **README**, **README.pypi**, and the **docs index** now link to the citation guide. **`docs/integrations.md`** gains a stable citation URL and a “what to cite” table; **`docs/plugin_icd.md`** points ICD users at the central guide and inlines the BNNR BibTeX block instead of only grad-cam. Integration **example docstrings** and **`examples/integrations/README.md`** remind readers to cite via `docs/citation.md`.
> 
> *Note for reviewers:* `CITATION.cff` lists a single author while `docs/citation.md` BibTeX includes four authors—worth aligning if intentional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b6f24a5b0e68c9e77407ba41cbf490f090c97a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->