### PR TITLE
release: v0.4.11 — analyze-first docs, torchvision example, quality fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.4.11] — 2026-05-30
+
+### Added
+
+- `examples/classification/torchvision_analyze_cifar10.py` — ResNet-18 on CIFAR-10 → `analyze_model` HTML report (Python API).
+- GitHub issue templates: benchmark contribution, “Who uses BNNR” showcase.
+- `docs/getting_started.md`: “Try analyze first” section with live sample HTML link.
+
+### Changed
+
+- `docs/analyze.md`: torchvision checkpoint workflow (example script + CLI note for demo CNN).
+- `docs/examples.md`: torchvision analyze example section.
+
 ## [0.4.10] — 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - `docs/analyze.md`: torchvision checkpoint workflow (example script + CLI note for demo CNN).
 - `docs/examples.md`: torchvision analyze example section.
+- `docs/assets/analyze-report-sample.html`: footer/header version synced to 0.4.11.
 
 ## [0.4.10] — 2026-05-29
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
 repository-code: "https://github.com/bnnr-team/bnnr"
 url: "https://github.com/bnnr-team/bnnr"
 license: MIT
-version: 0.4.10
+version: 0.4.11
 date-released: 2026-05-29
 
 preferred-citation:
@@ -31,4 +31,4 @@ preferred-citation:
   title: "BNNR (Bulletproof Neural Network Recipe)"
   year: 2026
   url: "https://github.com/bnnr-team/bnnr"
-  version: 0.4.10
+  version: 0.4.11

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 **BNNR automatically improves your PyTorch vision models using XAI** — find what your model gets wrong, fix it with intelligent augmentation, and prove the result with structured reports and a live dashboard.
 
-Supported tasks (**v0.4.10**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](docs/README.md) ([detection](docs/detection.md) · [analyze](docs/analyze.md) · [benchmarks](docs/benchmarks.md)).
+Supported tasks (**v0.4.11**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](docs/README.md) ([detection](docs/detection.md) · [analyze](docs/analyze.md) · [benchmarks](docs/benchmarks.md)).
 
 **Try without installing:** [sample analyze HTML report](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) (MNIST, real run — confusion pairs, XAI heatmaps, recommendations).
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -30,7 +30,7 @@
 
 **BNNR automatically improves your PyTorch vision models using XAI** — find what your model gets wrong, fix it with intelligent augmentation, and prove the result with structured reports and a live dashboard.
 
-Supported tasks (**v0.4.10**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md).
+Supported tasks (**v0.4.11**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md).
 
 **Sample analyze report (no install):** [live HTML preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html)
 

--- a/dashboard_web/src/components/AugmentationPreview.tsx
+++ b/dashboard_web/src/components/AugmentationPreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ProbeItem, SamplePoint, StatePayload } from "../types";
 import { resolveArtifact } from "../hooks/useRunState";
 
