### PR TITLE
Fix for Unused global variable

### DIFF
--- a/src/bnnr/albumentations_aug.py
+++ b/src/bnnr/albumentations_aug.py
@@ -35,11 +35,11 @@ logger = logging.getLogger(__name__)
 
 _ALBUMENTATIONS_AVAILABLE = False
 try:
-    import albumentations as A  # noqa: N812
+    import albumentations
 
     _ALBUMENTATIONS_AVAILABLE = True
 except ImportError:
-    A = None  # type: ignore[assignment]
+    pass
 
 
 def albumentations_available() -> bool:


### PR DESCRIPTION
To fix this cleanly, keep the optional-import availability check but avoid binding an unused global name.

Best fix (no functional change):
- In `src/bnnr/albumentations_aug.py`, replace the `import albumentations as A` with a plain `import albumentations` inside the `try` block.
- Remove the fallback assignment `A = None` from the `except ImportError` block.
- Keep `_ALBUMENTATIONS_AVAILABLE` logic unchanged.

This preserves the dependency probe behavior while eliminating the unused global variable flagged by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._