### PR TITLE
Fix for Unused local variable

### DIFF
--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -101,7 +101,6 @@ def _standalone_report_html(state: dict, run_name: str) -> str:
     decisions = state.get("decision_history", [])
     selected_path = state.get("selected_path", ["baseline"])
     branches = state.get("branches", {})
-    _xai = state.get("xai", [])  # reserved for future use
     sample_timelines = state.get("sample_timelines", {})
     task = state.get("task")
     if not isinstance(task, str):


### PR DESCRIPTION
General fix: remove the unused local variable assignment, while preserving intent through a comment if future support is planned.

Best fix here: in `src/bnnr/dashboard/exporter.py` inside `_standalone_report_html`, delete the line assigning `_xai` and keep/update nearby comments to reflect that XAI is not yet rendered. This does not change runtime behavior because the value was never used.

Needed changes:
- No new imports.
- No new methods/definitions.
- Single-line code edit around line 104 in `_standalone_report_html`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._