### PR TITLE
docs: torchvision analyze section + contributor issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark_contribution.yml
+++ b/.github/ISSUE_TEMPLATE/benchmark_contribution.yml
@@ -1,0 +1,45 @@
+name: Benchmark contribution
+description: Propose a new dataset or protocol for benchmarks/
+title: "[Benchmark]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a benchmark extension. See [docs/benchmarks.md](https://github.com/bnnr-team/bnnr/blob/main/docs/benchmarks.md) and [benchmarks/README.md](https://github.com/bnnr-team/bnnr/blob/main/benchmarks/README.md) for the current CIFAR-10 protocol.
+  - type: input
+    id: dataset
+    attributes:
+      label: Dataset name
+      placeholder: e.g. Fashion-MNIST, STL-10
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this benchmark helps BNNR
+      description: What gap does it fill vs the existing CIFAR-10 table?
+    validations:
+      required: true
+  - type: textarea
+    id: protocol
+    attributes:
+      label: Protocol (seeds, metrics, baselines)
+      description: Number of seeds, metrics, and baselines (no BNNR / RandAugment / BNNR branch search, etc.)
+    validations:
+      required: true
+  - type: dropdown
+    id: contribution_type
+    attributes:
+      label: What will you contribute?
+      options:
+        - Run benchmarks/run.py and submit results.json
+        - Documentation / protocol only
+        - Need help from maintainers
+    validations:
+      required: true
+  - type: input
+    id: prior_art
+    attributes:
+      label: Link to prior art / paper (optional)
+      placeholder: https://...

--- a/.github/ISSUE_TEMPLATE/showcase.yml
+++ b/.github/ISSUE_TEMPLATE/showcase.yml
@@ -1,0 +1,52 @@
+name: Who uses BNNR (showcase)
+description: Share production or research usage of BNNR
+title: "[Showcase]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share how you use BNNR in the wild. You can also post in [GitHub Discussions → Show and tell](https://github.com/bnnr-team/bnnr/discussions/categories/show-and-tell) without opening an issue.
+  - type: input
+    id: org
+    attributes:
+      label: Organization / project name
+    validations:
+      required: true
+  - type: dropdown
+    id: use_case
+    attributes:
+      label: Primary use case
+      options:
+        - bnnr analyze (failure / XAI report)
+        - ICD / AICD plugin in my training loop
+        - Detection / Ultralytics integration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Short description
+      description: What problem did BNNR help with?
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Link (repo, paper, blog, or demo)
+      placeholder: https://
+    validations:
+      required: true
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Screenshot or sample report link (optional)
+  - type: checkboxes
+    id: permission
+    attributes:
+      label: Permission to list publicly
+      options:
+        - label: OK to mention in README or docs
+        - label: OK to highlight in GitHub Discussions
+        - label: Keep private (maintainers only)

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -30,6 +30,30 @@ xdg-open out_analyze/report.html
 
 The report includes: accuracy/F1, per-class diagnostics, confusion matrix, XAI quality score, failure patterns, and actionable recommendations. API and CLI produce equivalent results for the same model and data.
 
+## Torchvision pretrained checkpoint
+
+Use this when you already have a **torchvision** classification model (e.g. ResNet trained on CIFAR-10) and want a failure/XAI report **without** running full BNNR training.
+
+**Prerequisites**
+
+- Checkpoint saved as `.pt` (BNNR checkpoint or raw `state_dict` loadable by the analyze pipeline).
+- Validation data that matches the model: built-in name (`cifar10`, `mnist`, …) or ImageFolder layout (see [CLI examples](#examples) below).
+- `num_classes` and input size must match the checkpoint (use `--config` for ImageFolder when defaults are not enough).
+
+**Example (built-in CIFAR-10 val set)**
+
+```bash
+python3 -m bnnr analyze \
+  --model ./resnet18_cifar10.pt \
+  --data cifar10 \
+  --output ./out_analyze
+xdg-open ./out_analyze/report.html
+```
+
+For custom wrappers or non-BNNR checkpoints, see [golden_path.md](golden_path.md). Expected report layout: [sample HTML on raw.githack.com](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html).
+
+**Note:** Object detection checkpoints are not supported by `bnnr analyze` yet (classification and multilabel only).
+
 ## Overview
 
 `bnnr analyze` (and the Python API `analyze_model`) runs:


### PR DESCRIPTION
## Summary
Closes maintainer-tracked good first issues for epic #158 (partial).

Fixes #160, #161, #162.

- **#160:** `## Torchvision pretrained checkpoint` in `docs/analyze.md` (prerequisites, CLI example, links to golden path + sample HTML; no detection analyze promise)
- **#161:** `.github/ISSUE_TEMPLATE/benchmark_contribution.yml`
- **#162:** `.github/ISSUE_TEMPLATE/showcase.yml` (links to Show and tell Discussions)

**Left for community:** #159 (`getting_started` “Try analyze first”) — unassigned on purpose.

## Test plan
- [x] Docs-only + YAML templates (no runtime code changes)
- [x] githack URL matches README sample link
- [x] Issue template YAML follows existing `bug_report.yml` / `feature_request.yml` patterns
- [ ] CI green on PR

## Notes
Supersedes duplicate work on #157 (roadmap already on `main` via #166).

Made with [Cursor](https://cursor.com)