### PR TITLE
docs: align user documentation with code (audit 2026-05-31)

### DIFF
--- a/DOCUMENTATION_AUDIT_REPORT.md
+++ b/DOCUMENTATION_AUDIT_REPORT.md
@@ -1,0 +1,76 @@
+# BNNR Documentation Audit Report
+
+**Audit date:** 2026-05-31  
+**Package version (ground truth):** `0.4.11` (`src/bnnr/version.py`)  
+**Method:** Code-first verification — `src/bnnr/`, `tests/`, `pyproject.toml`.
+
+**Out of scope:** `docs/roadmap.md`, `plans/`, README section “What makes BNNR different”, `CHANGELOG.md` (historical).
+
+---
+
+## 1. Executive Summary
+
+| Metric | Count |
+|--------|------:|
+| Documentation files reviewed (`.md`) | 36 |
+| Jupyter notebooks reviewed | 6 |
+| Example Python scripts reviewed | 11 |
+| Inconsistencies found | 12 |
+| Documentation files corrected | 10 |
+| Supporting scripts updated | 1 |
+
+No changes to `src/bnnr/` implementation code.
+
+---
+
+## 2. Findings (summary)
+
+| ID | File | Issue | Fix |
+|----|------|-------|-----|
+| F-01 | `docs/cli.md` | Missing `stl10` in train datasets | Added |
+| F-02 | `docs/configuration.md` | `detection_xai_method` documented as `saliency` | Corrected to `activation` \| `occlusion` |
+| F-03 | `docs/augmentations.md` | Incomplete preset list | Added `demo`, `none`, `screening` |
+| F-04 | `docs/api_reference.md` | Stable vs deprecated API conflated | Restructured with `__all__` table |
+| F-05 | `docs/configuration.md`, `docs/README.md` | `BNNRConfig` attributed to `core.py` | Point to `config_model.py` |
+| F-06 | `docs/configuration.md` | Missing `duplicate_hamming_threshold` | Documented (default `10`) |
+| F-07 | `docs/artifacts.md` | Nonexistent `worst_predictions` JSON key | Replaced with actual keys |
+| F-08 | `docs/analyze.md` | Outdated limitations (v0.2.x) | Updated to current behavior |
+| F-09 | `docs/detection.md` | Incomplete detection config table | Full field list from `config_model.py` |
+| F-10 | `docs/artifacts.md` | Missing `events.jsonl` schema version | Documented `2.1` |
+| F-11 | `scripts/validate_user_notebooks.py` | 5 vs 6 catalog notebooks | Added cooking notebook |
+| F-12 | `docs/getting_started.md` | Incomplete dataset list | Added `stl10`, `fashion_mnist` |
+
+---
+
+## 3. High-Risk Inconsistencies
+
+1. Missing `stl10` in CLI train docs — users could assume unsupported dataset.
+2. Invalid `detection_xai_method: saliency` — config validation would fail or misconfigure runs.
+3. API reference implied all top-level imports are stable — deprecation warnings not documented.
+4. `worst_predictions` in artifacts doc — JSON parsers would fail on missing key.
+
+---
+
+## 4. API Mismatches (resolved)
+
+See corrected `docs/cli.md`, `docs/configuration.md`, `docs/api_reference.md`. Key alignments:
+
+- **CLI datasets:** `mnist`, `fashion_mnist`, `cifar10`, `stl10`, `imagefolder`, `coco_mini`, `yolo`
+- **Analyze tasks:** `classification`, `multilabel` only (not detection)
+- **Stable API:** 23 symbols in `bnnr.__all__`; 57 backward-compatible deprecated imports
+- **`EVENT_SCHEMA_VERSION`:** `"2.1"`
+
+---
+
+## 5. Example Fixes
+
+| Asset | Result |
+|-------|--------|
+| 11× `examples/**/*.py` | `py_compile` — all OK |
+| 6 notebooks | `validate_user_notebooks.py` — all OK |
+
+---
+
+## 6. Files Modified in This PR
+
+`docs/cli.md`, `docs/configuration.md`, `docs/augmentations.md`, `docs/api_reference.md`, `docs/README.md`, `docs/artifacts.md`, `docs/analyze.md`, `docs/detection.md`, `docs/getting_started.md`, `scripts/validate_user_notebooks.py`, `DOCUMENTATION_AUDIT_REPORT.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ A code-verified documentation index for installation, configuration, CLI/API usa
 Use this as the starting point when you need the shortest path to the page relevant to your task.
 
 - `getting_started.md` — first run from a clean machine
-- `configuration.md` — all `BNNRConfig` fields and defaults from `src/bnnr/core.py`
+- `configuration.md` — all `BNNRConfig` fields and defaults from `src/bnnr/config_model.py`
 - `cli.md` — CLI commands and option reference from `src/bnnr/cli.py`
 - `dashboard.md` — live/replay/mobile/QR dashboard workflow
 - `api_reference.md` — public Python API usage (classification helpers and a short Detection / Ultralytics subsection)

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -219,13 +219,13 @@ report.to_html("./analysis_out/report.html")
 
 For full API details, see `api_reference.md`.
 
-## Limitations (v0.2.x)
+## Limitations (current code)
 
-- **Detection**: Not supported by `bnnr analyze` or `analyze_model`; use classification or multi-label only.
-- **Compare**: No built-in comparison of two models (e.g. pre vs post fine-tuning); planned for a later release.
+- **Detection**: Not supported by `bnnr analyze` or `analyze_model`; supported tasks are `classification` and `multilabel` only.
+- **Compare**: `compare_runs` compares training `report.json` files; there is no built-in side-by-side compare of two `analyze` HTML reports in the CLI.
 - **Events**: Analyze does not emit events to `events.jsonl`; it produces standalone artifacts only.
-- **ROC/PR curves**: Analyze currently focuses on point metrics and diagnostics; ROC-AUC / PR curves are not rendered in `report.html` yet.
-- **Advanced concept XAI (e.g. CRAFT/NMF)**: Current analyze uses saliency/CAM-style methods; concept-level methods are roadmap candidates, not part of v0.2.x.
+- **ROC/PR curves**: Analyze focuses on point metrics and diagnostics; ROC-AUC / PR curves are not rendered in `report.html`.
+- **Advanced concept XAI (e.g. CRAFT/NMF)**: `analyze_model` uses saliency/CAM-style methods (`xai_method`, default `opticam`); CRAFT/NMF are available in training/XAI modules but not wired into the analyze pipeline.
 
 ## See also
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -10,7 +10,28 @@ Use this when CLI presets are not enough and you need full control.
 
 ## Source of truth
 
-This page documents only symbols exported publicly from `src/bnnr/__init__.py`.
+Implemented in `src/bnnr/`. The package exposes two import tiers:
+
+1. **Stable API** — names in `bnnr.__all__` (recommended for new code).
+2. **Backward-compatible imports** — additional names importable as `from bnnr import …` but emit `DeprecationWarning`; prefer `from bnnr.<subpackage> import …` (see [tests/test_backward_compat.py](../tests/test_backward_compat.py)).
+
+Detection, events, config I/O, and extended XAI symbols are **not** in `__all__`; import them from the submodules listed below.
+
+## Stable API (`bnnr.__all__`)
+
+| Symbol | Role |
+|--------|------|
+| `__version__` | Package version string |
+| `BNNRConfig`, `BNNRTrainer` | Config model and training loop |
+| `quick_run` | One-call classification training |
+| `ModelAdapter`, `SimpleTorchAdapter` | Model integration protocols |
+| `BNNRRunResult`, `Reporter`, `load_report`, `compare_runs` | Run outputs and comparison |
+| `BaseAugmentation`, `BasicAugmentation`, `ChurchNoise` | Core augmentation types |
+| `ICD`, `AICD` | Saliency-guided augmentations |
+| `auto_select_augmentations`, `get_preset`, `list_presets` | Preset helpers |
+| `OptiCAMExplainer`, `generate_saliency_maps` | Classification XAI |
+| `start_dashboard` | Live dashboard helper |
+| `analyze_model`, `AnalysisReport` | Standalone model diagnostics |
 
 ## Quickstart API (recommended)
 
@@ -27,16 +48,15 @@ Returns `BNNRRunResult`.
 
 ## Core training API (low-level)
 
-- `BNNRConfig`
-- `BNNRTrainer`
-- `BNNRRunResult`
-- `CheckpointInfo`
+Stable: `BNNRConfig`, `BNNRTrainer`, `BNNRRunResult`.
+
+Backward-compatible: `CheckpointInfo` — `from bnnr.reporting import CheckpointInfo`.
 
 ## Model adapter API
 
-- `ModelAdapter`
-- `XAICapableModel`
-- `SimpleTorchAdapter`
+Stable: `ModelAdapter`, `SimpleTorchAdapter`.
+
+Backward-compatible: `XAICapableModel` — `from bnnr.adapter import XAICapableModel`.
 
 ## Analysis API (standalone model diagnostics)
 
@@ -47,85 +67,46 @@ See `analyze.md` for usage and CLI.
 
 ## Reporting and events API
 
-- `Reporter`
-- `load_report`
-- `compare_runs`
-- `JsonlEventSink`
-- `EVENT_SCHEMA_VERSION`
-- `replay_events`
+Stable: `Reporter`, `load_report`, `compare_runs`.
 
-## Config helpers
+Backward-compatible (prefer submodule imports):
 
-- `load_config`
-- `save_config`
-- `validate_config`
-- `merge_configs`
-- `apply_xai_preset`
-- `get_xai_preset`
-- `list_xai_presets`
+- `JsonlEventSink`, `EVENT_SCHEMA_VERSION` (`"2.1"`), `replay_events` — `from bnnr.events import …`
+
+## Config helpers (backward-compatible)
+
+Import from `bnnr.config` (top-level `from bnnr import …` is deprecated):
+
+- `load_config`, `save_config`, `validate_config`, `merge_configs`
+- `apply_xai_preset`, `get_xai_preset`, `list_xai_presets` — presets `xai_light`, `xai_full`, `xai_adaptive`
+
+CLI defaults without YAML: `default_train_config()` (`m_epochs=3`, `max_iterations=2`, `device="auto"`), `default_demo_config()` (`m_epochs=1`, `max_iterations=1`).
 
 ## Augmentation API
 
-- `BaseAugmentation`
-- `AugmentationRegistry`
-- `AugmentationRunner`
-- `TorchvisionAugmentation`
-- `KorniaAugmentation`
-- `AlbumentationsAugmentation`
-- `create_kornia_pipeline`
-- `kornia_available`
-- `albumentations_available`
+Stable: `BaseAugmentation`, `BasicAugmentation`, `ChurchNoise`, `ICD`, `AICD`, `auto_select_augmentations`, `get_preset`, `list_presets`.
 
-Built-in classification augmentations:
+Backward-compatible — `from bnnr.augmentations import …` / `from bnnr.augmentation_runner import …`:
 
-- `ChurchNoise`
-- `BasicAugmentation`
-- `DifPresets`
-- `Drust`
-- `LuxferGlass`
-- `ProCAM`
-- `Smugs`
-- `TeaStains`
+- `AugmentationRegistry`, `AugmentationRunner`, `TorchvisionAugmentation`
+- `DifPresets`, `Drust`, `LuxferGlass`, `ProCAM`, `Smugs`, `TeaStains`
 
-Preset helpers:
+Optional backends — `from bnnr.kornia_aug import …`, `from bnnr.albumentations_aug import …`:
 
-- `auto_select_augmentations`
-- `get_preset`
-- `list_presets`
+- `KorniaAugmentation`, `create_kornia_pipeline`, `kornia_available`
+- `AlbumentationsAugmentation`, `albumentations_available`
 
 ## XAI API (classification)
 
-Explainers and generation:
+Stable: `OptiCAMExplainer`, `generate_saliency_maps`, `ICD`, `AICD`.
 
-- `BaseExplainer`
-- `OptiCAMExplainer`
-- `NMFConceptExplainer`
-- `CRAFTExplainer`
-- `RealCRAFTExplainer`
-- `RecursiveCRAFTExplainer`
-- `generate_saliency_maps`
-- `generate_craft_concepts`
-- `generate_nmf_concepts`
-- `save_xai_visualization`
+Backward-compatible — `from bnnr.xai import …`, `from bnnr.xai_cache import …`, `from bnnr.xai_analysis import …`:
 
-Analysis and scoring:
-
-- `analyze_xai_batch`
-- `analyze_xai_batch_rich`
-- `compute_xai_quality_score`
-- `generate_class_diagnosis`
-- `generate_class_insight`
-- `generate_epoch_summary`
-- `generate_rich_epoch_summary`
-
-Cache:
-
+- Explainers: `BaseExplainer`, `NMFConceptExplainer`, `CRAFTExplainer`, `RealCRAFTExplainer`, `RecursiveCRAFTExplainer`
+- `generate_craft_concepts`, `generate_nmf_concepts`, `save_xai_visualization`
+- `analyze_xai_batch`, `analyze_xai_batch_rich`, `compute_xai_quality_score`
+- `generate_class_diagnosis`, `generate_class_insight`, `generate_epoch_summary`, `generate_rich_epoch_summary`
 - `XAICache`
-
-ICD variants:
-
-- `ICD`
-- `AICD`
 
 ## Dashboard helper
 
@@ -158,9 +139,13 @@ print(result.best_metrics)
 
 ## Detection
 
+Import detection symbols from submodules (top-level `from bnnr import DetectionAdapter` is deprecated).
+
 ### Model adapters
 
-- `DetectionAdapter(model, optimizer, target_layers=None, device="cuda", scheduler=None, use_amp=False, score_threshold=0.05)` — wraps torchvision-style detectors (Faster R-CNN, RetinaNet, SSD, FCOS). In train mode calls `model(images, targets)` for losses; in eval mode calls `model(images)` for prediction dicts.
+`from bnnr.detection_adapter import DetectionAdapter, UltralyticsDetectionAdapter`
+
+- `DetectionAdapter(model, optimizer, target_layers=None, device="cuda", scheduler=None, use_amp=False, score_threshold=0.05)` — wraps torchvision-style detectors (Faster R-CNN, RetinaNet, SSD, FCOS). In train mode calls `model(images, targets)` for losses; in eval mode calls `model(images)` for prediction dicts. `device` accepts `cuda`, `cpu`, or `auto`.
 - `UltralyticsDetectionAdapter(model_name="yolov8n.pt", device="cuda", score_threshold=0.05, num_classes=None, lr=1e-3, optimizer=None, use_amp=False)` — wraps Ultralytics YOLO. Runs inference via `YOLO.predict` with 0–255 scaling, and exposes `predict_detection_dicts(batch_bchw)` for XAI and probe snapshots.
 
 Both adapters implement `train_step`, `eval_step`, `epoch_end_eval`, `epoch_end`, `state_dict`, `load_state_dict`, `get_target_layers`, and `get_model`.
@@ -169,12 +154,14 @@ For raw `ultralytics.nn.tasks` modules without this adapter, detection XAI stays
 
 ### Collate functions
 
+`from bnnr.detection_collate import detection_collate_fn, detection_collate_fn_with_index`
+
 - `detection_collate_fn(batch)` → `(Tensor[B,C,H,W], list[dict])` — stack images, keep targets as list
 - `detection_collate_fn_with_index(batch)` → `(Tensor[B,C,H,W], list[dict], Tensor[B])` — same, with sample indices
 
 ### Detection augmentations
 
-Bbox-aware transforms (subclass `BboxAwareAugmentation`):
+`from bnnr.detection_augmentations import …` — bbox-aware transforms (subclass `BboxAwareAugmentation`):
 
 - `DetectionHorizontalFlip` — horizontal flip with bbox mirroring
 - `DetectionVerticalFlip` — vertical flip with bbox mirroring
@@ -189,15 +176,19 @@ XAI-driven augmentations:
 - `DetectionICD(threshold_percentile=70.0, tile_size=8, fill_strategy="gaussian_blur")` — masks high-saliency (object) tiles
 - `DetectionAICD(threshold_percentile=70.0, tile_size=8, fill_strategy="gaussian_blur")` — masks low-saliency (background) tiles
 
-Presets: `get_detection_preset(name)` with `name` ∈ `{"light", "standard", "aggressive"}`.
+Presets: `from bnnr.detection_augmentations import get_detection_preset` — `name` ∈ `{"light", "standard", "aggressive"}`.
 
 ### Detection metrics
+
+`from bnnr.detection_metrics import …`
 
 - `calculate_detection_metrics(predictions, targets, iou_thresholds=None, score_threshold=0.0)` → `{"map_50": float, "map_50_95": float}`
 - `calculate_per_class_ap(predictions, targets, iou_threshold=0.5, class_names=None)` → per-class AP dict
 - `calculate_detection_confusion_matrix(predictions, targets, num_classes=None, iou_threshold=0.5)` → `{"labels", "matrix"}`
 
 ### Detection XAI
+
+`from bnnr.detection_xai import …`
 
 - `generate_detection_saliency(model, images, target_layers, device="cpu", forward_layout="torchvision_list"|"ultralytics_bchw")` — backbone activation–based class-agnostic saliency
 - `compute_detection_box_saliency_occlusion(...)` — per-box occlusion grid saliency

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -35,7 +35,7 @@ Checkpoints are saved in `checkpoint_dir`.
 
 When you run `bnnr analyze --model ... --data ... --output DIR`, the following are written under `DIR`:
 
-- `analysis_report.json` — full analysis payload (metrics, per_class_accuracy, confusion, XAI, data_quality, worst_predictions, failure_patterns, recommendations, extended v0.2 fields).
+- `analysis_report.json` — full analysis payload (metrics, per_class_accuracy, confusion, XAI, data_quality, failure_patterns, recommendations, extended fields; see keys below).
 - `report.html` — **self-contained** HTML report: XAI/confusion overlay PNGs embedded as base64 when written by `bnnr analyze` or `report.to_html(..., artifact_root=output_dir)`. Safe to share without sibling files.
 - `artifacts/confusion_pairs/` (optional) — saliency overlays for top confused class pairs.
 - `artifacts/class_examples/` (optional) — best/worst per-class XAI overlays.
@@ -49,9 +49,10 @@ Structure of `analysis_report.json` (top-level keys, v0.2):
 - `per_class_accuracy` — per-class counts and accuracy.
 - `confusion` — confusion matrix (format depends on task).
 - `xai_insights`, `xai_diagnoses`, `xai_quality_summary` — present when XAI was run.
-- `data_quality` — result of `run_data_quality_analysis` (warnings, duplicate_groups, summary).
-- `worst_predictions` — list of `{index, true_label, pred_label, confidence, loss, ...}`.
+- `data_quality` — result of data quality analysis (warnings, duplicate_groups, summary).
 - `failure_patterns` — e.g. confused pairs, low XAI quality classes.
+- `confusion_pair_xai`, `best_worst_examples` — optional XAI overlay metadata (classification; written when XAI is enabled).
+- `calibration_summary`, `analysis_scope`, `cv_results` — optional sections depending on task and flags.
 - `recommendations` — list of text recommendations.
 - `executive_summary` — health status/score, key findings, top actions, critical classes.
 - `findings` — structured findings with evidence and interpretation.
@@ -87,7 +88,7 @@ Common top-level keys:
 
 ## `events.jsonl`
 
-Written when `event_log_enabled=true`.
+Written when `event_log_enabled=true` (default). Each line is a JSON object with `schema_version` (`"2.1"`, from `bnnr.events.EVENT_SCHEMA_VERSION`).
 Used by replay and export in `src/bnnr/events.py` and `src/bnnr/dashboard/backend.py`.
 
 Common event types emitted by current code:

--- a/docs/augmentations.md
+++ b/docs/augmentations.md
@@ -12,12 +12,14 @@ Use this when selecting augmentation candidates for classification or multi-labe
 
 Available names:
 
-- `auto`
+- `auto` — virtual; hardware-aware selection via `auto_select_augmentations`
 - `light`
 - `standard`
 - `aggressive`
 - `gpu`
-- `screening` (API-level helper that maps to aggressive with uniform probability)
+- `demo` — ICD + ChurchNoise (used by `python -m bnnr demo`; also valid for `get_preset("demo")`)
+- `screening` — virtual; maps to aggressive with uniform probability (`get_preset` / API only)
+- `none` — no augmentations (`python -m bnnr train --preset none` only; not a named entry in `list_presets`)
 
 Examples:
 
@@ -28,7 +30,7 @@ augs_auto = auto_select_augmentations(random_state=42)
 augs_std = get_preset("standard", random_state=42)
 ```
 
