### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/dashboard_web/src/components/ConfusionChord.tsx
+++ b/dashboard_web/src/components/ConfusionChord.tsx
@@ -135,13 +135,6 @@ export function ConfusionChord({ matrix, classNames }: Props) {
         const sourceStart = consumed[i];
         const sourceEnd = consumed[i] + ribbonSpan;
         consumed[i] = sourceEnd;
-        // Find corresponding target sub-arc
-        const arcJ = arcs[j];
-        const arcJSpan = arcJ.endAngle - arcJ.startAngle;
-        // Target: how much of j's incoming is from i
-        let jIncoming = 0;
-        for (let k = 0; k < n; k++) jIncoming += flow[k][j];
-        const tFraction = jIncoming > 0 ? flow[i][j] / jIncoming : 0;
         // We need a separate consumed tracker for target side
         // Simplify: allocate from end of arc backwards for targets
         // For simplicity, we'll just place target ribbons sequentially


### PR DESCRIPTION
The fix is to remove the unused local computation of `tFraction` (and related unused temporary values only if they are truly not used) in the first ribbon-construction loop, while keeping behavior unchanged.

Best fix here:
- In `dashboard_web/src/components/ConfusionChord.tsx`, inside the `useMemo<ChordRibbon[]>` block, remove:
  - the `arcJ`/`arcJSpan` temporaries (if unused),
  - the `jIncoming` accumulation,
  - and `tFraction` declaration at line 144,
  because target-side fractions are already computed in the second pass (lines 160–172).
- Keep all functional logic intact: source ribbon allocation and second-pass target allocation remain unchanged.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._