### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/dashboard_web/src/components/LossLandscape.tsx
+++ b/dashboard_web/src/components/LossLandscape.tsx
@@ -61,7 +61,6 @@ export function LossLandscape({ timeline, decisions, task = "classification" }: 
     const ms: Array<{ x: string; label: string }> = [];
     let prevBranch = "";
     for (const r of rows) {
-      const parts = r.label.split("/");
       if (prevBranch !== "" && r.label !== prevBranch) {
         // Check if this is a transition point
         const branchInTimeline = timeline.find((t) =>


### PR DESCRIPTION
Remove the unused local variable declaration inside the marker-building loop.

Best fix (no functionality change):
- In `dashboard_web/src/components/LossLandscape.tsx`, inside the `for (const r of rows)` loop in the `useMemo` block, delete line 64:
  - `const parts = r.label.split("/");`
- No other code changes are required.
- No imports, methods, or definitions need to be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._