### PR TITLE
Release v0.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.4.12] — 2026-06-07
+
+### Added
+
+- `examples/integrations/gradcam_to_saliency_augmentation.ipynb` — tutorial from a Grad-CAM heatmap to the ICD/AICD saliency-guided augmentations.
+- `docs/getting_started.md`: torchvision analyze golden path promoted with a copy-paste run block.
+
+### Changed
+
+- Benchmark suite: ResNet18 / Imagewoof low-data, from-scratch harness replaces the ResNet50 / CIFAR-100 setup; RandAugment and TrivialAugment baselines.
+
 ## [0.4.11] — 2026-05-30
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ authors:
 repository-code: "https://github.com/bnnr-team/bnnr"
 url: "https://github.com/bnnr-team/bnnr"
 license: MIT
-version: 0.4.11
-date-released: 2026-05-29
+version: 0.4.12
+date-released: 2026-06-07
 
 preferred-citation:
   type: software
@@ -31,4 +31,4 @@ preferred-citation:
   title: "BNNR (Bulletproof Neural Network Recipe)"
   year: 2026
   url: "https://github.com/bnnr-team/bnnr"
-  version: 0.4.11
+  version: 0.4.12

--- a/docs/assets/analyze-report-sample.html
+++ b/docs/assets/analyze-report-sample.html
@@ -396,7 +396,7 @@ tr:hover td { background: rgba(240,160,105,0.03); }
 <div>
 <h1>BNNR Analysis Report</h1>
 <div class="report-meta">
-<span>v0.4.11</span>
+<span>v0.4.12</span>
 <span>Classification</span>
 <span>10 classes · 10,000 samples</span>
 </div></div></div>
@@ -436,6 +436,6 @@ tr:hover td { background: rgba(240,160,105,0.03); }
 <div class="rec-grid"><div class="rec-card"><div class="rec-header"><span class="rec-priority" style="min-width:22px;text-align:center;">1</span><span class="rec-title">Reduce top class confusions: 4, 9, 7, 5, 8, 3</span> <span class="badge badge-ok">Observed</span></div><div class="rec-why">label 4 recall=80%. label 9 recall=86%. label 7 recall=78%.</div><div class="rec-evidence" style="font-size:11px;color:var(--muted);margin-top:4px;"><strong>From this run:</strong> label 4 recall=80%; label 9 recall=86%; label 7 recall=78%; count=145; count=144</div><div class="rec-action">→ Inspect XAI overlays for both classes (see Confusion Analysis section). Pair-specific augmentation or metric learning (ArcFace; Deng et al., CVPR 2019) increases inter-class separation.</div><div style="font-size:12px;color:var(--green);margin-top:6px;padding:4px 10px;background:rgba(34,197,94,0.08);border-radius:6px;border:1px solid rgba(34,197,94,0.2);">[Observed] Literature context (not verified on this run): Targeted data collection or metric learning often reduces specific confusions; quantify with your confusion matrix after changes.</div><div style="font-size:10px;color:var(--muted);margin-top:4px;font-style:italic;">📚 Deng et al., ArcFace, CVPR 2019</div></div></div>
 </div>
 </div></div>
-<div class="footer"><div class="brand">BNNR — Train → Explain → Improve → Prove</div><div class="tagline">Helping your model earn its place in production.</div><div style="margin-top:8px;">BNNR v0.4.11</div></div>
+<div class="footer"><div class="brand">BNNR — Train → Explain → Improve → Prove</div><div class="tagline">Helping your model earn its place in production.</div><div style="margin-top:8px;">BNNR v0.4.12</div></div>
 </div>
 </body></html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bnnr"
-version = "0.4.11"
+version = "0.4.12"
 description = "BNNR — Train → Explain → Improve → Prove"
 readme = "README.pypi.md"
 license = { text = "MIT" }

--- a/src/bnnr/version.py
+++ b/src/bnnr/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the BNNR package version (also used as analyze report schema version)."""
 
-__version__ = "0.4.11"
+__version__ = "0.4.12"


### PR DESCRIPTION
Version bump to 0.4.12.

Changes since 0.4.11:
- Grad-CAM to saliency-guided augmentation tutorial notebook (#235)
- ICD acronym typo fix (#236)
- torchvision analyze golden path promoted in getting_started (#230)
- ResNet18 / Imagewoof benchmark harness (#220)

Merging this and tagging v0.4.12 triggers the PyPI publish workflow.