### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/bnnr/adapter.py
+++ b/src/bnnr/adapter.py
@@ -13,13 +13,13 @@ from bnnr.utils import calculate_metrics, get_device
 @runtime_checkable
 class ModelAdapter(Protocol):
     def train_step(self, batch: tuple[Tensor, Tensor]) -> dict[str, float]:
-        ...
+        raise NotImplementedError
 
     def eval_step(self, batch: tuple[Tensor, Tensor]) -> dict[str, float]:
-        ...
+        raise NotImplementedError
 
     def state_dict(self) -> dict[str, Any]:
-        ...
+        raise NotImplementedError
 
     def load_state_dict(self, state: dict[str, Any]) -> None:
         pass
@@ -28,7 +28,7 @@ class ModelAdapter(Protocol):
 @runtime_checkable
 class XAICapableModel(ModelAdapter, Protocol):
     def get_target_layers(self) -> list[nn.Module]:
-        ...
+        raise NotImplementedError
 
     def get_model(self) -> nn.Module:
         pass


### PR DESCRIPTION
To fix this without changing functional behavior, replace ellipsis-only method bodies in protocol definitions with explicit `raise NotImplementedError`. This preserves the interface contract and removes no-op statements that trigger CodeQL.

Best change in `src/bnnr/adapter.py`:
- In `ModelAdapter`:
  - `train_step` (line 16) replace `...` with `raise NotImplementedError`
  - `eval_step` (line 19) replace `...` with `raise NotImplementedError`
  - `state_dict` (line 22) replace `...` with `raise NotImplementedError`
- In `XAICapableModel`:
  - `get_target_layers` (line 31) replace `...` with `raise NotImplementedError`

No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._