-CLI `--preset` supports: `auto`, `light`, `standard`, `aggressive`, `gpu`.
+CLI `--preset` / `--augmentation-preset` on `train` supports: `auto`, `light`, `standard`, `aggressive`, `gpu`, `none` (unknown names fall back to `auto` with a warning). The `demo` command always uses preset `demo`.
 
 ## Built-in classification augmentations
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,6 +55,7 @@ Omit `--config` to use built-in quickstart defaults (`m_epochs=3`, `max_iteratio
 - `mnist`
 - `fashion_mnist`
 - `cifar10`
+- `stl10`
 - `imagefolder`
 
 **Object detection (requires `task: detection` in your YAML and a matching config; see [detection.md](detection.md)):**
@@ -64,7 +65,7 @@ Omit `--config` to use built-in quickstart defaults (`m_epochs=3`, `max_iteratio
 
 ### Multi-label classification
 
-`bnnr train` with **mnist**, **fashion_mnist**, **cifar10**, or **imagefolder** always builds **single-label** pipelines (`CrossEntropyLoss`, one class index per sample). Setting `task: multilabel` in your config YAML **does not** change that behavior. For multi-label, use the Python API ([golden_path.md](golden_path.md)) or the scripts under `examples/multilabel/` ([examples.md](examples.md)).
+`bnnr train` with **mnist**, **fashion_mnist**, **cifar10**, **stl10**, or **imagefolder** always builds **single-label** pipelines (`CrossEntropyLoss`, one class index per sample). Setting `task: multilabel` in your config YAML **does not** change that behavior. For multi-label, use the Python API ([golden_path.md](golden_path.md)) or the scripts under `examples/multilabel/` ([examples.md](examples.md)).
 
 ### Main options
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/bnnr?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/bnnr)
 
 ## What you will find here
