### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/dashboard_web/src/components/AugmentationPreview.tsx
+++ b/dashboard_web/src/components/AugmentationPreview.tsx
@@ -8,13 +8,6 @@ interface Props {
   offline: boolean;
 }
 
-/** Human-readable label for a timeline entry */
-function chipLabel(entry: SamplePoint): string {
-  if (entry.branch === "baseline") return `baseline e${entry.epoch}`;
-  // Post-baseline entries: show branch name (iteration context)
-  return entry.branch;
-}
-
 /** Unique key for a timeline entry (handles duplicate epochs) */
 function chipKey(entry: SamplePoint, idx: number): string {
   return `${entry.iteration}_${entry.epoch}_${entry.branch}_${idx}`;


### PR DESCRIPTION
To fix an unused-function finding without changing behavior, the best approach is to remove the unused function definition entirely (instead of forcing artificial usage). This keeps the component lean and avoids introducing unnecessary logic.

In `dashboard_web/src/components/AugmentationPreview.tsx`, delete the `chipLabel` helper (lines 11–16 in the snippet), leaving `chipKey` and the rest of the file untouched. No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._