### PR TITLE
Fix for Unused global variable

### DIFF
--- a/src/bnnr/detection_augmentations.py
+++ b/src/bnnr/detection_augmentations.py
@@ -32,8 +32,6 @@ from torch import Tensor
 
 from bnnr.augmentations import BaseAugmentation
 
-logger = logging.getLogger(__name__)
-
 
 # ---------------------------------------------------------------------------
 #  BboxAwareAugmentation base


### PR DESCRIPTION
To fix an unused global variable warning without changing functionality, remove the unused variable declaration. In this file, that means deleting the `logger = logging.getLogger(__name__)` line.

Best single fix here:
- **File:** `src/bnnr/detection_augmentations.py`
- **Region:** near imports and module globals (line 35 in provided snippet)
- **Change:** remove the logger assignment line.
- **No additional imports/methods/definitions** are needed.

This preserves runtime behavior (since the variable is unused) and resolves the CodeQL finding cleanly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._