### PR TITLE
chore: resolve code-quality autofix queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: coverage.xml
           fail_ci_if_error: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+BNNR (Bulletproof Neural Network Recipe) is a Python library for automatically improving PyTorch vision models using XAI. It has a React/Vite dashboard frontend at `dashboard_web/` that gets built into the Python package at `src/bnnr/dashboard/frontend/dist/`.
+
+### Development environment
+
+- **Python 3.12** with a virtualenv at `/workspace/.venv`
+- **Node.js 22** for the dashboard frontend build
+- Activate the venv: `source /workspace/.venv/bin/activate`
+- No external services (databases, Docker, etc.) are required
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install Python deps | `pip install -e ".[dev,dashboard]"` |
+| Build dashboard frontend | `cd dashboard_web && npm ci && npm run build` |
+| Run tests | `pytest` |
+| Lint | `ruff check src tests` |
+| Type check | `mypy src` |
+| Run demo | `python -m bnnr demo` |
+| Run CLI training | `python -m bnnr train --dataset cifar10 --preset light --with-dashboard` |
+
+### Gotchas and non-obvious notes
+
+- The dashboard frontend **must be built before** the Python editable install, because `hatch` includes `src/bnnr/dashboard/frontend/dist/` in the wheel. If the dist folder is missing, the dashboard won't serve its UI.
+- `python3.12-venv` system package is required (not installed by default on VM). The update script handles this.
+- The `bnnr demo` command auto-downloads CIFAR-10 (~170MB) on first run. Tests use synthetic data and do not require network access after initial setup.
+- dbus/GCM errors in terminal output during demo are Chrome background noise and are harmless.
+- Tests run on CPU only (`device="cpu"`); no GPU is needed.
+- pytest config is in `pyproject.toml` with `testpaths = ["tests"]` and coverage reporting enabled.
+- Tests marked `yolo26` may require large model downloads; they are safe to skip locally.

