### PR TITLE
Fix for Unused import

### DIFF
--- a/src/bnnr/albumentations_aug.py
+++ b/src/bnnr/albumentations_aug.py
@@ -32,11 +32,11 @@ from bnnr.augmentations import BaseAugmentation
 
 _ALBUMENTATIONS_AVAILABLE = False
 try:
-    import albumentations as A  # noqa: N812
+    import albumentations
 
     _ALBUMENTATIONS_AVAILABLE = True
 except ImportError:
-    A = None  # type: ignore[assignment]
+    pass
 
 
 def albumentations_available() -> bool:


### PR DESCRIPTION
To fix this without changing behavior, keep the `try/except ImportError` dependency probe but import `albumentations` without assigning it to `A`. Then remove the fallback assignment `A = None`, since no symbol is needed.

Concretely in `src/bnnr/albumentations_aug.py`:
- Replace `import albumentations as A` with `import albumentations` inside the `try`.
- Remove `A = None` in the `except ImportError` block.
- Keep `_ALBUMENTATIONS_AVAILABLE` toggling exactly as-is.

No other code paths need changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._