@@ -11,77 +11,6 @@ interface Props {
 /** Unique key for a timeline entry (handles duplicate epochs) */
 function chipKey(entry: SamplePoint, idx: number): string {
   return `${entry.iteration}_${entry.epoch}_${entry.branch}_${idx}`;
-}
-
-type XaiPanel = "gt" | "saliency" | "pred";
-
-function panelToIndex(panel: XaiPanel): number {
-  if (panel === "gt") return 0;
-  if (panel === "saliency") return 1;
-  return 2;
-}
-
-function ImageRegionCanvas({
-  src,
-  outSize = 512,
-  className,
-  alt,
-  panel,
-  crop,
-  imageSize,
-}: {
-  src: string;
-  outSize?: number;
-  className?: string;
-  alt?: string;
-  panel?: XaiPanel;
-  crop?: [number, number, number, number];
-  imageSize?: [number, number];
-}) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas || !src) return;
-    const img = new Image();
-    img.onload = () => {
-      const ctx = canvas.getContext("2d");
-      if (!ctx) return;
-      canvas.width = outSize;
-      canvas.height = outSize;
-      ctx.clearRect(0, 0, outSize, outSize);
-      ctx.imageSmoothingEnabled = true;
-      ctx.imageSmoothingQuality = "high";
-      let sx = 0;
-      let sy = 0;
-      let sw = img.width;
-      let sh = img.height;
-
-      if (panel !== undefined) {
-        // XAI artifacts are 3 horizontal panels: GT | Saliency | Pred+Saliency
-        const panelW = img.width / 3;
-        sx = panelToIndex(panel) * panelW;
-        sw = panelW;
-      }
-
-      if (crop && imageSize) {
-        const [ih, iw] = imageSize;
-        const [x1, y1, x2, y2] = crop;
-        const localX1 = (x1 / Math.max(1, iw)) * sw;
-        const localY1 = (y1 / Math.max(1, ih)) * sh;
-        const localX2 = (x2 / Math.max(1, iw)) * sw;
-        const localY2 = (y2 / Math.max(1, ih)) * sh;
-        sx += localX1;
-        sy += localY1;
-        sw = Math.max(1, localX2 - localX1);
-        sh = Math.max(1, localY2 - localY1);
-      }
-      ctx.drawImage(img, sx, sy, sw, sh, 0, 0, outSize, outSize);
-    };
-    img.src = src;
-  }, [src, outSize, panel, crop, imageSize]);
-
-  return <canvas ref={canvasRef} className={className ?? "preview-img"} aria-label={alt ?? "image-region"} />;
 }
 
 export function AugmentationPreview({ state, activeRun, offline }: Props) {

--- a/dashboard_web/src/components/ConfusionChord.tsx
+++ b/dashboard_web/src/components/ConfusionChord.tsx
@@ -135,13 +135,6 @@ export function ConfusionChord({ matrix, classNames }: Props) {
         const sourceStart = consumed[i];
         const sourceEnd = consumed[i] + ribbonSpan;
         consumed[i] = sourceEnd;
-        // Find corresponding target sub-arc
-        const arcJ = arcs[j];
-        const arcJSpan = arcJ.endAngle - arcJ.startAngle;
-        // Target: how much of j's incoming is from i
-        let jIncoming = 0;
-        for (let k = 0; k < n; k++) jIncoming += flow[k][j];
-        const tFraction = jIncoming > 0 ? flow[i][j] / jIncoming : 0;
         // We need a separate consumed tracker for target side
         // Simplify: allocate from end of arc backwards for targets
         // For simplicity, we'll just place target ribbons sequentially

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -32,22 +32,28 @@ The report includes: accuracy/F1, per-class diagnostics, confusion matrix, XAI q
 
 ## Torchvision pretrained checkpoint
 
-Use this when you already have a **torchvision** classification model (e.g. ResNet trained on CIFAR-10) and want a failure/XAI report **without** running full BNNR training.
+Use this when you already have a **torchvision** classification model (e.g. ResNet on CIFAR-10) and want a failure/XAI report **without** running full BNNR training.
 
-**Prerequisites**
+**CLI note:** `bnnr analyze --data cifar10` builds the built-in demo CNN (`_CifarCNN`), not ResNet-18. For torchvision architectures, use the Python API (below) or the runnable example.
 
-- Checkpoint saved as `.pt` (BNNR checkpoint or raw `state_dict` loadable by the analyze pipeline).
-- Validation data that matches the model: built-in name (`cifar10`, `mnist`, …) or ImageFolder layout (see [CLI examples](#examples) below).
-- `num_classes` and input size must match the checkpoint (use `--config` for ImageFolder when defaults are not enough).
+**Runnable example (ResNet-18 + CIFAR-10 val set)**
 
-**Example (built-in CIFAR-10 val set)**
+```bash
+PYTHONPATH=src python3 examples/classification/torchvision_analyze_cifar10.py --quick
+xdg-open torchvision_analyze_out/report.html
+```
+
+With your own weights: train or export a `state_dict`, then pass `--checkpoint ./resnet18_cifar10.pt`. See [examples.md](examples.md) for smoke flags.
+
+**CLI when the checkpoint matches the built-in pipeline**
+
+After `python -m bnnr train --dataset cifar10`, analyze the saved demo-CNN checkpoint:
 
 ```bash
 python3 -m bnnr analyze \
-  --model ./resnet18_cifar10.pt \
+  --model ./checkpoints/iter_2_baseline.pt \
   --data cifar10 \
   --output ./out_analyze
-xdg-open ./out_analyze/report.html
 ```
 
 For custom wrappers or non-BNNR checkpoints, see [golden_path.md](golden_path.md). Expected report layout: [sample HTML on raw.githack.com](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html).

--- a/docs/assets/analyze-report-sample.html
+++ b/docs/assets/analyze-report-sample.html
@@ -396,7 +396,7 @@ tr:hover td { background: rgba(240,160,105,0.03); }
 <div>
 <h1>BNNR Analysis Report</h1>
 <div class="report-meta">
-<span>v0.4.10</span>
+<span>v0.4.11</span>
 <span>Classification</span>
 <span>10 classes · 10,000 samples</span>
 </div></div></div>
@@ -436,6 +436,6 @@ tr:hover td { background: rgba(240,160,105,0.03); }
 <div class="rec-grid"><div class="rec-card"><div class="rec-header"><span class="rec-priority" style="min-width:22px;text-align:center;">1</span><span class="rec-title">Reduce top class confusions: 4, 9, 7, 5, 8, 3</span> <span class="badge badge-ok">Observed</span></div><div class="rec-why">label 4 recall=80%. label 9 recall=86%. label 7 recall=78%.</div><div class="rec-evidence" style="font-size:11px;color:var(--muted);margin-top:4px;"><strong>From this run:</strong> label 4 recall=80%; label 9 recall=86%; label 7 recall=78%; count=145; count=144</div><div class="rec-action">→ Inspect XAI overlays for both classes (see Confusion Analysis section). Pair-specific augmentation or metric learning (ArcFace; Deng et al., CVPR 2019) increases inter-class separation.</div><div style="font-size:12px;color:var(--green);margin-top:6px;padding:4px 10px;background:rgba(34,197,94,0.08);border-radius:6px;border:1px solid rgba(34,197,94,0.2);">[Observed] Literature context (not verified on this run): Targeted data collection or metric learning often reduces specific confusions; quantify with your confusion matrix after changes.</div><div style="font-size:10px;color:var(--muted);margin-top:4px;font-style:italic;">📚 Deng et al., ArcFace, CVPR 2019</div></div></div>
 </div>
 </div></div>
-<div class="footer"><div class="brand">BNNR — Train → Explain → Improve → Prove</div><div class="tagline">Helping your model earn its place in production.</div><div style="margin-top:8px;">BNNR v0.4.10</div></div>
+<div class="footer"><div class="brand">BNNR — Train → Explain → Improve → Prove</div><div class="tagline">Helping your model earn its place in production.</div><div style="margin-top:8px;">BNNR v0.4.11</div></div>
 </div>
 </body></html>

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,6 +1,6 @@
 # Citing BNNR
 
-If you use BNNR in research, a report, or a downstream integration guide, cite this repository. Pin a [release tag](https://github.com/bnnr-team/bnnr/releases) (for example `v0.4.10`) when you need a fixed version.
+If you use BNNR in research, a report, or a downstream integration guide, cite this repository. Pin a [release tag](https://github.com/bnnr-team/bnnr/releases) (for example `v0.4.11`) when you need a fixed version.
 
 Authors: Mateusz Walo, Diana Morzhak, Dominika Zydorczyk, Zuzanna Saczuk ([team record](../AUTHORS.md)).
 
@@ -12,7 +12,7 @@ Authors: Mateusz Walo, Diana Morzhak, Dominika Zydorczyk, Zuzanna Saczuk ([team 
   title = {{BNNR}: Bulletproof Neural Network Recipe},
   year = {2026},
   url = {https://github.com/bnnr-team/bnnr},
-  version = {0.4.10},
+  version = {0.4.11},
   license = {MIT}
 }
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -38,6 +38,30 @@ PYTHONPATH=src python3 examples/classification/showcase_stl10.py \
 
 **First run:** STL-10 is downloaded automatically (needs network). For a shorter interactive run, the script supports `--quick`; see the module docstring for timings and GPU/CPU notes.
 
+## 1b) Torchvision ResNet-18 → analyze (CIFAR-10)
+
+Script:
+- `examples/classification/torchvision_analyze_cifar10.py`
+
+What it demonstrates:
+- torchvision `resnet18` + `SimpleTorchAdapter` + `analyze_model` (HTML report without `BNNRTrainer`),
+- optional short training on a CIFAR-10 subset or `--checkpoint` for existing weights.
+
+### Quick run (downloads CIFAR-10 once)
+
+```bash
+PYTHONPATH=src python3 examples/classification/torchvision_analyze_cifar10.py --quick
+```
+
+### Fast smoke (CI / no download)
+
+```bash
+PYTHONPATH=src python3 examples/classification/torchvision_analyze_cifar10.py \
+  --output-dir /tmp/torchvision_analyze_out --synthetic --no-xai --device cpu
+```
+
+See [analyze.md](analyze.md) for the torchvision checkpoint workflow.
+
 ## 2) Multi-label showcase
 
 Script:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,6 +21,12 @@ Use this on a fresh machine or first setup.
 - `pip`
 - Optional GPU support depends on your local PyTorch/CUDA installation
 
+## Try analyze first (no training)
+
+Open the [sample analyze HTML report](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html) in your browser — no install required. It shows validation metrics, top confused class pairs, and XAI heatmaps on failure cases from a real MNIST run.
+
+After you install BNNR (below), run `python -m bnnr demo` for a quick training showcase, then see [analyze.md](analyze.md) for `bnnr analyze` on your own checkpoint.
+
 ## 2) Install BNNR
 
 If `python3 -m venv` fails with `ensurepip is not available`, install your OS venv package (for example `python3.12-venv` on Ubuntu) and retry.

--- a/docs/plugin_icd.md
+++ b/docs/plugin_icd.md
@@ -75,7 +75,7 @@ If you use ICD/AICD from BNNR in research, cite **BNNR** and **pytorch-grad-cam*
   title = {{BNNR}: Bulletproof Neural Network Recipe},
   year = {2026},
   url = {https://github.com/bnnr-team/bnnr},
-  version = {0.4.10},
+  version = {0.4.11},
   license = {MIT}
 }
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Product roadmap
 
-**Updated:** 2026-05-30 · **Current release:** v0.4.10
+**Updated:** 2026-05-30 · **Current release:** v0.4.11
 
 BNNR is a PyTorch vision toolkit: **train → explain → improve → prove** — with `bnnr analyze` (failure + XAI HTML report), ICD/AICD augmentations, and optional detection training via adapters.
 

--- a/examples/classification/torchvision_analyze_cifar10.py
+++ b/examples/classification/torchvision_analyze_cifar10.py
@@ -1,0 +1,230 @@
+"""Torchvision ResNet-18 on CIFAR-10 → BNNR analyze report (Python API).
+
+Trains (or loads) a torchvision ResNet-18 classifier, then runs ``analyze_model``
+for a portable HTML/JSON failure + XAI report — without BNNRTrainer.
+
+Install:
+    pip install bnnr
+
+Run (clone repo for PYTHONPATH=src):
+    PYTHONPATH=src python examples/classification/torchvision_analyze_cifar10.py --quick
+
+CI smoke (no download):
+    PYTHONPATH=src python examples/classification/torchvision_analyze_cifar10.py \\
+        --output-dir /tmp/out --synthetic --no-xai --device cpu
+
+Citation: docs/citation.md in the bnnr repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Dataset, Subset
+from torchvision import datasets, transforms
+from torchvision.models import resnet18
+
+from bnnr.adapter import SimpleTorchAdapter
+from bnnr.analyze import analyze_model
+from bnnr.core import BNNRConfig
+
+SEED = 42
+NUM_CLASSES = 10
+
+
+class IndexedDataset(Dataset):
+    """Wrap (image, label) → (image, label, index) for analyze."""
+
+    def __init__(self, base: Dataset) -> None:
+        self.base = base
+
+    def __len__(self) -> int:
+        return len(self.base)  # type: ignore[arg-type]
+
+    def __getitem__(self, idx: int):
+        image, label = self.base[idx]
+        return image, label, idx
+
+
+class _SyntheticCifarSubset(Dataset):
+    """In-memory CIFAR-shaped batch for CI (no download)."""
+
+    def __init__(self, n: int, seed: int) -> None:
+        gen = torch.Generator().manual_seed(seed)
+        self.images = torch.rand(n, 3, 32, 32, generator=gen)
+        self.labels = torch.arange(n, dtype=torch.long) % NUM_CLASSES
+
+    def __len__(self) -> int:
+        return int(self.labels.shape[0])
+
+    def __getitem__(self, idx: int):
+        return self.images[idx], int(self.labels[idx].item())
+
+
+def _build_resnet18(num_classes: int = NUM_CLASSES) -> nn.Module:
+    return resnet18(weights=None, num_classes=num_classes)
+
+
+def _cifar_loaders(
+    data_root: Path,
+    *,
+    synthetic: bool,
+    quick: bool,
+    batch_size: int,
+    seed: int,
+) -> tuple[DataLoader, DataLoader]:
+    transform = transforms.Compose([transforms.ToTensor()])
+    if synthetic:
+        n_train, n_val = 32, 24
+        train_ds: Dataset = _SyntheticCifarSubset(n_train, seed=seed)
+        val_ds: Dataset = _SyntheticCifarSubset(n_val, seed=seed + 1)
+    else:
+        train_full = datasets.CIFAR10(
+            str(data_root),
+            train=True,
+            download=True,
+            transform=transform,
+        )
+        val_full = datasets.CIFAR10(
+            str(data_root),
+            train=False,
+            download=True,
+            transform=transform,
+        )
+        if quick:
+            gen = torch.Generator().manual_seed(seed)
+            train_idx = torch.randperm(len(train_full), generator=gen)[:256].tolist()
+            val_idx = torch.randperm(len(val_full), generator=gen)[:128].tolist()
+            train_ds = Subset(train_full, train_idx)
+            val_ds = Subset(val_full, val_idx)
+        else:
+            train_ds = train_full
+            val_ds = val_full
+
+    train_loader = DataLoader(
+        IndexedDataset(train_ds),
+        batch_size=batch_size,
+        shuffle=True,
+    )
+    val_loader = DataLoader(
+        IndexedDataset(val_ds),
+        batch_size=batch_size,
+        shuffle=False,
+    )
+    return train_loader, val_loader
+
+
+def _train_one_epoch(
+    adapter: SimpleTorchAdapter,
+    train_loader: DataLoader,
+    device: torch.device,
+) -> None:
+    adapter.model.train()
+    for batch in train_loader:
+        images, labels, _indices = batch
+        images = images.to(device)
+        labels = labels.to(device)
+        adapter.optimizer.zero_grad()
+        logits = adapter.model(images)
+        loss = adapter.criterion(logits, labels)
+        loss.backward()
+        adapter.optimizer.step()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Torchvision ResNet-18 on CIFAR-10 → BNNR analyze HTML report",
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("torchvision_analyze_out"))
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--seed", type=int, default=SEED)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Small CIFAR-10 subset + 1 training epoch before analyze",
+    )
+    parser.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="In-memory data only (no CIFAR-10 download; for CI)",
+    )
+    parser.add_argument("--no-xai", action="store_true", help="Skip XAI in analyze")
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=None,
+        help="Load ResNet-18 state_dict from .pt (skip training)",
+    )
+    parser.add_argument(
+        "--xai-samples",
+        type=int,
+        default=32,
+        help="Probe set size for XAI (lower = faster)",
+    )
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    device = torch.device(
+        args.device if args.device != "auto" else ("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    data_root = args.output_dir / "cifar_data"
+
+    train_loader, val_loader = _cifar_loaders(
+        data_root,
+        synthetic=args.synthetic,
+        quick=args.quick or args.synthetic,
+        batch_size=args.batch_size,
+        seed=args.seed,
+    )
+
+    model = _build_resnet18().to(device)
+    target_layers = [model.layer4[-1]]
+    adapter = SimpleTorchAdapter(
+        model=model,
+        criterion=nn.CrossEntropyLoss(),
+        optimizer=torch.optim.Adam(model.parameters(), lr=1e-3),
+        target_layers=target_layers,
+        device=str(device),
+    )
+
+    if args.checkpoint is not None:
+        state = torch.load(args.checkpoint, map_location=device, weights_only=False)
+        if isinstance(state, dict) and "model_state" in state:
+            state = state["model_state"]
+        elif isinstance(state, dict) and "model" in state:
+            state = state["model"]
+        model.load_state_dict(state, strict=True)
+        print(f"Loaded checkpoint from {args.checkpoint}")
+    elif not args.synthetic:
+        epochs = 1 if args.quick else 3
+        print(f"Training ResNet-18 for {epochs} epoch(s) on CIFAR-10 subset …")
+        for ep in range(epochs):
+            _train_one_epoch(adapter, train_loader, device)
+            print(f"  epoch {ep + 1}/{epochs} done")
+    else:
+        print("Synthetic mode: skipping training (random weights)")
+
+    config = BNNRConfig(device=str(device), task="classification")
+    print("Running analyze_model …")
+    report = analyze_model(
+        adapter,
+        val_loader,
+        config=config,
+        output_dir=args.output_dir,
+        run_data_quality=not args.synthetic,
+        xai_enabled=not args.no_xai,
+        xai_samples=min(args.xai_samples, len(val_loader.dataset)),  # type: ignore[arg-type]
+    )
+    html_path = args.output_dir / "report.html"
+    report.to_html(html_path, artifact_root=args.output_dir, embed_images=True)
+    print(f"Saved {args.output_dir / 'analysis_report.json'}")
+    print(f"Saved {html_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bnnr"
-version = "0.4.10"
+version = "0.4.11"
 description = "BNNR — Train → Explain → Improve → Prove"
 readme = "README.pypi.md"
 license = { text = "MIT" }

--- a/src/bnnr/version.py
+++ b/src/bnnr/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the BNNR package version (also used as analyze report schema version)."""
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"

--- a/tests/test_torchvision_analyze_cifar10.py
+++ b/tests/test_torchvision_analyze_cifar10.py
@@ -1,0 +1,37 @@
+"""Smoke test for examples/classification/torchvision_analyze_cifar10.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "examples" / "classification" / "torchvision_analyze_cifar10.py"
+
+
+def test_torchvision_analyze_cifar10_smoke(tmp_path: Path) -> None:
+    out_dir = tmp_path / "analyze_out"
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--output-dir",
+            str(out_dir),
+            "--device",
+            "cpu",
+            "--synthetic",
+            "--no-xai",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    html = out_dir / "report.html"
+    assert html.is_file(), f"missing {html}"
+    assert html.stat().st_size > 1024

--- a/uv.lock
+++ b/uv.lock
@@ -96,7 +96,7 @@ wheels = [
 
 [[package]]
 name = "bnnr"
-version = "0.4.9"
+version = "0.4.11"
 source = { editable = "." }
 dependencies = [
     { name = "grad-cam" },
@@ -142,6 +142,9 @@ dev = [
 gpu = [
     { name = "kornia" },
 ]
+ultralytics = [
+    { name = "ultralytics" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -170,6 +173,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.9.0,<1.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12" },
     { name = "ultralytics", marker = "extra == 'dev'", specifier = ">=8.3.0,<9.0" },
+    { name = "ultralytics", marker = "extra == 'ultralytics'", specifier = ">=8.3.0,<9.0" },
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.30.0" },
     { name = "websockets", marker = "extra == 'dashboard'", specifier = ">=12.0" },
 ]


### PR DESCRIPTION
## Summary

- **Epic #158 / #159:** contributor issue templates, torchvision section in `analyze.md`, “Try analyze first” in `getting_started.md`
- **Example:** `examples/classification/torchvision_analyze_cifar10.py` + smoke test
- **Release:** v0.4.11 version bump and CHANGELOG
- **Quality:** consolidated CodeQL autofix (dashboard dead code); closed superseded draft PRs #168–#181

Closes #158, #159.

## Test plan

- [ ] CI green (ruff, mypy, pytest including `test_torchvision_analyze_cifar10.py`)
- [ ] `PYTHONPATH=src python examples/classification/torchvision_analyze_cifar10.py --synthetic --no-xai`

Made with [Cursor](https://cursor.com)