### PR TITLE
feat(benchmark): Colab notebook + --drive-base-dir flag for one-click runs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -124,7 +124,15 @@ A larger, more convincing benchmark than the demo-CNN / CIFAR-10 table above: a 
 - **Same** backbone, optimizer (SGD, momentum 0.9, weight decay 5e-4), cosine schedule, epochs, and seeds across all conditions — only the augmentation strategy varies.
 - **OptiCAM** overlays on fixed CIFAR-100 test indices, exported per run (`runs_resnet50/*/xai/`).
 
-### Run
+### Run in Colab (recommended)
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/benchmarks/colab_resnet50_cifar100.ipynb)
+
+Mount Google Drive, run all cells. Everything (metrics, XAI overlays, ZIP backup) lands on your Drive at `MyDrive/bnnr_benchmarks/`. Resume-safe — if the Colab session dies, re-run the full-benchmark cell and completed (condition, seed) pairs are skipped.
+
+ETA: ~2h on T4, ~30 min on A100.
+
+### Run locally
 
 ```bash
 # Fast sanity check (CPU-friendly, no pretrained download, tiny subset)
@@ -134,6 +142,10 @@ python benchmarks/run_resnet50.py --smoke
 bash benchmarks/reproduce_resnet50.sh
 # or:
 python benchmarks/run_resnet50.py --seeds 42,43,44,45,46 --device cuda
+
+# Write results + XAI overlays into a single directory (e.g. Drive / shared volume)
+python benchmarks/run_resnet50.py --seeds 42,43,44,45,46 --device cuda \
+  --drive-base-dir /path/to/output
 
 # Summarize
 python benchmarks/summarize.py --results benchmarks/results_resnet50.json --markdown

--- a/benchmarks/colab_resnet50_cifar100.ipynb
+++ b/benchmarks/colab_resnet50_cifar100.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BNNR \u2014 ResNet50 / CIFAR-100 augmentation benchmark (Colab)\n",
+    "\n",
+    "Reproducible comparison of four augmentation strategies on a real architecture:\n",
+    "\n",
+    "| Condition | Augmentation |\n",
+    "|-----------|--------------|\n",
+    "| `no_bnnr` | Crop + flip only |\n",
+    "| `randaugment` | + torchvision RandAugment |\n",
+    "| `trivialaugment` | + torchvision TrivialAugmentWide |\n",
+    "| `bnnr_branch_search` | Full BNNR loop (ICD + AICD + ChurchNoise) |\n",
+    "\n",
+    "**5 seeds \u00d7 4 conditions = 20 runs.** ETA on T4: ~2h. ETA on A100: ~30 min.\n",
+    "\n",
+    "**Resume-safe.** Results stream to Google Drive after every (condition, seed) \u2014 if the Colab session dies, just re-run all cells: completed runs are skipped automatically.\n",
+    "\n",
+    "**What lands on your Drive:**\n",
+    "- `bnnr_benchmarks/results_resnet50.json` \u2014 aggregated metrics\n",
+    "- `bnnr_benchmarks/runs_resnet50/<run_dir>/xai/*.png` \u2014 OptiCAM overlays\n",
+    "- `bnnr_benchmarks/runs_resnet50.zip` \u2014 full archive (created in last cell)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Mount Google Drive\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')\n",
+    "\n",
+    "DRIVE_BASE = '/content/drive/MyDrive/bnnr_benchmarks'\n",
+    "!mkdir -p {DRIVE_BASE}\n",
+    "print(f'Drive output directory: {DRIVE_BASE}')\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Clone repo and install BNNR\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%cd /content\n",
+    "![ -d bnnr ] || git clone --depth=1 https://github.com/bnnr-team/bnnr.git\n",
+    "%cd /content/bnnr\n",
+    "!git pull --rebase\n",
+    "!pip install -e . -q\n",
+    "print('BNNR installed from:', !pwd)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. GPU check + ETA\n",
+    "\n",
+    "Confirm Colab gave you a GPU. T4 is fine but slow (~2h). If you got a CPU runtime, go to **Runtime \u2192 Change runtime type \u2192 T4 GPU** and re-run from the top.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch\n",
+    "print('CUDA available:', torch.cuda.is_available())\n",
+    "if torch.cuda.is_available():\n",
+    "    name = torch.cuda.get_device_name(0)\n",
+    "    print(f'GPU: {name}')\n",
+    "    eta = {'T4': '~2h', 'A100': '~30 min', 'V100': '~1h', 'L4': '~1h'}\n",
+    "    for k, v in eta.items():\n",
+    "        if k in name:\n",
+    "            print(f'ETA: {v} for full 5-seed run')\n",
+    "            break\n",
+    "else:\n",
+    "    print('WARNING: no GPU. Full run will take 10+ hours on CPU. Switch runtime.')\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Dry-run preview\n",
+    "\n",
+    "Prints the planned matrix without running anything. Use this to verify the config before you commit to a 2h run.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "!PYTHONPATH=src python benchmarks/run_resnet50.py \\\n",
+    "  --seeds 42,43,44,45,46 \\\n",
+    "  --device cuda \\\n",
+    "  --drive-base-dir {DRIVE_BASE} \\\n",
+    "  --dry-run\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Smoke test (2 minutes)\n",
+    "\n",
+    "1 epoch, 256/128 subset, img-size 64, no pretrained download. Verifies the full pipeline (data load \u2192 train \u2192 XAI export \u2192 JSON save) on real GPU before committing to the long run.\n",
+    "\n",
+    "Smoke results write to `{DRIVE_BASE}/results_resnet50.json`. **Delete that file after the smoke if you want to start fresh** \u2014 see cell 6 cleanup.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "!PYTHONPATH=src python benchmarks/run_resnet50.py \\\n",
+    "  --device cuda \\\n",
+    "  --drive-base-dir {DRIVE_BASE} \\\n",
+    "  --smoke\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. (Optional) Clean smoke results before full run\n",
+    "\n",
+    "If you ran the smoke in cell 5, the smoke entries are mixed into `results_resnet50.json`. **Run this cell to wipe them** so the full run starts from a clean slate. Skip this cell if you ran the smoke locally before and want to keep partial real results.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import json, os\n",
+    "results_path = f'{DRIVE_BASE}/results_resnet50.json'\n",
+    "if os.path.exists(results_path):\n",
+    "    with open(results_path) as f: data = json.load(f)\n",
+    "    before = len(data.get('runs', []))\n",
+    "    # Keep only runs with epochs == 15 (full run signature); drop smoke (epochs=1) and errors\n",
+    "    data['runs'] = [r for r in data.get('runs', []) if r.get('m_epochs') == 15 and 'val_metric' in r]\n",
+    "    after = len(data['runs'])\n",
+    "    with open(results_path, 'w') as f: json.dump(data, f, indent=2)\n",
+    "    print(f'Filtered {before} -> {after} runs (kept only m_epochs=15 with val_metric)')\n",
+    "else:\n",
+    "    print('No results file yet \u2014 nothing to clean.')\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Full benchmark \u2014 5 seeds \u00d7 4 conditions\n",
+    "\n",
+    "**This is the long run.** Resume-safe: if Colab kills the session, just re-run this cell. Already-completed (condition, seed) pairs will be skipped.\n",
+    "\n",
+    "Keep the browser tab active. Colab idles out after ~90 min of no interaction. To stay alive: occasionally scroll, or use a Colab keep-alive browser extension.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "!PYTHONPATH=src python benchmarks/run_resnet50.py \\\n",
+    "  --seeds 42,43,44,45,46 \\\n",
+    "  --device cuda \\\n",
+    "  --drive-base-dir {DRIVE_BASE}\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Summarize \u2192 markdown table\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "!PYTHONPATH=src python benchmarks/summarize.py \\\n",
+    "  --results {DRIVE_BASE}/results_resnet50.json \\\n",
+    "  --markdown\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Backup `runs_resnet50/` directory as ZIP on Drive\n",
+    "\n",
+    "The `runs_resnet50/` directory contains all XAI overlay PNGs and per-run logs. The full run already wrote those to Drive (because of `--drive-base-dir`), but a single ZIP is faster to download and easier to share.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import shutil\n",
+    "zip_path = shutil.make_archive(\n",
+    "    f'{DRIVE_BASE}/runs_resnet50_archive',\n",
+    "    'zip',\n",
+    "    f'{DRIVE_BASE}/runs_resnet50',\n",
+    ")\n",
+    "print(f'Archive created: {zip_path}')\n",
+    "!ls -lh {DRIVE_BASE}/\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Done\n",
+    "\n",
+    "You now have on your Drive:\n",
+    "- `results_resnet50.json` \u2014 to paste into `benchmarks/README.md` after review\n",
+    "- `runs_resnet50/` \u2014 per-run logs and XAI overlays (use for X/LinkedIn screenshots)\n",
+    "- `runs_resnet50_archive.zip` \u2014 full backup\n",
+    "\n",
+    "**Next steps:**\n",
+    "1. Open `results_resnet50.json` and sanity-check the numbers (no errors, all 20 runs present)\n",
+    "2. Paste the markdown table from cell 8 into `benchmarks/README.md` \u00a7 Results\n",
+    "3. Pick the best XAI overlay comparison from `runs_resnet50/*/xai/` for the README hero image\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "colab": {
+   "provenance": [],
+   "machine_shape": "hm"
+  },
+  "accelerator": "GPU"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/benchmarks/run_resnet50.py
+++ b/benchmarks/run_resnet50.py
@@ -555,12 +555,27 @@ def main() -> None:
     parser.add_argument("--results", type=Path, default=DEFAULT_RESULTS)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT)
     parser.add_argument(
+        "--drive-base-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Convenience for Colab/Drive: a single directory under which both "
+            "results_resnet50.json and runs_resnet50/ are written. Overrides "
+            "--results and --output-root."
+        ),
+    )
+    parser.add_argument(
         "--smoke",
         action="store_true",
         help="Fast sanity run: 1 epoch, 256/128 subset, img-size 64, no pretrained download",
     )
     parser.add_argument("--dry-run", action="store_true", help="Print plan and exit")
     args = parser.parse_args()
+
+    if args.drive_base_dir is not None:
+        args.drive_base_dir.mkdir(parents=True, exist_ok=True)
+        args.results = args.drive_base_dir / "results_resnet50.json"
+        args.output_root = args.drive_base_dir / "runs_resnet50"
 
     if args.smoke:
         args.epochs = 1


### PR DESCRIPTION
After today's live debugging session on Colab T4, this PR ships everything needed for the workflow: **clone → open notebook → Run all → results on your Drive**.

## What's in

### 1. `--drive-base-dir DIR` flag (`benchmarks/run_resnet50.py`)
One argument replaces two. Sets both `--results` and `--output-root` under the same directory, creates it if missing. Critical for Colab where forgetting `--output-root` means XAI overlays disappear when the session ends.

```bash
python benchmarks/run_resnet50.py \
  --seeds 42,43,44,45,46 \
  --device cuda \
  --drive-base-dir /content/drive/MyDrive/bnnr_benchmarks
