### PR TITLE
Fix for Unused global variable

### DIFF
--- a/src/bnnr/detection_metrics.py
+++ b/src/bnnr/detection_metrics.py
@@ -10,14 +10,11 @@ covers the most common use cases.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import numpy as np
 import torch
 from torch import Tensor
-
-logger = logging.getLogger(__name__)
 
 
 def _compute_iou_matrix(boxes1: Tensor, boxes2: Tensor) -> Tensor:


### PR DESCRIPTION
The best fix is to remove the unused `logger` global declaration. Since that declaration is the only visible use of the `logging` module in the provided snippet, remove the `import logging` line as well to avoid creating a new unused-import warning.

In `src/bnnr/detection_metrics.py`:
- Delete `import logging` near the top imports.
- Delete `logger = logging.getLogger(__name__)` at module scope.

No functional behavior changes are introduced; this is purely dead-code cleanup.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._