### PR TITLE
Fix for Non-standard exception raised in special method

### DIFF
--- a/examples/integrations/coco128_ultralytics_dataset.py
+++ b/examples/integrations/coco128_ultralytics_dataset.py
@@ -87,7 +87,7 @@ class Coco128BnnrDataset(Dataset):
                     labels.append(c)
 
         if not boxes:
-            raise ValueError(
+            raise IndexError(
                 f"Coco128BnnrDataset: no valid xyxy boxes after resize/clip for {path}. "
                 f"Fix labels in {label_path}."
             )


### PR DESCRIPTION
Use a `LookupError` subtype in `__getitem__` instead of `ValueError` for sample retrieval failure.  
Best fix without changing functionality: replace the `raise ValueError(...)` block (lines 89–93) with `raise IndexError(...)` while keeping the same message text. This preserves current fail-fast behavior and diagnostics, but aligns with the expected exception interface of `__getitem__`.

File/region to change:
- `examples/integrations/coco128_ultralytics_dataset.py`
  - In `Coco128BnnrDataset.__getitem__`, the `if not boxes:` raise block.

No new imports, helper methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._