### PR TITLE
fix(examples): tidy showcase_voc imports and empty except

### DIFF
--- a/examples/detection/showcase_voc.py
+++ b/examples/detection/showcase_voc.py
@@ -43,7 +43,7 @@ import tarfile
 import urllib.request
 from collections.abc import Sized
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import torch
 import torch.nn as nn
@@ -328,6 +328,7 @@ def _build_all_detection_augmentations(
             )
         )
     except ImportError:
+        # Albumentations is optional; if unavailable, skip color-jitter augmentation.
         pass
 
     # ── Wave 5 — parameter variants (stronger settings) ──────────────


### PR DESCRIPTION
Consolidates #125 and #138.

Made with [Cursor](https://cursor.com)