### PR TITLE
chore(albumentations): drop unused 'A' alias in optional-import probe

### DIFF
--- a/src/bnnr/albumentations_aug.py
+++ b/src/bnnr/albumentations_aug.py
@@ -24,19 +24,15 @@ Example::
 
 from __future__ import annotations
 
+import importlib.util
 from typing import Any
 
 import numpy as np
 
 from bnnr.augmentations import BaseAugmentation
 
-_ALBUMENTATIONS_AVAILABLE = False
-try:
-    import albumentations  # noqa: F401 — optional dependency probe
-
-    _ALBUMENTATIONS_AVAILABLE = True
-except ImportError:
-    pass
+# Optional dependency: detect without importing (avoids a dead probe import).
+_ALBUMENTATIONS_AVAILABLE = importlib.util.find_spec("albumentations") is not None
 
 
 def albumentations_available() -> bool:

--- a/src/bnnr/albumentations_aug.py
+++ b/src/bnnr/albumentations_aug.py
@@ -32,11 +32,11 @@ from bnnr.augmentations import BaseAugmentation
 
 _ALBUMENTATIONS_AVAILABLE = False
 try:
-    import albumentations as A  # noqa: N812
+    import albumentations  # noqa: F401 — optional dependency probe
 
     _ALBUMENTATIONS_AVAILABLE = True
 except ImportError:
-    A = None  # type: ignore[assignment]
+    pass
 
 
 def albumentations_available() -> bool:


### PR DESCRIPTION
Cleanup consolidating the only *real* finding from the closed auto-fix drafts (#214/#216).

The `import albumentations as A` alias was referenced **only in the module docstring**, never in code — a dead import alias plus a dead `A = None` fallback. Replaced with a plain optional-dependency probe import.

- No behaviour change (`albumentations_available()` still works).
- ruff clean; albumentations tests pass (6 passed, 1 skipped).

Supersedes the closed drafts #214 and #216. The other 8 closed drafts (#207–#213, #215) were duplicates of merged #203, false positives on Protocol `...` stubs / backward-compat re-exports, or structurally broken auto-diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)