### PR TITLE
Fix for Unused global variable

### DIFF
--- a/src/bnnr/albumentations_aug.py
+++ b/src/bnnr/albumentations_aug.py
@@ -24,14 +24,11 @@ Example::
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import numpy as np
 
 from bnnr.augmentations import BaseAugmentation
-
-logger = logging.getLogger(__name__)
 
 _ALBUMENTATIONS_AVAILABLE = False
 try:


### PR DESCRIPTION
To fix this without changing functionality, remove the unused module-level logger declaration and the `logging` import that only existed for that declaration.

Best single fix in this file:
- In `src/bnnr/albumentations_aug.py`, delete `import logging` (line 27 in the snippet).
- Delete `logger = logging.getLogger(__name__)` (line 34 in the snippet).
- Keep all other logic unchanged.

No new methods, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._