--- a/dashboard_web/src/App.tsx
+++ b/dashboard_web/src/App.tsx
@@ -62,8 +62,6 @@ export function App() {
     const branchCount = Object.keys(state.branches).length;
     const decisionCount = decisions.length;
 
-    const ml = runTask === "multilabel";
-
     const primaryMetric = (r: typeof last) => primaryMetricValue(r, runTask);
     const secondaryMetric = (r: typeof last) => secondaryMetricValue(r, runTask);
 

--- a/dashboard_web/src/components/AugmentationPreview.tsx
+++ b/dashboard_web/src/components/AugmentationPreview.tsx
@@ -8,13 +8,6 @@ interface Props {
   offline: boolean;
 }
 
-/** Human-readable label for a timeline entry */
-function chipLabel(entry: SamplePoint): string {
-  if (entry.branch === "baseline") return `baseline e${entry.epoch}`;
-  // Post-baseline entries: show branch name (iteration context)
-  return entry.branch;
-}
-
 /** Unique key for a timeline entry (handles duplicate epochs) */
 function chipKey(entry: SamplePoint, idx: number): string {
   return `${entry.iteration}_${entry.epoch}_${entry.branch}_${idx}`;
@@ -89,39 +82,6 @@ function ImageRegionCanvas({
   }, [src, outSize, panel, crop, imageSize]);
 
   return <canvas ref={canvasRef} className={className ?? "preview-img"} aria-label={alt ?? "image-region"} />;
-}
-
-function BoxOverlayPreview({
-  src,
-  alt,
-  box,
-  imageSize,
-  panel,
-}: {
-  src: string;
-  alt: string;
-  box: [number, number, number, number];
-  imageSize: [number, number];
-  panel?: XaiPanel;
-}) {
-  const [h, w] = imageSize;
-  const [x1, y1, x2, y2] = box;
-  const left = `${Math.max(0, (x1 / Math.max(1, w)) * 100)}%`;
-  const top = `${Math.max(0, (y1 / Math.max(1, h)) * 100)}%`;
-  const width = `${Math.max(0, ((x2 - x1) / Math.max(1, w)) * 100)}%`;
-  const height = `${Math.max(0, ((y2 - y1) / Math.max(1, h)) * 100)}%`;
-
-  return (
-    <div className="bbox-overlay-wrap">
-      <ImageRegionCanvas
-        src={src}
-        alt={alt}
-        className="preview-img"
-        panel={panel}
-      />
-      <div className="bbox-overlay-rect" style={{ left, top, width, height }} />
-    </div>
-  );
 }
 
 export function AugmentationPreview({ state, activeRun, offline }: Props) {

--- a/dashboard_web/src/components/BranchGraph.tsx
+++ b/dashboard_web/src/components/BranchGraph.tsx
@@ -10,7 +10,7 @@ import ReactFlow, {
 import "reactflow/dist/style.css";
 import dagre from "dagre";
 import type { BranchEdge, BranchNode, DecisionRecord, StatePayload } from "../types";
-import { useChartColors, useTheme } from "../ThemeContext";
+import { useTheme } from "../ThemeContext";
 import { NodeTooltip } from "./NodeTooltip";
 import { NodeDetailPanel } from "./NodeDetailPanel";
 
@@ -54,7 +54,6 @@ interface Props {
 
 export function BranchGraph({ state, activeRun, offline }: Props) {
   const { theme } = useTheme();
-  const cc = useChartColors();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [hoverNodeId, setHoverNodeId] = useState<string | null>(null);
   const [hoverPos, setHoverPos] = useState<{ x: number; y: number } | null>(null);

--- a/dashboard_web/src/components/ConfusionChord.tsx
+++ b/dashboard_web/src/components/ConfusionChord.tsx
@@ -144,7 +144,6 @@ export function ConfusionChord({ matrix, classNames }: Props) {
         const tFraction = jIncoming > 0 ? flow[i][j] / jIncoming : 0;
         // We need a separate consumed tracker for target side
         // Simplify: allocate from end of arc backwards for targets
-        const tSpan = tFraction * arcJSpan;
         // For simplicity, we'll just place target ribbons sequentially
         // This is an approximation but looks good visually
         result.push({

--- a/dashboard_web/src/components/LossLandscape.tsx
+++ b/dashboard_web/src/components/LossLandscape.tsx
@@ -61,7 +61,6 @@ export function LossLandscape({ timeline, decisions, task = "classification" }: 
     const ms: Array<{ x: string; label: string }> = [];
     let prevBranch = "";
     for (const r of rows) {
-      const parts = r.label.split("/");
       if (prevBranch !== "" && r.label !== prevBranch) {
         // Check if this is a transition point
         const branchInTimeline = timeline.find((t) =>

--- a/examples/classification/demo_full_pipeline.py
+++ b/examples/classification/demo_full_pipeline.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, Dataset, TensorDataset
@@ -36,7 +35,6 @@ from torch.utils.data import DataLoader, Dataset, TensorDataset
 from bnnr import BNNRConfig, BNNRTrainer, SimpleTorchAdapter
 from bnnr.albumentations_aug import AlbumentationsAugmentation, albumentations_available
 from bnnr.augmentations import (
-    AugmentationRegistry,
     BasicAugmentation,
     ChurchNoise,
     DifPresets,

--- a/examples/detection/showcase_voc.py
+++ b/examples/detection/showcase_voc.py
@@ -43,7 +43,7 @@ import tarfile
 import urllib.request
 from collections.abc import Sized
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import torch
 import torch.nn as nn
@@ -328,6 +328,7 @@ def _build_all_detection_augmentations(
             )
         )
     except ImportError:
+        # Albumentations is optional; if unavailable, skip color-jitter augmentation.
         pass
 
     # ── Wave 5 — parameter variants (stronger settings) ──────────────

--- a/examples/integrations/coco128_ultralytics_dataset.py
+++ b/examples/integrations/coco128_ultralytics_dataset.py
@@ -87,7 +87,7 @@ class Coco128BnnrDataset(Dataset):
                     labels.append(c)
 
         if not boxes:
-            raise ValueError(
+            raise IndexError(
                 f"Coco128BnnrDataset: no valid xyxy boxes after resize/clip for {path}. "
                 f"Fix labels in {label_path}."
             )

--- a/scripts/readme_capture_dashboard.py
+++ b/scripts/readme_capture_dashboard.py
@@ -8,7 +8,6 @@ Requires: fastapi, uvicorn, playwright (install in active env).
 """
 from __future__ import annotations
 
-import subprocess
 import sys
 import time
 import types

--- a/security/pip-audit-allowlist.txt
+++ b/security/pip-audit-allowlist.txt
@@ -1,8 +1,8 @@
 # One CVE ID per line. Review quarterly; prefer fixing via dependency bumps.
-# Torch 2.9+ not yet in our pin range — tracked with dependency-review on PRs.
-PYSEC-2025-203
-PYSEC-2025-204
-PYSEC-2025-206
-PYSEC-2026-139
+# Tracked with dependency-review on PRs.
+PYSEC-2025-203  # torch; fixed in torch 2.9+
+PYSEC-2025-204  # torch; fixed in torch 2.9+
+PYSEC-2025-206  # torch; fixed in torch 2.9+
+PYSEC-2026-139  # torch; fixed in torch 2.9+
 # starlette via fastapi[dashboard] — bump when upstream pins fixed release
 PYSEC-2026-161

--- a/src/bnnr/albumentations_aug.py
+++ b/src/bnnr/albumentations_aug.py
@@ -24,14 +24,11 @@ Example::
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import numpy as np
 
 from bnnr.augmentations import BaseAugmentation
-
-logger = logging.getLogger(__name__)
 
 _ALBUMENTATIONS_AVAILABLE = False
 try:

--- a/src/bnnr/analysis/html_report.py
+++ b/src/bnnr/analysis/html_report.py
@@ -21,13 +21,6 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_CLASS_COLORS = [
-    "#f0a069", "#818cf8", "#22c55e", "#ef4444", "#facc15",
-    "#06b6d4", "#e879f9", "#f97316", "#a3e635", "#fb7185",
-    "#38bdf8", "#c084fc", "#34d399", "#fbbf24", "#f472b6",
-    "#2dd4bf", "#a78bfa", "#4ade80", "#fb923c", "#94a3b8",
-]
-
 _LOGO_B64_CACHE: str | None = None
 
 _BNNR_LOGO_SVG_FALLBACK = (

--- a/src/bnnr/core.py
+++ b/src/bnnr/core.py
@@ -14,9 +14,6 @@ from bnnr.adapter import (  # noqa: F401 — re-exported for backward compat
 from bnnr.config_model import BNNRConfig  # noqa: F401 — re-exported for backward compat
 from bnnr.trainer import BNNRTrainer
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
-    _is_ultralytics_tasks_backbone,
-    _RuntimeState,
-    _TrainerState,
     clone_state_dict,
     copy_state_dict_inplace,
 )

--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -141,6 +141,8 @@ def _safe_artifact_path(run_root: Path, path: str) -> Path:
             if alt.is_file():
                 return alt
         except ValueError:
+            # Optional fallback path is invalid; ignore and return the
+            # canonical 404 below to avoid leaking path validation details.
             pass
 
     raise HTTPException(status_code=404, detail="Artifact not found")

--- a/src/bnnr/dashboard/exporter.py
+++ b/src/bnnr/dashboard/exporter.py
@@ -101,7 +101,6 @@ def _standalone_report_html(state: dict, run_name: str) -> str:
     decisions = state.get("decision_history", [])
     selected_path = state.get("selected_path", ["baseline"])
     branches = state.get("branches", {})
-    _xai = state.get("xai", [])  # reserved for future use
     sample_timelines = state.get("sample_timelines", {})
     task = state.get("task")
     if not isinstance(task, str):

--- a/src/bnnr/detection_augmentations.py
+++ b/src/bnnr/detection_augmentations.py
@@ -22,7 +22,6 @@ Additionally, two detection-specific composite augmentations are included:
 from __future__ import annotations
 
 import abc
-import logging
 from typing import Any
 
 import cv2
@@ -31,9 +30,6 @@ import torch
 from torch import Tensor
 
 from bnnr.augmentations import BaseAugmentation
-
-logger = logging.getLogger(__name__)
-
 
 # ---------------------------------------------------------------------------
 #  BboxAwareAugmentation base

--- a/src/bnnr/detection_icd.py
+++ b/src/bnnr/detection_icd.py
@@ -20,7 +20,6 @@ compatible with ``BNNRTrainer``'s detection path.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import cv2
@@ -33,8 +32,6 @@ from bnnr.detection_augmentations import (
     _ensure_numpy_labels,
     _restore_target_types,
 )
-
-logger = logging.getLogger(__name__)
 
 _VALID_FILL_STRATEGIES = frozenset(
     {"gaussian_blur", "local_mean", "global_mean", "noise", "solid"}

--- a/src/bnnr/detection_metrics.py
+++ b/src/bnnr/detection_metrics.py
@@ -10,14 +10,11 @@ covers the most common use cases.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import numpy as np
 import torch
 from torch import Tensor
-
-logger = logging.getLogger(__name__)
 
 
 def _compute_iou_matrix(boxes1: Tensor, boxes2: Tensor) -> Tensor:

--- a/tests/test_dashboard_serve.py
+++ b/tests/test_dashboard_serve.py
@@ -162,7 +162,7 @@ class TestDashboardLazyImport:
         assert callable(start_dashboard)
 
     def test_unknown_attr_raises(self):
-        import bnnr.dashboard
+        from bnnr import dashboard
 
         with pytest.raises(AttributeError):
-            _ = bnnr.dashboard.nonexistent_thing  # type: ignore[attr-defined]
+            _ = dashboard.nonexistent_thing  # type: ignore[attr-defined]

--- a/tests/test_lan_access.py
+++ b/tests/test_lan_access.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import re
 from unittest.mock import MagicMock, patch
 
-from bnnr.dashboard.serve import _get_lan_ip, _print_qr_code
+import bnnr.dashboard.serve as serve_mod
 
 # ── _get_lan_ip ──────────────────────────────────────────────────────────────
 
 def test_get_lan_ip_returns_valid_ipv4() -> None:
-    ip = _get_lan_ip()
+    ip = serve_mod._get_lan_ip()
     # Must be a valid IPv4 address (4 groups of 1-3 digits)
     assert re.match(r"^\d{1,3}(\.\d{1,3}){3}$", ip), f"Not a valid IPv4: {ip}"
 
@@ -17,7 +17,7 @@ def test_get_lan_ip_returns_valid_ipv4() -> None:
 def test_get_lan_ip_fallback_on_socket_error() -> None:
     with patch("bnnr.dashboard.serve.socket.socket") as mock_sock:
         mock_sock.side_effect = OSError("no network")
-        ip = _get_lan_ip()
+        ip = serve_mod._get_lan_ip()
     assert ip == "127.0.0.1"
 
 
@@ -28,7 +28,7 @@ def test_get_lan_ip_fallback_on_connect_error() -> None:
     mock_instance.connect.side_effect = OSError("unreachable")
 
     with patch("bnnr.dashboard.serve.socket.socket", return_value=mock_instance):
-        ip = _get_lan_ip()
+        ip = serve_mod._get_lan_ip()
     assert ip == "127.0.0.1"
 
 
@@ -37,7 +37,7 @@ def test_get_lan_ip_fallback_on_connect_error() -> None:
 def test_print_qr_code_without_library(capsys) -> None:
     """When qrcode is not installed, a helpful hint is printed."""
     with patch.dict("sys.modules", {"qrcode": None}):
-        _print_qr_code("http://192.168.1.42:8080/")
+        serve_mod._print_qr_code("http://192.168.1.42:8080/")
     captured = capsys.readouterr().out
     assert "qrcode" in captured.lower()
 
@@ -50,7 +50,7 @@ def test_print_qr_code_with_library(capsys) -> None:
         import pytest
         pytest.skip("qrcode not installed")
 
-    _print_qr_code("http://192.168.1.42:8080/")
+    serve_mod._print_qr_code("http://192.168.1.42:8080/")
     captured = capsys.readouterr().out
     # QR code rendering uses full-block Unicode chars
     assert "\u2588" in captured
@@ -79,7 +79,6 @@ def test_start_dashboard_always_uses_0000(temp_dir) -> None:
         # Re-import to pick up the mocked modules
         import importlib
 
-        import bnnr.dashboard.serve as serve_mod
         importlib.reload(serve_mod)
         serve_mod.start_dashboard(
             run_root=temp_dir / "reports",
@@ -108,7 +107,6 @@ def test_start_dashboard_returns_lan_url(temp_dir) -> None:
     }):
         import importlib
 
-        import bnnr.dashboard.serve as serve_mod
         importlib.reload(serve_mod)
         url = serve_mod.start_dashboard(
             run_root=temp_dir / "reports",
@@ -117,5 +115,5 @@ def test_start_dashboard_returns_lan_url(temp_dir) -> None:
         )
 
     # Should contain the LAN IP, not 127.0.0.1
-    lan_ip = _get_lan_ip()
+    lan_ip = serve_mod._get_lan_ip()
     assert f"http://{lan_ip}:9999/" == url


### PR DESCRIPTION
## Summary
- Merges validated Copilot/code-quality autofix changes from the open PR queue (unused imports, dead code, allowlist comments).
- Bumps `codecov/codecov-action` v4→v6 (supersedes #105).
- Adds `AGENTS.md` for Cursor Cloud (supersedes #115).
- Consolidates overlapping bot PRs per file (demo pipeline, showcase_voc, AugmentationPreview, albumentations_aug, test_lan_access).

## Skipped (closed without merge)
- #119 CHANGELOG i18n, adapter/events Protocol autofixes, #151 backward_compat import hack, duplicate #149.

## Test plan
- [x] `ruff check` on touched Python modules
- [ ] CI full matrix

Made with [Cursor](https://cursor.com)