### PR TITLE
Fix for Unused import

### DIFF
--- a/src/bnnr/albumentations_aug.py
+++ b/src/bnnr/albumentations_aug.py
@@ -35,11 +35,11 @@ logger = logging.getLogger(__name__)
 
 _ALBUMENTATIONS_AVAILABLE = False
 try:
-    import albumentations as A  # noqa: N812
+    import albumentations
 
     _ALBUMENTATIONS_AVAILABLE = True
 except ImportError:
-    A = None  # type: ignore[assignment]
+    _ALBUMENTATIONS_AVAILABLE = False
 
 
 def albumentations_available() -> bool:


### PR DESCRIPTION
General fix: when an optional import is only used to check availability, avoid binding it to a variable you never reference. Use a plain `import albumentations` inside the `try` block, and remove the fallback assignment `A = None`.

Best fix for this file: in `src/bnnr/albumentations_aug.py`, update the `try/except` around lines 37–43 so it performs an import-only availability check and sets `_ALBUMENTATIONS_AVAILABLE` accordingly. This removes the unused symbol while preserving existing functionality and error handling behavior. No other methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._