### PR TITLE
Fix for Unused import

### DIFF
--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -27,7 +27,6 @@ from bnnr.training import loop as _loop
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
-    _is_ultralytics_tasks_backbone,
     _RuntimeState,
     _TrainerState,
     clone_state_dict,

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -27,7 +27,6 @@ from bnnr.training import loop as _loop
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
-    clone_state_dict,
     copy_state_dict_inplace,
 )
 from bnnr.utils import setup_logging

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -27,7 +27,6 @@ from bnnr.training import loop as _loop
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
-    _TrainerState,
     clone_state_dict,
     copy_state_dict_inplace,
 )

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -27,7 +27,6 @@ from bnnr.training import loop as _loop
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
-    _RuntimeState,
     _TrainerState,
     clone_state_dict,
     copy_state_dict_inplace,


### PR DESCRIPTION
Remove `_is_ultralytics_tasks_backbone` from the `from bnnr.training.checkpoint import (...)` list in `src/bnnr/trainer.py`.

Best single fix without changing functionality:
- Edit only the checkpoint import block around lines 29–35.
- Keep `_RuntimeState`, `_TrainerState`, `clone_state_dict`, and `copy_state_dict_inplace` unchanged.
- Remove only `_is_ultralytics_tasks_backbone,` from that tuple import.
- No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._