### PR TITLE
Fix for Unused global variable

### DIFF
--- a/src/bnnr/detection_icd.py
+++ b/src/bnnr/detection_icd.py
@@ -20,7 +20,6 @@ compatible with ``BNNRTrainer``'s detection path.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import cv2
@@ -33,8 +32,6 @@ from bnnr.detection_augmentations import (
     _ensure_numpy_labels,
     _restore_target_types,
 )
-
-logger = logging.getLogger(__name__)
 
 _VALID_FILL_STRATEGIES = frozenset(
     {"gaussian_blur", "local_mean", "global_mean", "noise", "solid"}


### PR DESCRIPTION
General fix: remove unused variables and any imports that become unused, to keep the module clean and satisfy static analysis without changing runtime behavior.

Best fix here (no functionality change): in `src/bnnr/detection_icd.py`, delete:
- `import logging` (line 23 in snippet), since it is only used for `logger`.
- `logger = logging.getLogger(__name__)` (line 37 in snippet), since it is unused.

No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._