### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/dashboard_web/src/App.tsx
+++ b/dashboard_web/src/App.tsx
@@ -62,8 +62,6 @@ export function App() {
     const branchCount = Object.keys(state.branches).length;
     const decisionCount = decisions.length;
 
-    const ml = runTask === "multilabel";
-
     const primaryMetric = (r: typeof last) => primaryMetricValue(r, runTask);
     const secondaryMetric = (r: typeof last) => secondaryMetricValue(r, runTask);
 


### PR DESCRIPTION
Remove the unused local variable `ml` from the `kpi` `useMemo` block in `dashboard_web/src/App.tsx`.

- General fix: delete variables that are declared but never used, unless they are intentionally kept with explicit documentation.
- Best specific fix here: remove line 65 (`const ml = runTask === "multilabel";`) only. No other code needs to change because the variable is not referenced.
- File/region: `dashboard_web/src/App.tsx`, inside `const kpi = useMemo(() => { ... })`.
- No imports, methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._