### PR TITLE
Fix for Unused global variable

### DIFF
--- a/src/bnnr/albumentations_aug.py
+++ b/src/bnnr/albumentations_aug.py
@@ -32,11 +32,11 @@ from bnnr.augmentations import BaseAugmentation
 
 _ALBUMENTATIONS_AVAILABLE = False
 try:
-    import albumentations as A  # noqa: N812
+    import albumentations
 
     _ALBUMENTATIONS_AVAILABLE = True
 except ImportError:
-    A = None  # type: ignore[assignment]
+    pass
 
 
 def albumentations_available() -> bool:


### PR DESCRIPTION
To fix this without changing functionality, replace the aliased import with a plain import used only for availability probing, and remove the fallback assignment to `A`. Keep `_ALBUMENTATIONS_AVAILABLE` as the single source of truth used elsewhere.

In `src/bnnr/albumentations_aug.py`:
- Change `import albumentations as A` to `import albumentations`.
- Remove `A = None` from the `except ImportError` block.
- Leave `_ALBUMENTATIONS_AVAILABLE` logic and all other code unchanged.

This preserves behavior (detect installed package or not) and removes the unused global variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._