### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/bnnr/adapter.py
+++ b/src/bnnr/adapter.py
@@ -13,13 +13,13 @@ from bnnr.utils import calculate_metrics, get_device
 @runtime_checkable
 class ModelAdapter(Protocol):
     def train_step(self, batch: tuple[Tensor, Tensor]) -> dict[str, float]:
-        ...
+        raise NotImplementedError
 
     def eval_step(self, batch: tuple[Tensor, Tensor]) -> dict[str, float]:
-        ...
+        raise NotImplementedError
 
     def state_dict(self) -> dict[str, Any]:
-        ...
+        raise NotImplementedError
 
     def load_state_dict(self, state: dict[str, Any]) -> None:
         pass
@@ -28,7 +28,7 @@ class ModelAdapter(Protocol):
 @runtime_checkable
 class XAICapableModel(ModelAdapter, Protocol):
     def get_target_layers(self) -> list[nn.Module]:
-        ...
+        raise NotImplementedError
 
     def get_model(self) -> nn.Module:
         pass


### PR DESCRIPTION
To fix “statement has no effect” in protocol methods, replace `...` placeholder bodies with explicit `raise NotImplementedError` statements. This removes no-op statements and makes intent explicit.

Best single approach here:
- In `src/bnnr/adapter.py`, update protocol methods using `...`:
  - `ModelAdapter.train_step`
  - `ModelAdapter.eval_step`
  - `ModelAdapter.state_dict`
  - `XAICapableModel.get_target_layers`
- Keep existing `pass` methods unchanged unless flagged (they are not no-op expressions and are acceptable).
- No imports or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._