### PR TITLE
Fix for Unused import

### DIFF
--- a/scripts/readme_capture_dashboard.py
+++ b/scripts/readme_capture_dashboard.py
@@ -8,7 +8,6 @@ Requires: fastapi, uvicorn, playwright (install in active env).
 """
 from __future__ import annotations
 
-import subprocess
 import sys
 import time
 import types


### PR DESCRIPTION
Remove the unused `subprocess` import from `scripts/readme_capture_dashboard.py`.

- **General fix approach:** delete imports that are not referenced anywhere in the file.
- **Best single fix here:** in the import block near the top of `scripts/readme_capture_dashboard.py`, remove `import subprocess` and keep all other imports unchanged.
- **Scope:** only the import section at the top of the file; no logic changes, no new methods, no new dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._