### PR TITLE
Fix for Empty except

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -141,6 +141,8 @@ def _safe_artifact_path(run_root: Path, path: str) -> Path:
             if alt.is_file():
                 return alt
         except ValueError:
+            # Optional fallback path is invalid; ignore and return the
+            # canonical 404 below to avoid leaking path validation details.
             pass
 
     raise HTTPException(status_code=404, detail="Artifact not found")


### PR DESCRIPTION
Keep the current control flow (do not change behavior), but document why the `ValueError` is intentionally ignored in the fallback path resolution.

Best fix in `src/bnnr/dashboard/backend.py` around lines 139–145:
- Keep `except ValueError:`.
- Replace `pass` with a brief explanatory comment and a no-op (`pass`) so the intent is explicit.
- No new imports, methods, or dependencies are required.

This preserves existing functionality: if the alternate path is invalid, execution falls through to the existing `404 Artifact not found`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._