```

### 2. `benchmarks/colab_resnet50_cifar100.ipynb` — 9 cells
1. Mount Drive
2. Clone + install BNNR
3. GPU check + ETA per device (T4 / A100 / V100 / L4)
4. Dry-run preview
5. Smoke test (~2 min) — verify pipeline on real GPU before committing
6. Optional cleanup: filter results to `m_epochs == 15` (drop smoke + errors)
7. **Full benchmark** — 5 seeds × 4 conditions, resume-safe
8. Summarize → markdown table
9. ZIP `runs_resnet50/` on Drive for easy download

### 3. README updates
- "Open in Colab" badge at the top of the ResNet50 section
- `--drive-base-dir` example added to the local-run snippet

## Why now

Three friction points hit me today running the live benchmark:

1. `RESULTS=...` env var only works with `reproduce_resnet50.sh`, not the Python script — so my first run wrote nothing to Drive.
2. Setting `--results` without `--output-root` silently puts XAI overlays into ephemeral Colab storage — they vanish at session end.
3. No notebook means every user retypes mount / clone / install / paths from scratch and makes the same mistakes.

This PR makes the workflow foolproof for myself and future contributors.

## Test plan
- [x] `--drive-base-dir /tmp/test --dry-run` creates the directory, prints the planned matrix, exits without running
- [x] Notebook is valid JSON, 20 cells, opens in Jupyter
- [ ] End-to-end on Colab T4 (this is what I'll actually use after merge)

## Note on existing benchmark in flight
There's a live full-run still in progress from earlier today writing to the wrong path. After merge I'll start fresh from this notebook — the in-flight session was using the buggy command anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)