### PR TITLE
Fix for Unused import

### DIFF
--- a/src/bnnr/core.py
+++ b/src/bnnr/core.py
@@ -14,9 +14,6 @@ from bnnr.adapter import (  # noqa: F401 — re-exported for backward compat
 from bnnr.config_model import BNNRConfig  # noqa: F401 — re-exported for backward compat
 from bnnr.trainer import BNNRTrainer
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
-    _is_ultralytics_tasks_backbone,
-    _RuntimeState,
-    _TrainerState,
     clone_state_dict,
     copy_state_dict_inplace,
 )


### PR DESCRIPTION
Remove the unused private imports from the checkpoint import block, keeping only the names that are actually re-exported/publicly exposed by this module (`clone_state_dict`, `copy_state_dict_inplace`) plus `BNNRTrainer` and the adapter/config imports already used for compatibility.

**Best single fix (no functionality change to documented/public API):**
- In `src/bnnr/core.py`, edit the import block starting at line 16.
- Delete `_is_ultralytics_tasks_backbone`, `_RuntimeState`, and `_TrainerState` from the `from bnnr.training.checkpoint import (...)` list.
- Keep `clone_state_dict` and `copy_state_dict_inplace`.
- No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._