### PR TITLE
Fix for Unused import

### DIFF
--- a/examples/classification/demo_full_pipeline.py
+++ b/examples/classification/demo_full_pipeline.py
@@ -36,7 +36,6 @@ from torch.utils.data import DataLoader, Dataset, TensorDataset
 from bnnr import BNNRConfig, BNNRTrainer, SimpleTorchAdapter
 from bnnr.albumentations_aug import AlbumentationsAugmentation, albumentations_available
 from bnnr.augmentations import (
-    AugmentationRegistry,
     BasicAugmentation,
     ChurchNoise,
     DifPresets,


### PR DESCRIPTION
The fix is to remove `AugmentationRegistry` from the `from bnnr.augmentations import (...)` list in `examples/classification/demo_full_pipeline.py`, while leaving all actually used augmentation imports intact.

Best single fix (no functional change):
- Edit only the import block around lines 38–49.
- Delete `AugmentationRegistry,` from that tuple-style import list.
- No other code changes are needed, and no new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._