### PR TITLE
Fix for Unused import

### DIFF
--- a/examples/detection/showcase_voc.py
+++ b/examples/detection/showcase_voc.py
@@ -43,7 +43,7 @@ import tarfile
 import urllib.request
 from collections.abc import Sized
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
To fix this, remove the unused `Any` import from the `typing` import line and keep only `cast` if `cast` is still used elsewhere.

Best minimal fix in `examples/detection/showcase_voc.py`:
- Change:
  - `from typing import Any, cast`
- To:
  - `from typing import cast`

No behavior changes are introduced; this is a cleanup-only edit that satisfies CodeQL/lint rules.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._