### PR TITLE
fix: CV when predictions include classes absent from labels

### DIFF
--- a/src/bnnr/analysis/cross_validation.py
+++ b/src/bnnr/analysis/cross_validation.py
@@ -104,7 +104,7 @@ def run_cross_validation_from_predictions(
     f1s: list[float] = []
     kappas: list[float] = []
 
-    classes = np.unique(labels)
+    classes = np.union1d(labels, preds)
     class_to_idx = {int(c): i for i, c in enumerate(classes)}
     k = len(classes)
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -664,6 +664,19 @@ def test_grouped_findings() -> None:
         assert finding_types.count(ft) == 1, f"Finding type {ft} appears more than once (not grouped)"
 
 
+def test_cross_validation_predicted_class_not_in_labels() -> None:
+    """CV must not fail when preds include a class absent from ground-truth labels."""
+    import numpy as np
+
+    from bnnr.analysis.cross_validation import run_cross_validation_from_predictions
+
+    labels = np.array([1, 2, 2, 2, 1, 2, 1, 2, 2, 2, 1, 1])
+    preds = np.zeros_like(labels)
+    cv = run_cross_validation_from_predictions(preds, labels, n_folds=3)
+    assert cv.n_folds == 3
+    assert "mean_accuracy" in cv.global_metrics
+
+
 def test_cross_validation_all_metrics() -> None:
     """Cross-validation includes precision, recall, f1, and Cohen's Kappa."""
     import numpy as np


### PR DESCRIPTION
## Summary

- Fixes `KeyError: 0` in `run_cross_validation_from_predictions` when predictions contain a class that never appears in ground-truth labels (CI failure in `test_analyze_model_with_cv`).
- Builds the confusion-matrix class index from `np.union1d(labels, preds)` instead of labels only.
- Adds a focused regression test mirroring the CI failure case.

## Root cause

The default untrained model in `test_analyze_model_with_cv` predicts class `0` for every sample while the synthetic loader only uses labels `1` and `2`. CV built `class_to_idx` from `np.unique(labels)` only, so mapping prediction `0` failed.

## Test plan

- [x] `pytest tests/test_analyze.py::test_analyze_model_with_cv tests/test_analyze.py::test_cross_validation_predicted_class_not_in_labels tests/test_analyze.py::test_cross_validation_all_metrics`
- [ ] Full CI green on merge


Made with [Cursor](https://cursor.com)