### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/dashboard_web/src/components/ConfusionChord.tsx
+++ b/dashboard_web/src/components/ConfusionChord.tsx
@@ -144,7 +144,6 @@ export function ConfusionChord({ matrix, classNames }: Props) {
         const tFraction = jIncoming > 0 ? flow[i][j] / jIncoming : 0;
         // We need a separate consumed tracker for target side
         // Simplify: allocate from end of arc backwards for targets
-        const tSpan = tFraction * arcJSpan;
         // For simplicity, we'll just place target ribbons sequentially
         // This is an approximation but looks good visually
         result.push({


### PR DESCRIPTION
In general, fix unused-variable findings by either:
- removing dead declarations if they are not needed, or
- wiring them into actual logic if they are required for correctness.

Here, the best fix without changing existing functionality is to remove the unused `tSpan` computation on line 147 while leaving current ribbon target placement behavior unchanged (still using placeholder `targetStart`/`targetEnd`). This is a minimal, safe cleanup in `dashboard_web/src/components/ConfusionChord.tsx` within the loop where ribbons are built.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._