### PR TITLE
docs: align public roadmap with analyze-first growth plan

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,10 @@
 # Product roadmap
 
-**Updated:** 2026-05-30 · **Current release:** v0.4.11
+**Updated:** 2026-05-31 · **Current release:** v0.4.11
 
-BNNR is a PyTorch vision toolkit: **train → explain → improve → prove** — with `bnnr analyze` (failure + XAI HTML report), ICD/AICD augmentations, and optional detection training via adapters.
+BNNR is a PyTorch vision toolkit focused on **model diagnostics first** (`bnnr analyze`), then saliency-guided augmentations (ICD/AICD), with optional training and detection adapters.
+
+**Start here:** [analyze.md](analyze.md) · [sample HTML report](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html)
 
 ---
 
@@ -14,29 +16,36 @@ BNNR is a PyTorch vision toolkit: **train → explain → improve → prove** �
 | **Training** | CLI `train` / `demo` / `quickstart`; presets; live dashboard |
 | **XAI aug** | ICD, AICD, branch search; [plugin_icd.md](plugin_icd.md) for custom loops |
 | **Detection** | Train API + bbox augs; Ultralytics adapter; [detection.md](detection.md) — **no** `analyze` for detection yet |
-| **Benchmarks** | CIFAR-10 (3 seeds): no aug vs RandAugment vs BNNR — [benchmarks.md](benchmarks.md) |
+| **Benchmarks** | CIFAR-10 demo CNN (3 seeds): no aug vs RandAugment vs BNNR — [benchmarks.md](benchmarks.md) |
 | **Integrations** | pytorch-grad-cam loop, Ultralytics quickstart — [integrations.md](integrations.md) |
+| **Torchvision analyze** | Python example: [torchvision_analyze_cifar10.py](../examples/classification/torchvision_analyze_cifar10.py) |
 
 ---
 
-## Q2 2026 (June–July) — analyze adoption
+## Q2 2026 (June–August) — credibility + analyze adoption
 
 | Planned | Description |
 |---------|-------------|
-| **Torchvision → analyze** | Docs + runnable example: pretrained classifier checkpoint → `bnnr analyze` report (no full retrain) |
-| **Getting started** | “Try analyze first” + githack sample links in [getting_started.md](getting_started.md) |
+| **Analyze-first docs** | README and [getting_started.md](getting_started.md): try analyze before train; githack sample links |
+| **ResNet50 benchmark** | CIFAR-100 (or equivalent): 5 seeds; baselines RandAugment + TrivialAugment; reproducible script `benchmarks/reproduce_resnet50.sh` |
+| **Torchvision → analyze** | Prominent golden path: pretrained classifier → HTML report; runnable example in README |
+| **Repo discoverability** | GitHub description, website link, topics (maintainer ops) |
+| **Contributor templates** | Issue forms: benchmark proposal, “Who uses BNNR” showcase |
 | **Upstream docs** | Official link in Ultralytics docs (after PR merge); grad-cam ecosystem follow-up |
-| **Contributor templates** | GitHub issue forms: benchmark proposal, “Who uses BNNR” showcase |
+| **HuggingFace Space** | Minimal Gradio demo (sample report or analyze workflow) |
 
 ---
 
-## Q3 2026 (Aug–Sept) — analysis depth
+## Q3 2026 (September–November) — analysis depth + ecosystem
 
 | Planned | Description |
 |---------|-------------|
+| **HuggingFace models** | First `transformers` path for `analyze` (e.g. ViT) — documented example, not full Hub integration yet |
 | **Dataset insight** | “What to label next” / outlier buckets for manual review |
 | **More XAI methods** | Better stability + more methods; OptiCAM improvements; config docs |
-| **Batch reports** | Run `analyze` across many checkpoints/configs; compare runs |
+| **Multilabel CLI** | Parity for `bnnr train` / analyze workflows |
+| **Colab** | Analyze-only notebook linked from README |
+| **Batch reports** | Run `analyze` across many checkpoints/configs (foundation for compare) |
 
 ---
 
@@ -45,8 +54,18 @@ BNNR is a PyTorch vision toolkit: **train → explain → improve → prove** �
 | Planned | Description |
 |---------|-------------|
 | **Compare runs** | Side-by-side `analyze` for two checkpoints (compliance / audit use cases) |
+| **v1.0 criteria** | Public stability criteria; reduce “beta” friction on PyPI when met |
 | **GPU speedups** | Faster `analyze` runtime; caching and better defaults |
 | **More report templates** | Stakeholder-ready summary pages and comparisons |
+| **HF Hub analyze** | Load pretrained weights via Hub URI where feasible |
 
-**Later (gated):** detection `analyze` (heatmaps + failure buckets) — after classification analyze adoption and explicit community demand; see [detection.md](detection.md) for current train-only scope.
+---
 
+## 2027 H1 (gated)
+
+| Planned | Description |
+|---------|-------------|
+| **Detection analyze** | Heatmaps + failure buckets for detection — only after classification analyze adoption and clear community demand |
+| **CI integration** | Optional GitHub Actions step producing analyze HTML as artifact |
+
+See [detection.md](detection.md) for current train-only detection scope.


### PR DESCRIPTION
## Summary

- Refocus public roadmap intro on **analyze-first** (diagnostics before train/aug).
- **Q2 2026:** ResNet50/CIFAR-100 benchmark (5 seeds), analyze-first docs, torchvision golden path, HF Space MVP, repo discoverability (topics/description — done in GitHub UI).
- **Q3:** HuggingFace ViT analyze path, multilabel CLI, Colab analyze-only.
- **Q4:** Compare runs, v1.0 criteria, HF Hub analyze.
- **2027 H1 (gated):** detection analyze + optional CI analyze artifact.

Internal weekly plans (`plans/`) remain gitignored; this PR is the public-facing sync only.

## Test plan

- [x] Markdown renders (roadmap links valid)
- [ ] Review Q2 scope matches team capacity (benchmark before Show HN)


Made with [Cursor](https://cursor.com)