### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/bnnr/events.py
+++ b/src/bnnr/events.py
@@ -56,7 +56,7 @@ class BNNREvent:
 
 class EventSink(Protocol):
     def emit(self, event_type: EventType, payload: dict[str, Any], *, force: bool = False) -> None:
-        ...
+        pass
 
     def close(self) -> None:
         pass


### PR DESCRIPTION
To fix this without changing functionality, replace `...` statement bodies in the `EventSink` `Protocol` methods with `pass`.  
Best single fix in `src/bnnr/events.py`:
- In `class EventSink(Protocol)`, update:
  - `emit(...) -> None:` body from `...` to `pass`
  - `close(...) -> None:` body from `...` to `pass`

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._