### PR TITLE
docs: add Roadmap link to Links tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ See [docs/analyze.md](docs/analyze.md) for the full workflow.
 | LinkedIn | [BNNR on LinkedIn](https://www.linkedin.com/company/bnnr/) |
 | Documentation | [docs/README.md](docs/README.md) |
 | Examples | [docs/examples.md](docs/examples.md) |
+| Roadmap (Q2–Q3 2026) | [docs/roadmap.md](docs/roadmap.md) |
 | Colab (classification) | [Open in Colab](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/classification/bnnr_classification_demo.ipynb) |
 | API reference | [docs/api_reference.md](docs/api_reference.md) |
 | Model analysis (`bnnr analyze`) | [docs/analyze.md](docs/analyze.md) |

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -119,6 +119,7 @@ Real metrics from a BNNR training run — branch tree, charts, XAI previews, and
 | LinkedIn | [BNNR on LinkedIn](https://www.linkedin.com/company/bnnr/) |
 | Documentation | [docs/README.md](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md) |
 | Examples | [docs/examples.md](https://github.com/bnnr-team/bnnr/blob/main/docs/examples.md) |
+| Roadmap (Q2–Q3 2026) | [docs/roadmap.md](https://github.com/bnnr-team/bnnr/blob/main/docs/roadmap.md) |
 | Colab (classification) | [Open in Colab](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/classification/bnnr_classification_demo.ipynb) |
 | API reference | [docs/api_reference.md](https://github.com/bnnr-team/bnnr/blob/main/docs/api_reference.md) |
 | Model analysis (`bnnr analyze`) | [docs/analyze.md](https://github.com/bnnr-team/bnnr/blob/main/docs/analyze.md) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,11 +40,13 @@ BNNR is a PyTorch vision toolkit: **train → explain → improve → prove** �
 
 ---
 
-## Q4 2026 — detection analyze + scaling
+## Q4 2026 — depth + scaling
 
 | Planned | Description |
 |---------|-------------|
-| **Detection analyze** | Heatmaps + failure buckets for detection tasks |
+| **Compare runs** | Side-by-side `analyze` for two checkpoints (compliance / audit use cases) |
 | **GPU speedups** | Faster `analyze` runtime; caching and better defaults |
 | **More report templates** | Stakeholder-ready summary pages and comparisons |
+
+**Later (gated):** detection `analyze` (heatmaps + failure buckets) — after classification analyze adoption and explicit community demand; see [detection.md](detection.md) for current train-only scope.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,50 @@
+# Product roadmap
+
+**Updated:** 2026-05-30 · **Current release:** v0.4.10
+
+BNNR is a PyTorch vision toolkit: **train → explain → improve → prove** — with `bnnr analyze` (failure + XAI HTML report), ICD/AICD augmentations, and optional detection training via adapters.
+
+---
+
+## Shipped (baseline)
+
+| Area | What exists today |
+|------|-------------------|
+| **Analyze** | `bnnr analyze` + portable HTML/JSON for classification and multilabel; [sample report](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) |
+| **Training** | CLI `train` / `demo` / `quickstart`; presets; live dashboard |
+| **XAI aug** | ICD, AICD, branch search; [plugin_icd.md](plugin_icd.md) for custom loops |
+| **Detection** | Train API + bbox augs; Ultralytics adapter; [detection.md](detection.md) — **no** `analyze` for detection yet |
+| **Benchmarks** | CIFAR-10 (3 seeds): no aug vs RandAugment vs BNNR — [benchmarks.md](benchmarks.md) |
+| **Integrations** | pytorch-grad-cam loop, Ultralytics quickstart — [integrations.md](integrations.md) |
+
+---
+
+## Q2 2026 (June–July) — analyze adoption
+
+| Planned | Description |
+|---------|-------------|
+| **Torchvision → analyze** | Docs + runnable example: pretrained classifier checkpoint → `bnnr analyze` report (no full retrain) |
+| **Getting started** | “Try analyze first” + githack sample links in [getting_started.md](getting_started.md) |
+| **Upstream docs** | Official link in Ultralytics docs (after PR merge); grad-cam ecosystem follow-up |
+| **Contributor templates** | GitHub issue forms: benchmark proposal, “Who uses BNNR” showcase |
+
+---
+
+## Q3 2026 (Aug–Sept) — analysis depth
+
+| Planned | Description |
+|---------|-------------|
+| **Dataset insight** | “What to label next” / outlier buckets for manual review |
+| **More XAI methods** | Better stability + more methods; OptiCAM improvements; config docs |
+| **Batch reports** | Run `analyze` across many checkpoints/configs; compare runs |
+
+---
+
+## Q4 2026 — detection analyze + scaling
+
+| Planned | Description |
+|---------|-------------|
+| **Detection analyze** | Heatmaps + failure buckets for detection tasks |
+| **GPU speedups** | Faster `analyze` runtime; caching and better defaults |
+| **More report templates** | Stakeholder-ready summary pages and comparisons |
+


### PR DESCRIPTION
Fixes #163.

Notes:
- Adds the requested Roadmap row to the Links tables in README.md and README.pypi.md.
- `docs/roadmap.md` was referenced in #163 but is not present on `main` (PR #157 was closed), so this PR includes `docs/roadmap.md` to keep the new links non-broken.