### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/test_dashboard_serve.py
+++ b/tests/test_dashboard_serve.py
@@ -162,7 +162,7 @@ class TestDashboardLazyImport:
         assert callable(start_dashboard)
 
     def test_unknown_attr_raises(self):
-        import bnnr.dashboard
+        from bnnr import dashboard
 
         with pytest.raises(AttributeError):
-            _ = bnnr.dashboard.nonexistent_thing  # type: ignore[attr-defined]
+            _ = dashboard.nonexistent_thing  # type: ignore[attr-defined]


### PR DESCRIPTION
To fix this, use one consistent import style for `bnnr.dashboard` throughout `tests/test_dashboard_serve.py`.  
The best minimal change is in `TestDashboardLazyImport.test_unknown_attr_raises`: replace `import bnnr.dashboard` with `from bnnr import dashboard`, and update attribute access from `bnnr.dashboard.nonexistent_thing` to `dashboard.nonexistent_thing`.

This preserves functionality (still accessing the module object and triggering `AttributeError` for an unknown attribute), avoids mixing `import` and `from ... import ...` for the same module path, and requires no new imports/dependencies beyond the local line change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._