### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/dashboard_web/src/components/AugmentationPreview.tsx
+++ b/dashboard_web/src/components/AugmentationPreview.tsx
@@ -91,39 +91,6 @@ function ImageRegionCanvas({
   return <canvas ref={canvasRef} className={className ?? "preview-img"} aria-label={alt ?? "image-region"} />;
 }
 
-function BoxOverlayPreview({
-  src,
-  alt,
-  box,
-  imageSize,
-  panel,
-}: {
-  src: string;
-  alt: string;
-  box: [number, number, number, number];
-  imageSize: [number, number];
-  panel?: XaiPanel;
-}) {
-  const [h, w] = imageSize;
-  const [x1, y1, x2, y2] = box;
-  const left = `${Math.max(0, (x1 / Math.max(1, w)) * 100)}%`;
-  const top = `${Math.max(0, (y1 / Math.max(1, h)) * 100)}%`;
-  const width = `${Math.max(0, ((x2 - x1) / Math.max(1, w)) * 100)}%`;
-  const height = `${Math.max(0, ((y2 - y1) / Math.max(1, h)) * 100)}%`;
-
-  return (
-    <div className="bbox-overlay-wrap">
-      <ImageRegionCanvas
-        src={src}
-        alt={alt}
-        className="preview-img"
-        panel={panel}
-      />
-      <div className="bbox-overlay-rect" style={{ left, top, width, height }} />
-    </div>
-  );
-}
-
 export function AugmentationPreview({ state, activeRun, offline }: Props) {
   const probes = state.probe_set ?? [];
   const [selectedProbe, setSelectedProbe] = useState<string>("");


### PR DESCRIPTION
The best fix is to remove the unused `BoxOverlayPreview` function component entirely from `dashboard_web/src/components/AugmentationPreview.tsx`.

- **General approach:** delete dead code that is not referenced anywhere.
- **Specific change:** remove the full `BoxOverlayPreview` declaration block (lines 94–125 in the provided snippet), including its props typing and local calculations.
- **Functionality impact:** none, because the function is unused.
- **Additional changes needed:** none (no imports, methods, or definitions are required).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._