### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/bnnr/adapter.py
+++ b/src/bnnr/adapter.py
@@ -19,7 +19,7 @@ class ModelAdapter(Protocol):
         ...
 
     def state_dict(self) -> dict[str, Any]:
-        ...
+        pass
 
     def load_state_dict(self, state: dict[str, Any]) -> None:
         pass


### PR DESCRIPTION
Use `pass` for protocol method bodies instead of `...` where CodeQL flags “statement has no effect.”

Best fix here: in `src/bnnr/adapter.py`, update `ModelAdapter.state_dict` body (line 22 region) from `...` to `pass`. This preserves functionality (protocol definition remains abstract-like), avoids changing runtime behavior, and removes the CodeQL finding. No imports, new methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._