### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/dashboard_web/src/components/ConfusionChord.tsx
+++ b/dashboard_web/src/components/ConfusionChord.tsx
@@ -135,13 +135,6 @@ export function ConfusionChord({ matrix, classNames }: Props) {
         const sourceStart = consumed[i];
         const sourceEnd = consumed[i] + ribbonSpan;
         consumed[i] = sourceEnd;
-        // Find corresponding target sub-arc
-        const arcJ = arcs[j];
-        const arcJSpan = arcJ.endAngle - arcJ.startAngle;
-        // Target: how much of j's incoming is from i
-        let jIncoming = 0;
-        for (let k = 0; k < n; k++) jIncoming += flow[k][j];
-        const tFraction = jIncoming > 0 ? flow[i][j] / jIncoming : 0;
         // We need a separate consumed tracker for target side
         // Simplify: allocate from end of arc backwards for targets
         // For simplicity, we'll just place target ribbons sequentially


### PR DESCRIPTION
General fix: remove variables/computations that are never read, while preserving functional behavior.

Best fix here: in `dashboard_web/src/components/ConfusionChord.tsx`, inside the `useMemo<ChordRibbon[]>` first pass (around lines 139–144), delete the unused target-side precomputation (`arcJ`, `arcJSpan`, `jIncoming`, `tFraction`) because target positions are actually computed in the later loop (lines 160+). Keep the `result.push(...)` unchanged so behavior remains identical.

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._