### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/dashboard_web/src/components/BranchGraph.tsx
+++ b/dashboard_web/src/components/BranchGraph.tsx
@@ -10,7 +10,7 @@ import ReactFlow, {
 import "reactflow/dist/style.css";
 import dagre from "dagre";
 import type { BranchEdge, BranchNode, DecisionRecord, StatePayload } from "../types";
-import { useChartColors, useTheme } from "../ThemeContext";
+import { useTheme } from "../ThemeContext";
 import { NodeTooltip } from "./NodeTooltip";
 import { NodeDetailPanel } from "./NodeDetailPanel";
 
@@ -54,7 +54,6 @@ interface Props {
 
 export function BranchGraph({ state, activeRun, offline }: Props) {
   const { theme } = useTheme();
-  const cc = useChartColors();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [hoverNodeId, setHoverNodeId] = useState<string | null>(null);
   const [hoverPos, setHoverPos] = useState<{ x: number; y: number } | null>(null);


### PR DESCRIPTION
General fix: remove unused variables (and corresponding imports/hooks) when they are not required, to keep code clean and avoid misleading dead code.

Best fix here: in `dashboard_web/src/components/BranchGraph.tsx`, remove the unused `cc` binding while preserving hook ordering and component behavior. Since `useChartColors` is only used to initialize `cc`, also remove `useChartColors` from the import list in the same file. Keep `useTheme` unchanged because `theme` is used.

Changes needed:
- Update import from `../ThemeContext` to remove `useChartColors`.
- Remove line declaring `cc`.

No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._