### PR TITLE
Fix for Unused import

### DIFF
--- a/examples/classification/demo_full_pipeline.py
+++ b/examples/classification/demo_full_pipeline.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, Dataset, TensorDataset


### PR DESCRIPTION
General fix: remove imports that are not referenced anywhere in the module.

Best fix here: in `examples/classification/demo_full_pipeline.py`, delete the line `import numpy as np` (line 31 in the snippet). No functionality changes are introduced because the import is unused per the finding. No additional methods, definitions, or external packages are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._