### PR TITLE
fix: consolidate code-quality autofixes (#221–#228)

### DIFF
--- a/benchmarks/colab_imagewoof.ipynb
+++ b/benchmarks/colab_imagewoof.ipynb
@@ -64,7 +64,8 @@
     "%cd /content/bnnr\n",
     "!git pull --rebase\n",
     "!pip install -e . -q\n",
-    "print('BNNR installed from:', !pwd)"
+    "import os\n",
+    "print('BNNR installed from:', os.getcwd())"
    ]
   },
   {

--- a/benchmarks/run_imagewoof.py
+++ b/benchmarks/run_imagewoof.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import argparse
 import sys
 import time
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -515,7 +516,10 @@ def run_condition(
     spec = CONDITIONS[condition_id]
     if spec.strategy == "bnnr_branch_search":
         return _run_bnnr_condition(
-            condition=spec, seed=seed, args=args, output_root=output_root
+            condition=replace(spec, max_iterations=args.max_iterations),
+            seed=seed,
+            args=args,
+            output_root=output_root,
         )
     return _run_plain_condition(
         condition=spec,
@@ -669,7 +673,7 @@ def main() -> None:
         if c not in CONDITIONS:
             parser.error(f"Unknown condition {c!r}. Choose from: {', '.join(CONDITIONS)}")
 
-    print("ResNet18 / Imagewoof augmentation benchmark (low-data, from-scratch)")
+    print(f"{args.arch} / Imagewoof augmentation benchmark (low-data, from-scratch)")
     print(f"  arch={args.arch} pretrained={args.pretrained} img_size={args.img_size}")
     print(f"  train_per_class={args.train_per_class}  seeds={seeds}  conditions={conds}")
     print(f"  epochs={args.epochs}  device={args.device}")

--- a/scripts/validate_user_notebooks.py
+++ b/scripts/validate_user_notebooks.py
@@ -55,7 +55,7 @@ def _validate_notebook(path: Path) -> list[str]:
     if data.get("nbformat") != 4:
         errors.append(f"{path}: expected nbformat 4, got {data.get('nbformat')!r}")
     nb_minor = data.get("nbformat_minor")
-    if not isinstance(nb_minor, int):
+    if type(nb_minor) is not int:
         errors.append(f"{path}: expected integer nbformat_minor, got {nb_minor!r}")
 
     meta = data.get("metadata") or {}
@@ -64,8 +64,11 @@ def _validate_notebook(path: Path) -> list[str]:
         errors.append(f"{path}: kernelspec.name should be 'python3', got {ks.get('name')!r}")
 
     cells = data.get("cells")
-    if not isinstance(cells, list) or not cells:
+    if not isinstance(cells, list):
         errors.append(f"{path}: no cells array")
+        return errors
+    if not cells:
+        errors.append(f"{path}: notebook has no cells")
         return errors
 
     for idx, cell in enumerate(cells):

--- a/src/bnnr/adapter.py
+++ b/src/bnnr/adapter.py
@@ -13,13 +13,13 @@ from bnnr.utils import calculate_metrics, get_device
 @runtime_checkable
 class ModelAdapter(Protocol):
     def train_step(self, batch: tuple[Tensor, Tensor]) -> dict[str, float]:
-        ...
+        raise NotImplementedError
 
     def eval_step(self, batch: tuple[Tensor, Tensor]) -> dict[str, float]:
-        ...
+        raise NotImplementedError
 
     def state_dict(self) -> dict[str, Any]:
-        ...
+        raise NotImplementedError
 
     def load_state_dict(self, state: dict[str, Any]) -> None:
         pass
@@ -28,7 +28,7 @@ class ModelAdapter(Protocol):
 @runtime_checkable
 class XAICapableModel(ModelAdapter, Protocol):
     def get_target_layers(self) -> list[nn.Module]:
-        ...
+        raise NotImplementedError
 
     def get_model(self) -> nn.Module:
         pass

--- a/src/bnnr/events.py
+++ b/src/bnnr/events.py
@@ -56,7 +56,7 @@ class BNNREvent:
 
 class EventSink(Protocol):
     def emit(self, event_type: EventType, payload: dict[str, Any], *, force: bool = False) -> None:
-        ...
+        pass
 
     def close(self) -> None:
         pass

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -27,7 +27,6 @@ from bnnr.training import loop as _loop
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
-    _is_ultralytics_tasks_backbone,
     _RuntimeState,
     _TrainerState,
     clone_state_dict,


### PR DESCRIPTION
## Summary
- Consolidates all valid fixes from the 8 open autofix PRs (#221–#228) into one merge-ready changeset
- Replaces protocol `...` placeholders with explicit `raise NotImplementedError` / `pass` for CodeQL
- Removes only the unused `_is_ultralytics_tasks_backbone` re-export from `trainer.py` (keeps backward-compat exports that are actually used)
- Fixes Imagewoof benchmark: honor `--max-iterations`, print selected `--arch`, Colab `os.getcwd()` instead of invalid `!pwd` in print
- Hardens notebook validation (`nbformat_minor` bool rejection, explicit empty-cells check)

Supersedes and closes: #221, #222, #223, #224, #225, #226, #227, #228

## Test plan
- [x] `ruff check` on touched files
- [x] `python3 scripts/validate_user_notebooks.py`
- [x] `pytest tests/test_backward_compat.py tests/test_training_checkpoint.py -k clone_state_dict`
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)