### PR TITLE
Fix for Empty except

### DIFF
--- a/examples/detection/showcase_voc.py
+++ b/examples/detection/showcase_voc.py
@@ -328,6 +328,7 @@ def _build_all_detection_augmentations(
             )
         )
     except ImportError:
+        # Albumentations is optional; if unavailable, skip color-jitter augmentation.
         pass
 
     # ── Wave 5 — parameter variants (stronger settings) ──────────────


### PR DESCRIPTION
To fix this without changing functionality, keep the optional-import fallback behavior but replace the empty handler with an explanatory comment in the `except` block (or a lightweight note). The best minimal fix is:

- In `examples/detection/showcase_voc.py`, at the `except ImportError:` block around lines 330–331,
- Change it to `except ImportError:` followed by a clear comment explaining that albumentations is optional and the script intentionally continues without color-jitter augmentation when it is not installed.

This satisfies the CodeQL requirement (non-empty, documented handler) while preserving current behavior and avoiding new dependencies or broader logic changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._