-All configuration fields currently implemented in `src/bnnr/core.py`, grouped by responsibility, with defaults and validation notes.
+All configuration fields currently implemented in `src/bnnr/config_model.py` (re-exported as `bnnr.BNNRConfig`), grouped by responsibility, with defaults and validation notes.
 
 ## When to use this page
 Use this when creating or reviewing YAML config files for CLI or Python API runs.
@@ -132,6 +132,7 @@ trainer = BNNRTrainer(
 - `xai_selection_weight` (default: `0.0`, validated to `[0,1]`)
 - `xai_pruning_threshold` (default: `0.0`, validated to `[0,1]`)
 - `adaptive_icd_threshold` (default: `false`)
+- `duplicate_hamming_threshold` (default: `10`, validated `>=0`) — Hamming distance threshold for duplicate-sample detection in XAI cache
 
 ## Candidate pruning fields
 
@@ -189,7 +190,7 @@ Additional detection fields for advanced use:
 - `detection_nms_threshold` — NMS IoU threshold
 - `detection_min_box_area` — minimum box area to keep
 - `detection_max_truncation` — maximum box truncation ratio
-- `detection_xai_method` — XAI method for detection (`saliency`, `occlusion`)
+- `detection_xai_method` (default: `activation`) — XAI method for detection: `activation` (backbone activation heatmap) or `occlusion`
 - `detection_xai_grid_size` — grid resolution for occlusion XAI
 - `detection_xai_max_gt_boxes` — max ground-truth boxes rendered in XAI panels
 - `detection_xai_max_pred_boxes` — max prediction boxes rendered in XAI panels

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -169,6 +169,13 @@ config = BNNRConfig(
 | `detection_score_threshold` | `0.5` | Confidence threshold for evaluation |
 | `detection_targets_mode` | `"auto"` | Augmentation target mode: `auto`, `image_only`, `bbox_aware` |
 | `detection_class_names` | `None` | Optional list of class names for reports |
+| `detection_nms_threshold` | `0.5` | NMS IoU threshold |
+| `detection_min_box_area` | `16.0` | Minimum box area to keep |
+| `detection_max_truncation` | `0.7` | Maximum box truncation ratio |
+| `detection_xai_method` | `"activation"` | `activation` (backbone heatmap) or `occlusion` |
+| `detection_xai_grid_size` | `3` | Grid size for occlusion XAI |
+| `detection_xai_max_gt_boxes` | `1` | Max GT boxes in XAI panels |
+| `detection_xai_max_pred_boxes` | `1` | Max prediction boxes in XAI panels |
 
 ### Detection metrics
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -127,9 +127,9 @@ xai_enabled: false
 YAML
 ```
 
-**Multi-label classification:** `python -m bnnr train` with built-in datasets (`cifar10`, `mnist`, `imagefolder`, …) always uses single-label heads and `CrossEntropyLoss`. Putting `task: multilabel` in YAML **does not** switch the CLI to multi-label. Use the Python API (`task="multilabel"`, `SimpleTorchAdapter(multilabel=True)`, `BCEWithLogitsLoss`) or `examples/multilabel/multilabel_demo.py` — see [configuration.md](configuration.md), [golden_path.md](golden_path.md), [cli.md](cli.md), and [examples.md](examples.md).
+**Multi-label classification:** `python -m bnnr train` with built-in datasets (`mnist`, `fashion_mnist`, `cifar10`, `stl10`, `imagefolder`, …) always uses single-label heads and `CrossEntropyLoss`. Putting `task: multilabel` in YAML **does not** switch the CLI to multi-label. Use the Python API (`task="multilabel"`, `SimpleTorchAdapter(multilabel=True)`, `BCEWithLogitsLoss`) or `examples/multilabel/multilabel_demo.py` — see [configuration.md](configuration.md), [golden_path.md](golden_path.md), [cli.md](cli.md), and [examples.md](examples.md).
 
-**Object detection:** BNNR v0.2+ supports object detection with `task="detection"`. Use `DetectionAdapter` (torchvision) or `UltralyticsDetectionAdapter` (YOLOv8) as your model adapter, with bbox-aware augmentations and mAP metrics. Detection requires the Python API — see [detection.md](detection.md) for the full guide and [examples.md](examples.md) for ready-to-run scripts.
+**Object detection:** BNNR supports object detection with `task="detection"`. Use `DetectionAdapter` (torchvision) or `UltralyticsDetectionAdapter` (YOLOv8) as your model adapter, with bbox-aware augmentations and mAP metrics. Detection requires the Python API — see [detection.md](detection.md) for the full guide and [examples.md](examples.md) for ready-to-run scripts.
 
 ## 7) First run in live dashboard mode (recommended)
 

--- a/scripts/validate_user_notebooks.py
+++ b/scripts/validate_user_notebooks.py
@@ -19,6 +19,7 @@ from pathlib import Path
 USER_NOTEBOOKS: list[str] = [
     "examples/bnnr_augmentations_guide.ipynb",
     "examples/classification/bnnr_classification_demo.ipynb",
+    "examples/classification/bnnr_cooking_round1_butterfly.ipynb",
     "examples/multilabel/bnnr_multilabel_demo.ipynb",
     "examples/bnnr_custom_data.ipynb",
     "examples/detection/bnnr_detection_demo.ipynb",


### PR DESCRIPTION
## Summary

- Full code-first documentation audit against `src/bnnr/` (v0.4.11): 36 MD files, 6 notebooks, 11 example scripts reviewed.
- Fixed 12 inconsistencies in CLI, configuration, API reference, artifacts, detection, augmentations, and getting started guides.
- Restructured `docs/api_reference.md` to separate stable `__all__` exports from backward-compatible deprecated imports.
- Added `DOCUMENTATION_AUDIT_REPORT.md` with findings, high-risk items, and verification notes.
- Extended `scripts/validate_user_notebooks.py` to include `bnnr_cooking_round1_butterfly.ipynb` (6/6 catalog notebooks).

**Not in scope:** `docs/roadmap.md`, `plans/`, README marketing section.

## Key fixes

| Area | Change |
|------|--------|
| CLI `train` | Document `stl10` dataset |
| `BNNRConfig` | `detection_xai_method`: `activation` \| `occlusion` (not `saliency`) |
| Presets | Document `demo`, `none`, `screening` |
| Artifacts | Remove nonexistent `worst_predictions`; document events schema `2.1` |
| API reference | Stable vs deprecated import paths |

## Test plan

- [x] `PYTHONPATH=src python3 scripts/validate_user_notebooks.py` (6 notebooks OK)
- [x] `py_compile` on all `examples/**/*.py`
- [x] `python3 -m bnnr list-datasets` matches documented dataset list
- [ ] CI `notebooks-smoke` job (runs same validator)


Made with [Cursor](https://cursor.com)