### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -6,7 +6,8 @@ internal module boundaries never breaks existing user code.
 
 from __future__ import annotations
 
-import bnnr
+from bnnr import __all__ as bnnr_all
+from bnnr import __dict__ as bnnr_dict
 
 # ---------------------------------------------------------------------------
 #  Original 80 names that were importable from `bnnr` before the refactor.
@@ -129,16 +130,16 @@ _REDUCED_ALL = sorted([
 
 def test_all_previously_importable_names_still_work() -> None:
     for name in _ALL_IMPORTABLE_NAMES:
-        obj = getattr(bnnr, name, None)
+        obj = bnnr_dict.get(name, None)
         assert obj is not None, f"bnnr.{name} is no longer importable (backward compat broken)"
 
 
 def test_all_list_matches_reduced_snapshot() -> None:
-    assert sorted(bnnr.__all__) == _REDUCED_ALL
+    assert sorted(bnnr_all) == _REDUCED_ALL
 
 
 def test_all_list_is_subset_of_importable() -> None:
-    for name in bnnr.__all__:
+    for name in bnnr_all:
         if name == "__version__":
             continue
         assert name in _ALL_IMPORTABLE_NAMES, f"{name} in __all__ but not in importable set"


### PR DESCRIPTION
To fix this without changing functionality, keep a single import style for module `bnnr` in this file. The safest approach is to replace `import bnnr` with `from bnnr import __all__ as bnnr_all` and `from bnnr import <all expected names...>` only if those lines already exist in shown code. However, since we can only edit shown snippets and currently rely on `bnnr.<name>` access, the best minimal fix is:

- Replace `import bnnr` with `from bnnr import __dict__ as bnnr_dict, __all__ as bnnr_all`.
- Update uses:
  - `getattr(bnnr, name, None)` → `bnnr_dict.get(name, None)`
  - `sorted(bnnr.__all__)` → `sorted(bnnr_all)`
  - `for name in bnnr.__all__:` → `for name in bnnr_all:`

This removes the direct `import bnnr` while preserving behavior of the tests shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._