### PR TITLE
benchmark: ResNet50/CIFAR-100 harness (RandAugment + TrivialAugment, 5 seeds)

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,3 +1,4 @@
 runs/
+runs_resnet50/
 __pycache__/
 *.pyc

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,4 +1,13 @@
-# CIFAR-10 benchmarks
+# Benchmarks
+
+Two reproducible augmentation comparisons:
+
+1. **CIFAR-10 / demo CNN** (below) — fast, illustrative, runs on CPU.
+2. **ResNet50 / CIFAR-100** ([jump](#resnet50--cifar-100-benchmark)) — a real architecture and a harder dataset, with RandAugment **and** TrivialAugment baselines over 5 seeds. Infrastructure is in place; numbers land in the table after a GPU run.
+
+---
+
+## CIFAR-10 / demo CNN
 
 Reproducible comparison of **three training setups** on the same demo CNN, dataset split, and epoch budget:
 
@@ -94,3 +103,60 @@ python scripts/build_benchmark_xai_readme_asset.py
 ```
 
 Output: `docs/assets/benchmark-xai-comparison.png` (used in root README).
+
+---
+
+## ResNet50 / CIFAR-100 benchmark
+
+A larger, more convincing benchmark than the demo-CNN / CIFAR-10 table above: a real **ResNet50** backbone (ImageNet-pretrained by default) on **CIFAR-100** (100 classes), comparing the BNNR branch search against **two** strong external baselines.
+
+| Condition | What it is |
+|-----------|------------|
+| `no_bnnr` | Resize + RandomCrop + RandomHorizontalFlip — no BNNR augmentations |
+| `randaugment` | + **torchvision RandAugment** (external baseline) |
+| `trivialaugment` | + **torchvision TrivialAugmentWide** (parameter-free external baseline) |
+| `bnnr_branch_search` | Full **BNNR branch search** over **ICD**, **AICD**, and ChurchNoise |
+
+### Design
+
+- **ResNet50** from `torchvision.models`, ImageNet weights. The classifier head is replaced for 100 classes.
+- **In-model normalization:** ImageNet mean/std are applied *inside* the model (registered buffers), so every condition feeds plain `ToTensor()` tensors in `[0, 1]`. Pretrained weights stay valid and BNNR's uint8-range ICD/AICD augmentations remain compatible.
+- **Same** backbone, optimizer (SGD, momentum 0.9, weight decay 5e-4), cosine schedule, epochs, and seeds across all conditions — only the augmentation strategy varies.
+- **OptiCAM** overlays on fixed CIFAR-100 test indices, exported per run (`runs_resnet50/*/xai/`).
+
+### Run
+
+```bash
+# Fast sanity check (CPU-friendly, no pretrained download, tiny subset)
+python benchmarks/run_resnet50.py --smoke
+
+# Full benchmark — 5 seeds, GPU (this is the publication run)
+bash benchmarks/reproduce_resnet50.sh
+# or:
+python benchmarks/run_resnet50.py --seeds 42,43,44,45,46 --device cuda
+
+# Summarize
+python benchmarks/summarize.py --results benchmarks/results_resnet50.json --markdown
+```
+
+`run_resnet50.py` checkpoints `results_resnet50.json` after every (condition, seed) run, so the matrix is resume-safe — a crash or interruption keeps completed runs.
+
+### Layout
+
+```
+benchmarks/
+  run_resnet50.py            # CLI (resume-safe matrix runner)
+  reproduce_resnet50.sh      # one-command full run (5 seeds)
+  results_resnet50.json      # aggregated results (commit after review)
+  runs_resnet50/             # per-run logs + xai/ overlays (gitignored)
+```
+
+### Protocol caveats (read before quoting numbers)
+
+- **Unequal compute by design.** `bnnr_branch_search` runs a baseline phase plus branch search (more epochs of compute than the fixed-epoch baselines). Compare as *"full BNNR product vs fixed-epoch baselines"*, not equal-budget ablation.
+- **Not an ImageNet-SOTA claim.** This is a CIFAR-100 transfer setup for comparing augmentation *strategies*, not a leaderboard entry.
+- **CIFAR-100 upscaled to 224px** to use the pretrained ResNet50 features. `--img-size` and `--no-pretrained` are available for other regimes.
+
+### Results
+
+_Pending a GPU run._ Run `reproduce_resnet50.sh`, review `results_resnet50.json`, then paste the `summarize.py --markdown` table here and into the root `README.md`. Do not hand-write numbers.

--- a/benchmarks/lib.py
+++ b/benchmarks/lib.py
@@ -24,7 +24,7 @@ DEFAULT_CONFIG = BENCHMARKS_DIR / "config.yaml"
 if str(REPO_ROOT / "src") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "src"))
 
-Strategy = Literal["plain_training", "randaugment", "bnnr_branch_search"]
+Strategy = Literal["plain_training", "randaugment", "trivialaugment", "bnnr_branch_search"]
 
 
 @dataclass(frozen=True)
@@ -402,6 +402,7 @@ def _run_plain_epochs(
     run_dir: Path,
     bench: dict[str, Any],
     extra_meta: dict[str, Any] | None = None,
+    export_xai: bool = True,
 ) -> dict[str, Any]:
     from bnnr.core import BNNRTrainer
     from bnnr.training.loop import evaluate, train_epoch
@@ -446,15 +447,18 @@ def _run_plain_epochs(
         trainer.model.load_state_dict(best_state)
 
     elapsed_s = time.perf_counter() - t0
-    xai_indices = list(bench.get("xai_val_indices") or [0, 127, 255, 512])
-    xai_method = str(bench.get("xai_method") or cfg.xai_method or "opticam")
-    xai_meta = export_attention_maps(
-        adapter,
-        val_loader,
-        sample_indices=xai_indices,
-        output_dir=run_dir / "xai",
-        xai_method=xai_method,
-    )
+    if export_xai:
+        xai_indices = list(bench.get("xai_val_indices") or [0, 127, 255, 512])
+        xai_method = str(bench.get("xai_method") or cfg.xai_method or "opticam")
+        xai_meta = export_attention_maps(
+            adapter,
+            val_loader,
+            sample_indices=xai_indices,
+            output_dir=run_dir / "xai",
+            xai_method=xai_method,
+        )
+    else:
+        xai_meta = {"xai_dir": None, "overlay_paths": [], "aggregate_stats": {}}
 
     summary_path = run_dir / "run_summary.json"
     payload = {

--- a/benchmarks/reproduce_resnet50.sh
+++ b/benchmarks/reproduce_resnet50.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Reproduce the ResNet50 / CIFAR-100 augmentation benchmark (5 seeds).
+#
+# Compares: no_bnnr | randaugment | trivialaugment | bnnr_branch_search
+# on an ImageNet-pretrained ResNet50, CIFAR-100, identical training budget
+# per condition (only the augmentation strategy varies).
+#
+# Usage:
+#   bash benchmarks/reproduce_resnet50.sh                 # GPU, 5 seeds, defaults
+#   DEVICE=cpu SEEDS=42 bash benchmarks/reproduce_resnet50.sh   # quick single-seed
+#   EPOCHS=20 IMG_SIZE=224 bash benchmarks/reproduce_resnet50.sh # override knobs
+#
+# Environment overrides (all optional):
+#   SEEDS      default "42,43,44,45,46"
+#   DEVICE     default "auto"  (auto|cuda|cpu)
+#   EPOCHS     default 15      (epochs per training phase)
+#   IMG_SIZE   default 224     (CIFAR-100 resize target)
+#   BATCH      default 64
+#   RESULTS    default benchmarks/results_resnet50.json
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SEEDS="${SEEDS:-42,43,44,45,46}"
+DEVICE="${DEVICE:-auto}"
+EPOCHS="${EPOCHS:-15}"
+IMG_SIZE="${IMG_SIZE:-224}"
+BATCH="${BATCH:-64}"
+RESULTS="${RESULTS:-benchmarks/results_resnet50.json}"
+
+echo "=============================================================="
+echo " ResNet50 / CIFAR-100 augmentation benchmark"
+echo "   seeds=${SEEDS} device=${DEVICE} epochs=${EPOCHS} img_size=${IMG_SIZE}"
+echo "   results -> ${RESULTS}"
+echo "=============================================================="
+
+# PYTHONPATH=src so the script runs from a clean clone without install.
+PYTHONPATH="${PYTHONPATH:-}:src" python benchmarks/run_resnet50.py \
+  --seeds "${SEEDS}" \
+  --device "${DEVICE}" \
+  --epochs "${EPOCHS}" \
+  --img-size "${IMG_SIZE}" \
+  --batch-size "${BATCH}" \
+  --results "${RESULTS}"
+
+echo ""
+echo "Summary:"
+PYTHONPATH="${PYTHONPATH:-}:src" python benchmarks/summarize.py \
+  --results "${RESULTS}" --markdown
+
+echo ""
+echo "Next: review ${RESULTS}, then paste the table above into benchmarks/README.md"
+echo "and the root README.md (do not hand-write numbers)."

--- a/benchmarks/run_resnet50.py
+++ b/benchmarks/run_resnet50.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""ResNet50 / CIFAR-100 augmentation benchmark.
+
+Compares four training conditions on a *real* architecture (ResNet50) and a
+harder dataset (CIFAR-100, 100 classes) than the demo-CNN / CIFAR-10 table in
+``benchmarks/run.py``:
+
+    no_bnnr         RandomCrop + RandomHorizontalFlip (standard baseline)
+    randaugment     + torchvision RandAugment
+    trivialaugment  + torchvision TrivialAugmentWide
+    bnnr_branch_search   full BNNR loop (ICD + AICD + ChurchNoise, branch search)
+
+Protocol honesty (mirrors ``docs/benchmarks.md``):
+  * Same backbone, optimizer, scheduler, epochs, and seeds across conditions.
+  * The augmentation strategy is the *only* thing that varies per condition.
+  * BNNR branch search spends more compute (baseline phase + branch search);
+    this is disclosed in the results JSON and the README table.
+
+The ResNet50 wrapper normalizes inputs *inside* the model (ImageNet mean/std as
+registered buffers) so every condition can feed plain ``ToTensor()`` tensors in
+``[0, 1]``. This keeps pretrained weights happy while remaining compatible with
+BNNR's ICD/AICD augmentations, which operate on uint8-range tensors.
+
+This script builds the runnable infrastructure. Numbers land in the README only
+after a real GPU run (see ``benchmarks/reproduce_resnet50.sh``).
+
+Examples
+--------
+    # Quick smoke test (CPU-friendly, no pretrained download, tiny subset)
+    python benchmarks/run_resnet50.py --smoke
+
+    # Full benchmark, 5 seeds, GPU
+    python benchmarks/run_resnet50.py --seeds 42,43,44,45,46 --device cuda
+
+    # Single condition / single seed
+    python benchmarks/run_resnet50.py --conditions no_bnnr --seeds 42 --device cuda
+
+    python benchmarks/summarize.py --results benchmarks/results_resnet50.json --markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+BENCHMARKS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = BENCHMARKS_DIR.parent
+if str(BENCHMARKS_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCHMARKS_DIR))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from lib import (  # noqa: E402
+    ConditionSpec,
+    _extract_baseline_from_report,
+    _make_run_dir,
+    _result_entry,
+    _run_config,
+    _run_plain_epochs,
+    build_bnnr_candidate_augmentations,
+    export_attention_maps,
+    git_head,
+    load_results,
+    save_results,
+    torch_info,
+)
+
+DEFAULT_RESULTS = BENCHMARKS_DIR / "results_resnet50.json"
+DEFAULT_OUTPUT = BENCHMARKS_DIR / "runs_resnet50"
+
+# ImageNet normalization, applied inside the model (see _NormalizedResNet).
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+# OptiCAM overlay indices into the CIFAR-100 test split (10k images).
+_XAI_VAL_INDICES = [0, 127, 255, 512]
+
+
+CONDITIONS: dict[str, ConditionSpec] = {
+    "no_bnnr": ConditionSpec(
+        id="no_bnnr",
+        label="Without BNNR (crop + flip only)",
+        strategy="plain_training",
+        description=(
+            "Standard CIFAR-100 training: RandomCrop + RandomHorizontalFlip. "
+            "No BNNR batch augmentations and no branch search."
+        ),
+        augmentation_names=(),
+        max_iterations=0,
+    ),
+    "randaugment": ConditionSpec(
+        id="randaugment",
+        label="RandAugment (torchvision)",
+        strategy="randaugment",
+        description=(
+            "External baseline: RandomCrop + RandomHorizontalFlip + "
+            "torchvision RandAugment. Policy-based random augmentation, "
+            "no saliency guidance."
+        ),
+        augmentation_names=("RandAugment",),
+        max_iterations=0,
+    ),
+    "trivialaugment": ConditionSpec(
+        id="trivialaugment",
+        label="TrivialAugmentWide (torchvision)",
+        strategy="trivialaugment",
+        description=(
+            "External baseline: RandomCrop + RandomHorizontalFlip + "
+            "torchvision TrivialAugmentWide. Parameter-free SOTA-ish random "
+            "augmentation, no saliency guidance."
+        ),
+        augmentation_names=("TrivialAugmentWide",),
+        max_iterations=0,
+    ),
+    "bnnr_branch_search": ConditionSpec(
+        id="bnnr_branch_search",
+        label="BNNR branch search (ICD + AICD + ChurchNoise)",
+        strategy="bnnr_branch_search",
+        description=(
+            "Full BNNR loop: baseline phase, then branch search over "
+            "ICD (mask high-saliency regions), AICD (mask background), and "
+            "ChurchNoise. Keeps branches that improve validation accuracy."
+        ),
+        augmentation_names=("ICD", "AICD", "augmentation_1"),
+        max_iterations=3,
+    ),
+}
+
+_ARCH_TARGET_HINT = {
+    "resnet50": "backbone.layer4[-1]",
+    "resnet18": "backbone.layer4[-1]",
+}
+
+
+# ---------------------------------------------------------------------------
+# Model: torchvision ResNet with in-model ImageNet normalization
+# ---------------------------------------------------------------------------
+
+
+def _build_resnet(arch: str, num_classes: int, pretrained: bool) -> Any:
+    """torchvision ResNet adapted to ``num_classes`` with normalization baked in.
+
+    Inputs are expected in ``[0, 1]`` (plain ``ToTensor()``); the model
+    normalizes with ImageNet statistics internally so pretrained weights work
+    and BNNR's uint8-range augmentations stay compatible upstream.
+    """
+    import torch
+    from torch import nn
+    from torchvision import models
+
+    if arch == "resnet50":
+        weights = models.ResNet50_Weights.IMAGENET1K_V2 if pretrained else None
+        backbone = models.resnet50(weights=weights)
+    elif arch == "resnet18":
+        weights = models.ResNet18_Weights.IMAGENET1K_V1 if pretrained else None
+        backbone = models.resnet18(weights=weights)
+    else:
+        raise ValueError(f"Unsupported arch {arch!r} (use resnet50 or resnet18)")
+
+    backbone.fc = nn.Linear(backbone.fc.in_features, num_classes)
+
+    class _NormalizedResNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.backbone = backbone
+            self.register_buffer("mean", torch.tensor(_IMAGENET_MEAN).view(1, 3, 1, 1))
+            self.register_buffer("std", torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1))
+
+        def forward(self, x: Any) -> Any:
+            x = (x - self.mean) / self.std
+            return self.backbone(x)
+
+    return _NormalizedResNet()
+
+
+def _target_layers(model: Any) -> list[Any]:
+    return [model.backbone.layer4[-1]]
+
+
+# ---------------------------------------------------------------------------
+# Data: CIFAR-100 loaders (one builder per augmentation policy)
+# ---------------------------------------------------------------------------
+
+
+def _cifar100_loaders(
+    *,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+    policy: str,
+    max_train: int | None,
+    max_val: int | None,
+) -> tuple[Any, Any]:
+    """Return ``(train_loader, val_loader)`` for the requested augmentation policy.
+
+    ``policy`` is one of ``base`` | ``randaugment`` | ``trivialaugment``. The val
+    transform is identical across policies (resize + ToTensor).
+    """
+    from torch.utils.data import DataLoader
+    from torchvision import datasets, transforms
+
+    from bnnr.pipelines import _IndexedDataset, _maybe_subset
+
+    base_train = [
+        transforms.Resize((img_size, img_size)),
+        transforms.RandomCrop(img_size, padding=img_size // 8),
+        transforms.RandomHorizontalFlip(),
+    ]
+    if policy == "randaugment":
+        base_train.append(transforms.RandAugment())
+    elif policy == "trivialaugment":
+        base_train.append(transforms.TrivialAugmentWide())
+    elif policy != "base":
+        raise ValueError(f"Unknown policy {policy!r}")
+    base_train.append(transforms.ToTensor())
+
+    train_tf = transforms.Compose(base_train)
+    val_tf = transforms.Compose(
+        [transforms.Resize((img_size, img_size)), transforms.ToTensor()]
+    )
+
+    data_root = str(REPO_ROOT / "data")
+    train_ds = datasets.CIFAR100(data_root, train=True, download=True, transform=train_tf)
+    val_ds = datasets.CIFAR100(data_root, train=False, download=True, transform=val_tf)
+    train_ds = _maybe_subset(train_ds, max_train)
+    val_ds = _maybe_subset(val_ds, max_val)
+
+    import torch
+
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    train_loader = DataLoader(
+        _IndexedDataset(train_ds),
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=2,
+        generator=generator,
+    )
+    val_loader = DataLoader(
+        _IndexedDataset(val_ds), batch_size=batch_size, shuffle=False, num_workers=2
+    )
+    return train_loader, val_loader
+
+
+def _build_adapter(
+    *,
+    arch: str,
+    num_classes: int,
+    pretrained: bool,
+    lr: float,
+    device: str,
+    epochs: int,
+) -> Any:
+    import torch
+    from torch import nn
+
+    from bnnr.adapter import SimpleTorchAdapter
+
+    model = _build_resnet(arch, num_classes, pretrained)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(
+        model.parameters(), lr=lr, momentum=0.9, weight_decay=5e-4
+    )
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max(1, epochs))
+    return SimpleTorchAdapter(
+        model=model,
+        criterion=criterion,
+        optimizer=optimizer,
+        target_layers=_target_layers(model),
+        device=device,
+        scheduler=scheduler,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config + per-condition runners
+# ---------------------------------------------------------------------------
+
+
+def _base_config(*, epochs: int, device: str) -> Any:
+    from bnnr.config_model import BNNRConfig
+
+    return BNNRConfig(
+        task="classification",
+        device=device,
+        m_epochs=epochs,
+        selection_metric="accuracy",
+        metrics=["accuracy", "f1_macro", "loss"],
+        xai_method="opticam",
+    )
+
+
+def _stamp(entry: dict[str, Any], *, arch: str, img_size: int, pretrained: bool) -> dict[str, Any]:
+    """Override the cifar10 defaults baked into lib._result_entry."""
+    entry["dataset"] = "cifar100"
+    entry["model"] = arch
+    entry["img_size"] = img_size
+    entry["pretrained"] = pretrained
+    return entry
+
+
+def _run_plain_condition(
+    *,
+    condition: ConditionSpec,
+    policy: str,
+    seed: int,
+    args: argparse.Namespace,
+    output_root: Path,
+) -> dict[str, Any]:
+    run_dir = _make_run_dir(output_root, condition.id, seed)
+    base_cfg = _base_config(epochs=args.epochs, device=args.device)
+    cfg = _run_config(base_cfg, seed=seed, device=args.device, run_dir=run_dir, xai=False)
+
+    adapter = _build_adapter(
+        arch=args.arch,
+        num_classes=100,
+        pretrained=args.pretrained,
+        lr=args.lr,
+        device=cfg.device,
+        epochs=args.epochs,
+    )
+    train_loader, val_loader = _cifar100_loaders(
+        img_size=args.img_size,
+        batch_size=args.batch_size,
+        seed=seed,
+        policy=policy,
+        max_train=args.max_train_samples,
+        max_val=args.max_val_samples,
+    )
+    bench = {"xai_val_indices": _XAI_VAL_INDICES, "xai_method": "opticam"}
+    extra = {"augmentation_policy": policy} if policy != "base" else None
+    entry = _run_plain_epochs(
+        condition=condition,
+        cfg=cfg,
+        adapter=adapter,
+        train_loader=train_loader,
+        val_loader=val_loader,
+        augmentations=[],
+        run_dir=run_dir,
+        bench=bench,
+        extra_meta=extra,
+        export_xai=not args.no_xai,
+    )
+    return _stamp(entry, arch=args.arch, img_size=args.img_size, pretrained=args.pretrained)
+
+
+def _run_bnnr_condition(
+    *,
+    condition: ConditionSpec,
+    seed: int,
+    args: argparse.Namespace,
+    output_root: Path,
+) -> dict[str, Any]:
+    from bnnr.core import BNNRTrainer
+
+    run_dir = _make_run_dir(output_root, condition.id, seed)
+    base_cfg = _base_config(epochs=args.epochs, device=args.device)
+    cfg = _run_config(
+        base_cfg,
+        seed=seed,
+        device=args.device,
+        run_dir=run_dir,
+        xai=True,
+        max_iterations=condition.max_iterations,
+    )
+
+    adapter = _build_adapter(
+        arch=args.arch,
+        num_classes=100,
+        pretrained=args.pretrained,
+        lr=args.lr,
+        device=cfg.device,
+        epochs=args.epochs,
+    )
+    train_loader, val_loader = _cifar100_loaders(
+        img_size=args.img_size,
+        batch_size=args.batch_size,
+        seed=seed,
+        policy="base",
+        max_train=args.max_train_samples,
+        max_val=args.max_val_samples,
+    )
+    augmentations = build_bnnr_candidate_augmentations(
+        adapter.get_model(), adapter.get_target_layers(), seed
+    )
+
+    print(
+        f"\n{'='*60}\n"
+        f"  BNNR BRANCH SEARCH ({args.arch} / cifar100)\n"
+        f"  candidates={[a.name for a in augmentations]}\n"
+        f"  max_iterations={condition.max_iterations}  m_epochs={cfg.m_epochs}\n"
+        f"  seed={seed}  device={cfg.device}\n"
+        f"{'='*60}",
+        flush=True,
+    )
+
+    t0 = time.perf_counter()
+    trainer = BNNRTrainer(adapter, train_loader, val_loader, augmentations, cfg)
+    result = trainer.run()
+    elapsed_s = time.perf_counter() - t0
+
+    sel = cfg.selection_metric
+    best = float(result.best_metrics.get(sel, 0.0))
+    baseline_val = _extract_baseline_from_report(result.report_json_path, sel)
+    gain = round((best - baseline_val) * 100, 2) if baseline_val is not None else None
+
+    selected = [p for p in (result.best_path or "").split("+") if p and p != "baseline"]
+    if not selected and result.best_path and result.best_path != "baseline":
+        selected = [result.best_path]
+
+    if args.no_xai:
+        xai_meta = {"xai_dir": None, "overlay_paths": [], "aggregate_stats": {}}
+    else:
+        xai_meta = export_attention_maps(
+            adapter,
+            val_loader,
+            sample_indices=_XAI_VAL_INDICES,
+            output_dir=run_dir / "xai",
+            xai_method="opticam",
+        )
+
+    entry = _result_entry(
+        condition=condition,
+        cfg=cfg,
+        best_val=result.best_metrics,
+        best_epoch=None,
+        elapsed_s=elapsed_s,
+        run_dir=run_dir,
+        report_path=result.report_json_path,
+        best_path=result.best_path,
+        xai_meta=xai_meta,
+        baseline_val=baseline_val,
+        gain_pp=gain,
+        extra={
+            "selected_augmentations": selected,
+            "augmentation_names": [a.name for a in augmentations],
+        },
+    )
+    return _stamp(entry, arch=args.arch, img_size=args.img_size, pretrained=args.pretrained)
+
+
+_POLICY_BY_CONDITION = {
+    "no_bnnr": "base",
+    "randaugment": "randaugment",
+    "trivialaugment": "trivialaugment",
+}
+
+
+def run_condition(
+    *,
+    condition_id: str,
+    seed: int,
+    args: argparse.Namespace,
+    output_root: Path,
+) -> dict[str, Any]:
+    spec = CONDITIONS[condition_id]
+    if spec.strategy == "bnnr_branch_search":
+        return _run_bnnr_condition(
+            condition=spec, seed=seed, args=args, output_root=output_root
+        )
+    return _run_plain_condition(
+        condition=spec,
+        policy=_POLICY_BY_CONDITION[condition_id],
+        seed=seed,
+        args=args,
+        output_root=output_root,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Results document + CLI
+# ---------------------------------------------------------------------------
+
+
+def _benchmark_document(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "benchmark_id": "cifar100_resnet50_augmentation_comparison",
+        "model": f"{args.arch} (torchvision, pretrained={args.pretrained})",
+        "dataset": "cifar100 (torchvision, full train/test split)",
+        "img_size": args.img_size,
+        "batch_size": args.batch_size,
+        "optimizer": f"SGD(lr={args.lr}, momentum=0.9, wd=5e-4)",
+        "scheduler": "CosineAnnealingLR",
+        "epochs_per_phase": args.epochs,
+        "primary_metric": "validation accuracy (best epoch)",
+        "normalization": "ImageNet mean/std applied inside the model",
+        "attention_method": "OptiCAM overlays on fixed CIFAR-100 test indices",
+        "target_layer": _ARCH_TARGET_HINT.get(args.arch, "backbone.layer4[-1]"),
+        "conditions": {
+            cid: {
+                "label": spec.label,
+                "strategy": spec.strategy,
+                "max_iterations": spec.max_iterations,
+                "augmentations": list(spec.augmentation_names),
+                "description": spec.description,
+            }
+            for cid, spec in CONDITIONS.items()
+        },
+        "protocol_caveats": [
+            "BNNR branch search uses more compute than the fixed-epoch baselines "
+            "(baseline phase + branch search). This is by design and disclosed here.",
+            "Same backbone, optimizer, scheduler, epochs and seeds across conditions; "
+            "only the augmentation strategy varies.",
+            "Not an ImageNet-SOTA claim. CIFAR-100 transfer benchmark for "
+            "augmentation-strategy comparison.",
+        ],
+    }
+
+
+def _estimate(args: argparse.Namespace, n_seeds: int, conds: list[str]) -> str:
+    per_cond_min = {
+        "no_bnnr": args.epochs * 1.0,
+        "randaugment": args.epochs * 1.1,
+        "trivialaugment": args.epochs * 1.1,
+        "bnnr_branch_search": args.epochs * (args.max_iterations + 1) * 1.2,
+    }
+    total = sum(per_cond_min.get(c, args.epochs) for c in conds) * n_seeds
+    if args.device != "cpu":
+        total *= 0.2
+    return f"~{total/60:.1f}h wall-clock estimate ({len(conds)} conditions x {n_seeds} seeds, {args.device})"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ResNet50 / CIFAR-100 augmentation benchmark",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--seeds", default="42,43,44,45,46", help="Comma-separated seeds")
+    parser.add_argument(
+        "--conditions",
+        default=",".join(CONDITIONS),
+        help=f"Comma-separated conditions ({', '.join(CONDITIONS)})",
+    )
+    parser.add_argument("--arch", default="resnet50", choices=["resnet50", "resnet18"])
+    parser.add_argument("--device", default="auto", help="auto | cuda | cpu")
+    parser.add_argument("--epochs", type=int, default=15, help="Epochs per training phase")
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--img-size", type=int, default=224, help="Resize target (224 uses pretrained features)")
+    parser.add_argument("--lr", type=float, default=0.01)
+    parser.add_argument("--max-iterations", type=int, default=3, help="BNNR branch-search iterations")
+    parser.add_argument(
+        "--pretrained",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use ImageNet-pretrained backbone (--no-pretrained to train from scratch)",
+    )
+    parser.add_argument("--max-train-samples", type=int, default=None)
+    parser.add_argument("--max-val-samples", type=int, default=None)
+    parser.add_argument("--no-xai", action="store_true", help="Skip OptiCAM overlay export (faster; no cv2 dependency)")
+    parser.add_argument("--results", type=Path, default=DEFAULT_RESULTS)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Fast sanity run: 1 epoch, 256/128 subset, img-size 64, no pretrained download",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print plan and exit")
+    args = parser.parse_args()
+
+    if args.smoke:
+        args.epochs = 1
+        args.img_size = 64
+        args.pretrained = False
+        args.max_train_samples = 256
+        args.max_val_samples = 128
+        args.max_iterations = 1
+        if args.seeds == "42,43,44,45,46":
+            args.seeds = "42"
+
+    seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
+    conds = [c.strip() for c in args.conditions.split(",") if c.strip()]
+    for c in conds:
+        if c not in CONDITIONS:
+            parser.error(f"Unknown condition {c!r}. Choose from: {', '.join(CONDITIONS)}")
+
+    print("ResNet50 / CIFAR-100 augmentation benchmark")
+    print(f"  arch={args.arch} pretrained={args.pretrained} img_size={args.img_size}")
+    print(f"  seeds={seeds}  conditions={conds}  epochs={args.epochs}  device={args.device}")
+    print(f"  {_estimate(args, len(seeds), conds)}")
+    print(f"  results -> {args.results}")
+    if args.dry_run:
+        return
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    data = load_results(args.results)
+    doc = _benchmark_document(args)
+    data.update(doc)
+    data.setdefault("runs", [])
+    data["hardware"] = torch_info()
+    data["git_head"] = git_head()
+    data["generated_at"] = datetime.now(timezone.utc).isoformat()
+
+    for seed in seeds:
+        for cid in conds:
+            print(f"\n>>> condition={cid} seed={seed}")
+            try:
+                entry = run_condition(
+                    condition_id=cid, seed=seed, args=args, output_root=args.output_root
+                )
+            except Exception as exc:  # noqa: BLE001 — record and continue the matrix
+                print(f"    FAILED ({cid}, seed={seed}): {exc}", file=sys.stderr)
+                entry = {
+                    "condition": cid,
+                    "seed": seed,
+                    "dataset": "cifar100",
+                    "model": args.arch,
+                    "error": str(exc),
+                }
+            data["runs"].append(entry)
+            save_results(args.results, data)  # checkpoint after every run
+            val = entry.get("val_metric")
+            if val is not None:
+                print(f"    {cid} seed={seed}: val_accuracy={val:.4f}")
+
+    print(f"\nDone. {len(data['runs'])} run records in {args.results}")
+    print(f"Summarize: python benchmarks/summarize.py --results {args.results} --markdown")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/summarize.py
+++ b/benchmarks/summarize.py
@@ -17,6 +17,7 @@ DEFAULT_RESULTS = BENCHMARKS_DIR / "results.json"
 DISPLAY = {
     "no_bnnr": "Without BNNR (crop + flip)",
     "randaugment": "RandAugment (torchvision)",
+    "trivialaugment": "TrivialAugmentWide (torchvision)",
     "bnnr_branch_search": "BNNR branch search (ICD + AICD)",
 }
 

--- a/examples/analyze_resnet50.py
+++ b/examples/analyze_resnet50.py
@@ -1,0 +1,234 @@
+"""Torchvision **pretrained ResNet50** on CIFAR-100 → BNNR analyze report.
+
+This is the "I have a torchvision model, give me a failure report" path from the
+2026 growth audit: take a standard ``torchvision.models.resnet50`` (ImageNet
+weights), point ``bnnr analyze`` at it, and get a portable HTML + JSON report
+with confusion matrix, top confused pairs, and OptiCAM saliency overlays — no
+BNNRTrainer, no retraining of the backbone.
+
+The backbone normalizes inputs *inside* the model (ImageNet mean/std as
+registered buffers), so the val loader can feed plain ``ToTensor()`` tensors in
+``[0, 1]`` — the same convention the rest of BNNR uses.
+
+Install:
+    pip install bnnr
+
+Meaningful report (load your fine-tuned 100-class checkpoint):
+    PYTHONPATH=src python examples/analyze_resnet50.py \\
+        --checkpoint path/to/resnet50_cifar100.pt --device cuda
+
+Quick look (trains only the classifier head for a few steps on a subset):
+    PYTHONPATH=src python examples/analyze_resnet50.py --quick --device cuda
+
+CI smoke (no download, no pretrained weights, random data):
+    PYTHONPATH=src python examples/analyze_resnet50.py \\
+        --output-dir /tmp/out --synthetic --no-xai --device cpu
+
+Note: with the bare ImageNet backbone and an *untrained* 100-class head the
+predictions are not meaningful — pass ``--checkpoint`` (or use ``--quick`` to
+warm the head) for a report worth reading. The point of this example is the
+torchvision → analyze plumbing.
+
+Citation: docs/citation.md in the bnnr repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Dataset, Subset
+from torchvision import datasets, models, transforms
+
+from bnnr.adapter import SimpleTorchAdapter
+from bnnr.analyze import analyze_model
+from bnnr.core import BNNRConfig
+
+SEED = 42
+NUM_CLASSES = 100
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+class IndexedDataset(Dataset):
+    """Wrap (image, label) → (image, label, index) for analyze."""
+
+    def __init__(self, base: Dataset) -> None:
+        self.base = base
+
+    def __len__(self) -> int:
+        return len(self.base)  # type: ignore[arg-type]
+
+    def __getitem__(self, idx: int):
+        image, label = self.base[idx]
+        return image, label, idx
+
+
+class _SyntheticCifarSubset(Dataset):
+    """In-memory CIFAR-shaped batch for CI (no download)."""
+
+    def __init__(self, n: int, img_size: int, seed: int) -> None:
+        gen = torch.Generator().manual_seed(seed)
+        self.images = torch.rand(n, 3, img_size, img_size, generator=gen)
+        self.labels = torch.arange(n, dtype=torch.long) % NUM_CLASSES
+
+    def __len__(self) -> int:
+        return int(self.labels.shape[0])
+
+    def __getitem__(self, idx: int):
+        return self.images[idx], int(self.labels[idx].item())
+
+
+class NormalizedResNet50(nn.Module):
+    """ResNet50 that normalizes [0, 1] inputs with ImageNet stats internally."""
+
+    def __init__(self, num_classes: int = NUM_CLASSES, pretrained: bool = True) -> None:
+        super().__init__()
+        weights = models.ResNet50_Weights.IMAGENET1K_V2 if pretrained else None
+        self.backbone = models.resnet50(weights=weights)
+        self.backbone.fc = nn.Linear(self.backbone.fc.in_features, num_classes)
+        self.register_buffer("mean", torch.tensor(_IMAGENET_MEAN).view(1, 3, 1, 1))
+        self.register_buffer("std", torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = (x - self.mean) / self.std
+        return self.backbone(x)
+
+
+def _cifar100_loaders(
+    data_root: Path,
+    *,
+    synthetic: bool,
+    quick: bool,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+) -> tuple[DataLoader, DataLoader]:
+    if synthetic:
+        train_ds: Dataset = _SyntheticCifarSubset(32, img_size, seed=seed)
+        val_ds: Dataset = _SyntheticCifarSubset(24, img_size, seed=seed + 1)
+    else:
+        transform = transforms.Compose(
+            [transforms.Resize((img_size, img_size)), transforms.ToTensor()]
+        )
+        train_full = datasets.CIFAR100(str(data_root), train=True, download=True, transform=transform)
+        val_full = datasets.CIFAR100(str(data_root), train=False, download=True, transform=transform)
+        if quick:
+            gen = torch.Generator().manual_seed(seed)
+            train_idx = torch.randperm(len(train_full), generator=gen)[:512].tolist()
+            val_idx = torch.randperm(len(val_full), generator=gen)[:256].tolist()
+            train_ds = Subset(train_full, train_idx)
+            val_ds = Subset(val_full, val_idx)
+        else:
+            train_ds, val_ds = train_full, val_full
+
+    train_loader = DataLoader(IndexedDataset(train_ds), batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(IndexedDataset(val_ds), batch_size=batch_size, shuffle=False)
+    return train_loader, val_loader
+
+
+def _train_head(adapter: SimpleTorchAdapter, train_loader: DataLoader, device: torch.device, epochs: int) -> None:
+    """Warm the classifier head so the report is not pure noise."""
+    adapter.model.train()
+    for ep in range(epochs):
+        for images, labels, _idx in train_loader:
+            images, labels = images.to(device), labels.to(device)
+            adapter.optimizer.zero_grad()
+            loss = adapter.criterion(adapter.model(images), labels)
+            loss.backward()
+            adapter.optimizer.step()
+        print(f"  head-warm epoch {ep + 1}/{epochs} done")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Torchvision pretrained ResNet50 on CIFAR-100 → BNNR analyze report",
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("analyze_resnet50_out"))
+    parser.add_argument("--device", default="auto", help="auto | cuda | cpu")
+    parser.add_argument("--seed", type=int, default=SEED)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--img-size", type=int, default=224, help="Resize target (224 uses pretrained features)")
+    parser.add_argument("--quick", action="store_true", help="Small subset + warm head for a few steps")
+    parser.add_argument("--synthetic", action="store_true", help="In-memory data only (no download; for CI)")
+    parser.add_argument("--no-xai", action="store_true", help="Skip XAI in analyze")
+    parser.add_argument(
+        "--pretrained",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="ImageNet-pretrained backbone (--no-pretrained for CI / offline)",
+    )
+    parser.add_argument("--checkpoint", type=Path, default=None, help="Load a fine-tuned state_dict (.pt)")
+    parser.add_argument("--xai-samples", type=int, default=64, help="Probe set size for XAI (lower = faster)")
+    args = parser.parse_args()
+
+    if args.synthetic:
+        args.pretrained = False
+        if args.img_size == 224:
+            args.img_size = 64  # keep CI fast
+
+    torch.manual_seed(args.seed)
+    device = torch.device(
+        args.device if args.device != "auto" else ("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    data_root = args.output_dir / "cifar_data"
+
+    train_loader, val_loader = _cifar100_loaders(
+        data_root,
+        synthetic=args.synthetic,
+        quick=args.quick or args.synthetic,
+        img_size=args.img_size,
+        batch_size=args.batch_size,
+        seed=args.seed,
+    )
+
+    model = NormalizedResNet50(num_classes=NUM_CLASSES, pretrained=args.pretrained).to(device)
+    adapter = SimpleTorchAdapter(
+        model=model,
+        criterion=nn.CrossEntropyLoss(),
+        optimizer=torch.optim.Adam(model.parameters(), lr=1e-3),
+        target_layers=[model.backbone.layer4[-1]],
+        device=str(device),
+    )
+
+    if args.checkpoint is not None:
+        state = torch.load(args.checkpoint, map_location=device, weights_only=False)
+        if isinstance(state, dict) and "model_state" in state:
+            state = state["model_state"]
+        elif isinstance(state, dict) and "model" in state:
+            state = state["model"]
+        model.load_state_dict(state, strict=False)
+        print(f"Loaded checkpoint from {args.checkpoint}")
+    elif args.quick and not args.synthetic:
+        print("Warming classifier head for 1 epoch on a CIFAR-100 subset …")
+        _train_head(adapter, train_loader, device, epochs=1)
+    elif args.synthetic:
+        print("Synthetic mode: skipping training (random weights)")
+    else:
+        print(
+            "Note: using the bare ImageNet backbone with an untrained 100-class head. "
+            "Predictions are not meaningful — pass --checkpoint or --quick for a real report."
+        )
+
+    config = BNNRConfig(device=str(device), task="classification")
+    print("Running analyze_model …")
+    report = analyze_model(
+        adapter,
+        val_loader,
+        config=config,
+        output_dir=args.output_dir,
+        run_data_quality=not args.synthetic,
+        xai_enabled=not args.no_xai,
+        xai_samples=min(args.xai_samples, len(val_loader.dataset)),  # type: ignore[arg-type]
+    )
+    html_path = args.output_dir / "report.html"
+    report.to_html(html_path, artifact_root=args.output_dir, embed_images=True)
+    print(f"Saved {args.output_dir / 'analysis_report.json'}")
+    print(f"Saved {html_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds the larger, more credible benchmark the 2026 growth audit calls for (`plans/BNNR_Audit_GrowthPlan_2026.md`, problem #3): a **real ResNet50** backbone on **CIFAR-100**, comparing BNNR branch search against **two** strong external baselines (RandAugment **and** TrivialAugment) over **5 seeds** — with a one-command reproduce script.

This PR builds the runnable infrastructure. **No numbers are claimed yet** — the results table is intentionally blank until a real GPU run via `reproduce_resnet50.sh`.

## New files

| File | Purpose |
|------|---------|
| `benchmarks/run_resnet50.py` | Resume-safe matrix runner. 4 conditions: `no_bnnr` / `randaugment` / `trivialaugment` / `bnnr_branch_search`. Flags: `--smoke`, `--no-xai`, `--dry-run`, `--seeds`, `--epochs`, `--img-size`, `--pretrained/--no-pretrained`. |
| `benchmarks/reproduce_resnet50.sh` | One command: full 5-seed run + markdown summary. |
| `examples/analyze_resnet50.py` | Torchvision **pretrained ResNet50** → `bnnr analyze` HTML/JSON report. Synthetic mode for CI (no download/XAI). |

## Design decisions

- **In-model ImageNet normalization** (registered buffers) so every condition feeds plain `ToTensor()` `[0,1]` tensors — pretrained weights stay valid *and* BNNR's uint8-range ICD/AICD augmentations remain compatible. This matches the repo-wide "no external Normalize()" convention.
- **Fairness:** identical backbone, optimizer (SGD+momentum+wd), cosine schedule, epochs, and seeds across conditions — only the augmentation strategy varies. Disclosed compute asymmetry for branch search is documented in `results_resnet50.json` and the README caveats.
- **Honest framing:** CIFAR-100 transfer for *augmentation-strategy* comparison, explicitly **not** an ImageNet-SOTA claim.

## Shared changes (backward-compatible)

- `benchmarks/lib.py`: `Strategy` Literal gains `"trivialaugment"`; `_run_plain_epochs` gains `export_xai=True` opt-out. The existing CIFAR-10 `run.py` is unaffected (defaults preserve old behavior).
- `benchmarks/summarize.py`: `DISPLAY` gains the TrivialAugment row (already supports `--results`).
- `benchmarks/.gitignore`: ignore `runs_resnet50/`.

## Validation (local CPU smoke, all four conditions)

Ran `run_resnet50.py --smoke` end-to-end:
- All 4 conditions train, write the results JSON, and summarize into a markdown table.
- BNNR branch search runs the full `BNNRTrainer` loop and selected `icd -> aicd`.
- `ruff` clean; `mypy` clean on the new file (one pre-existing `lib.py:196` `no-any-return` is unrelated and present on `main`).
- Existing `tests/test_benchmarks.py` still passes.

Smoke numbers are meaningless by design (random init, 1 epoch, ~1% chance on 100 classes) — they validate plumbing, not accuracy.

## Follow-up (not in this PR)

Run `reproduce_resnet50.sh` on GPU, review `results_resnet50.json`, then paste the `summarize.py --markdown` table into `benchmarks/README.md` and the root `README.md`. The root README already notes this benchmark is in progress (PR #199).

🤖 Generated with [Claude Code](https://claude.com/claude-code)