### PR TITLE
docs: add Zenodo DOIs for software and ICD/AICD paper

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,4 +20,4 @@ Approximate share of intellectual contribution to the project (internal estimate
 | Dominika Zydorczyk | 5% |
 | Zuzanna Saczuk | 5% |
 
-Formal citations ([`CITATION.cff`](CITATION.cff), [BibTeX in `docs/citation.md`](docs/citation.md)) list **all four authors equally**. That is standard for software papers and repository metadata; percentage splits belong here or in grant/team docs, not in BibTeX.
+Formal software citations ([`CITATION.cff`](CITATION.cff), [BibTeX in `docs/citation.md`](docs/citation.md#bnnr-software)) list **all four authors equally** and use the BNNR software DOI (`10.5281/zenodo.20581372`). The ICD/AICD method paper ([`bnnr-research`](https://github.com/bnnr-team/bnnr-research), DOI `10.5281/zenodo.20581077`) is authored by Mateusz Walo only. Percentage splits belong here or in grant/team docs, not in BibTeX.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: "BNNR (Bulletproof Neural Network Recipe)"
-message: "If you use this software, please cite it as below."
+message: "If you use the BNNR software library, cite the software entry below. If you use ICD or AICD, also cite the method paper — see docs/citation.md."
 type: software
 authors:
   - family-names: Walo
@@ -16,6 +16,7 @@ url: "https://github.com/bnnr-team/bnnr"
 license: MIT
 version: 0.4.12
 date-released: 2026-06-07
+doi: 10.5281/zenodo.20581372
 
 preferred-citation:
   type: software
@@ -32,3 +33,14 @@ preferred-citation:
   year: 2026
   url: "https://github.com/bnnr-team/bnnr"
   version: 0.4.12
+  doi: 10.5281/zenodo.20581372
+
+references:
+  - type: article
+    authors:
+      - family-names: Walo
+        given-names: Mateusz
+    title: "Intelligent Coarse Dropout and Anti-ICD: Saliency-Guided Masking Augmentation for Visual Classifiers"
+    year: 2026
+    doi: 10.5281/zenodo.20581077
+    url: "https://doi.org/10.5281/zenodo.20581077"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://pepy.tech/projects/bnnr"><img src="https://static.pepy.tech/personalized-badge/bnnr?period=total&amp;units=INTERNATIONAL_SYSTEM&amp;left_color=BLACK&amp;right_color=GREEN&amp;left_text=downloads" alt="PyPI downloads"></a>
   <a href="https://github.com/bnnr-team/bnnr/blob/main/LICENSE"><img src="https://img.shields.io/github/license/bnnr-team/bnnr?style=flat-square" alt="License"></a>
   <a href="https://github.com/bnnr-team/bnnr/actions/workflows/ci.yml"><img src="https://github.com/bnnr-team/bnnr/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://doi.org/10.5281/zenodo.20581372"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.20581372.svg" alt="DOI"></a>
 </p>
 
 <p align="center">
@@ -247,7 +248,10 @@ python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exp
 
 ## Citation
 
-If you use BNNR in academic work or publish an integration that builds on it, cite the repository (all authors: Walo, Morzhak, Zydorczyk, Saczuk). BibTeX: [docs/citation.md](docs/citation.md). Authors and roles: [AUTHORS.md](AUTHORS.md). GitHub: **Cite this repository** (`CITATION.cff`).
+- **BNNR software** (any feature): cite the [software entry](docs/citation.md#bnnr-software) (DOI [10.5281/zenodo.20581372](https://doi.org/10.5281/zenodo.20581372); authors: Walo, Morzhak, Zydorczyk, Saczuk).
+- **ICD or AICD**: also cite the [method paper](docs/citation.md#icd-aicd-method-paper) (DOI [10.5281/zenodo.20581077](https://doi.org/10.5281/zenodo.20581077)).
+
+Full BibTeX: [docs/citation.md](docs/citation.md). Authors and roles: [AUTHORS.md](AUTHORS.md). GitHub: **Cite this repository** (`CITATION.cff`).
 
 ---
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -202,7 +202,10 @@ python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exp
 
 ## Citation
 
-If you use BNNR in academic work, cite the repository: [docs/citation.md](https://github.com/bnnr-team/bnnr/blob/main/docs/citation.md) (BibTeX). GitHub: **Cite this repository** via `CITATION.cff`.
+- **BNNR software**: [software entry](https://github.com/bnnr-team/bnnr/blob/main/docs/citation.md#bnnr-software) — DOI [10.5281/zenodo.20581372](https://doi.org/10.5281/zenodo.20581372)
+- **ICD or AICD**: [method paper](https://github.com/bnnr-team/bnnr/blob/main/docs/citation.md#icd-aicd-method-paper) — DOI [10.5281/zenodo.20581077](https://doi.org/10.5281/zenodo.20581077)
+
+Full BibTeX: [docs/citation.md](https://github.com/bnnr-team/bnnr/blob/main/docs/citation.md). GitHub: **Cite this repository** via `CITATION.cff`.
 
 ---
 

--- a/docs/augmentations.md
+++ b/docs/augmentations.md
@@ -97,6 +97,8 @@ Detection augmentations are bbox-aware — they transform both images and boundi
 
 Both accept `threshold_percentile`, `tile_size`, `fill_strategy`, and `probability`.
 
+Method description and citation: [ICD/AICD method paper](citation.md#icd-aicd-method-paper) (DOI [10.5281/zenodo.20581077](https://doi.org/10.5281/zenodo.20581077)). Plug-in guide: [plugin_icd.md](plugin_icd.md).
+
 ### Detection presets
 
 ```python

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,10 +1,36 @@
 # Citing BNNR
 
-If you use BNNR in research, a report, or a downstream integration guide, cite this repository. Pin a [release tag](https://github.com/bnnr-team/bnnr/releases) (for example `v0.4.11`) when you need a fixed version.
+If you use BNNR in research, a report, or a downstream integration guide, cite the appropriate entry below. Pin a [release tag](https://github.com/bnnr-team/bnnr/releases) (for example `v0.4.12`) when you need a fixed software version.
 
-Authors: Mateusz Walo, Diana Morzhak, Dominika Zydorczyk, Zuzanna Saczuk ([team record](../AUTHORS.md)).
+Authors (software): Mateusz Walo, Diana Morzhak, Dominika Zydorczyk, Zuzanna Saczuk ([team record](../AUTHORS.md)).
 
-## BNNR
+| You use | Cite |
+|---------|------|
+| BNNR library (any feature) | [BNNR software](#bnnr-software) |
+| ICD or AICD augmentation | [ICD/AICD method paper](#icd-aicd-method-paper) + [BNNR software](#bnnr-software) |
+| ICD/AICD with `gradcam` saliency | [ICD/AICD method paper](#icd-aicd-method-paper) + [BNNR software](#bnnr-software) + [pytorch-grad-cam](#bnnr-with-pytorch-grad-cam-icd-gradcam-saliency) |
+
+## ICD/AICD method paper
+
+Cite this when you use **ICD** or **AICD** (classification or detection), describe the method, or reproduce the tile-based masking construction. LaTeX sources: [bnnr-research](https://github.com/bnnr-team/bnnr-research).
+
+```bibtex
+@article{walo2026icd,
+  author  = {Walo, Mateusz},
+  title   = {Intelligent Coarse Dropout and Anti-ICD: Saliency-Guided Masking Augmentation for Visual Classifiers},
+  year    = {2026},
+  doi     = {10.5281/zenodo.20581077},
+  url     = {https://doi.org/10.5281/zenodo.20581077},
+  note    = {Preprint},
+  publisher = {Zenodo}
+}
+```
+
+Plain text (papers without BibTeX):
+
+> Walo, M. Intelligent Coarse Dropout and Anti-ICD: Saliency-Guided Masking Augmentation for Visual Classifiers. https://doi.org/10.5281/zenodo.20581077 (2026).
+
+## BNNR software
 
 ```bibtex
 @software{walo2026bnnr,
@@ -12,18 +38,19 @@ Authors: Mateusz Walo, Diana Morzhak, Dominika Zydorczyk, Zuzanna Saczuk ([team 
   title = {{BNNR}: Bulletproof Neural Network Recipe},
   year = {2026},
   url = {https://github.com/bnnr-team/bnnr},
-  version = {0.4.11},
+  version = {0.4.12},
+  doi = {10.5281/zenodo.20581372},
   license = {MIT}
 }
 ```
 
 Plain text (papers without BibTeX):
 
-> Walo, M.; Morzhak, D.; Zydorczyk, D.; Saczuk, Z. BNNR (Bulletproof Neural Network Recipe). https://github.com/bnnr-team/bnnr (2026).
+> Walo, M.; Morzhak, D.; Zydorczyk, D.; Saczuk, Z. BNNR (Bulletproof Neural Network Recipe). https://doi.org/10.5281/zenodo.20581372 (2026).
 
 ## BNNR with pytorch-grad-cam (ICD / `gradcam` saliency)
 
-BNNR depends on [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam) for Grad-CAM saliency. Cite **both** BNNR and pytorch-grad-cam when you use ICD/AICD or the [grad-cam integration example](../examples/integrations/gradcam_to_icd_loop.py).
+BNNR depends on [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam) for Grad-CAM saliency. Cite the [ICD/AICD method paper](#icd-aicd-method-paper), **BNNR software**, and pytorch-grad-cam when you use ICD/AICD or the [grad-cam integration example](../examples/integrations/gradcam_to_icd_loop.py).
 
 ```bibtex
 @misc{jacobgilpytorchcam,
@@ -37,8 +64,8 @@ BNNR depends on [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam)
 
 ## BNNR with Ultralytics YOLO
 
-When you use [`UltralyticsDetectionAdapter`](../src/bnnr/detection_adapter.py) or the [Ultralytics quickstart](../examples/integrations/ultralytics_yolo_quickstart.py), cite **BNNR** and follow [Ultralytics](https://github.com/ultralytics/ultralytics) licensing and citation guidance for the YOLO stack you use.
+When you use [`UltralyticsDetectionAdapter`](../src/bnnr/detection_adapter.py) or the [Ultralytics quickstart](../examples/integrations/ultralytics_yolo_quickstart.py), cite **BNNR software** and follow [Ultralytics](https://github.com/ultralytics/ultralytics) licensing and citation guidance for the YOLO stack you use.
 
 ## Integration docs and examples
 
-Upstream docs (grad-cam, Ultralytics) that describe BNNR should include the BNNR entry above alongside their own project citation. Public links: [integrations.md](integrations.md), [plugin_icd.md](plugin_icd.md).
+Upstream docs (grad-cam, Ultralytics) that describe BNNR should include the entries above alongside their own project citation. Public links: [integrations.md](integrations.md), [plugin_icd.md](plugin_icd.md).

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -40,8 +40,8 @@ BNNR is **MIT**. The [Ultralytics](https://github.com/ultralytics/ultralytics) r
 
 | You use | Cite |
 |---------|------|
-| BNNR (any feature) | [BNNR](citation.md#bnnr) |
-| ICD/AICD with `gradcam` saliency | [BNNR](citation.md#bnnr) and [pytorch-grad-cam](citation.md#bnnr-with-pytorch-grad-cam-icd-gradcam-saliency) |
-| `UltralyticsDetectionAdapter` | [BNNR](citation.md#bnnr) and [Ultralytics](citation.md#bnnr-with-ultralytics-yolo) per their license |
+| BNNR (any feature) | [BNNR software](citation.md#bnnr-software) |
+| ICD/AICD with `gradcam` saliency | [ICD/AICD method paper](citation.md#icd-aicd-method-paper), [BNNR software](citation.md#bnnr-software), and [pytorch-grad-cam](citation.md#bnnr-with-pytorch-grad-cam-icd-gradcam-saliency) |
+| `UltralyticsDetectionAdapter` | [BNNR software](citation.md#bnnr-software) and [Ultralytics](citation.md#bnnr-with-ultralytics-yolo) per their license |
 
 BibTeX and plain-text formats: [citation.md](citation.md). GitHub also exposes this via `CITATION.cff` at the repository root.

--- a/docs/plugin_icd.md
+++ b/docs/plugin_icd.md
@@ -67,7 +67,19 @@ BNNR uses [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam) for s
 
 ## Citation
 
-If you use ICD/AICD from BNNR in research, cite **BNNR** and **pytorch-grad-cam** (saliency). Full BibTeX blocks: [citation.md](citation.md).
+If you use ICD/AICD from BNNR in research, cite the **method paper**, **BNNR software**, and **pytorch-grad-cam** (saliency). Full BibTeX blocks: [citation.md](citation.md).
+
+```bibtex
+@article{walo2026icd,
+  author  = {Walo, Mateusz},
+  title   = {Intelligent Coarse Dropout and Anti-ICD: Saliency-Guided Masking Augmentation for Visual Classifiers},
+  year    = {2026},
+  doi     = {10.5281/zenodo.20581077},
+  url     = {https://doi.org/10.5281/zenodo.20581077},
+  note    = {Preprint},
+  publisher = {Zenodo}
+}
+```
 
 ```bibtex
 @software{walo2026bnnr,
@@ -75,7 +87,8 @@ If you use ICD/AICD from BNNR in research, cite **BNNR** and **pytorch-grad-cam*
   title = {{BNNR}: Bulletproof Neural Network Recipe},
   year = {2026},
   url = {https://github.com/bnnr-team/bnnr},
-  version = {0.4.11},
+  version = {0.4.12},
+  doi = {10.5281/zenodo.20581372},
   license = {MIT}
 }
 ```

--- a/examples/classification/icd_plugin_minimal.py
+++ b/examples/classification/icd_plugin_minimal.py
@@ -9,7 +9,7 @@ Run:
 Quick:
     PYTHONPATH=src python examples/classification/icd_plugin_minimal.py --epochs 1 --device cpu
 
-Citation: docs/citation.md in the bnnr repo (BNNR + pytorch-grad-cam when using gradcam).
+Citation: ICD/AICD paper https://doi.org/10.5281/zenodo.20581077 + BNNR software + pytorch-grad-cam — see docs/citation.md.
 """
 
 from __future__ import annotations

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -22,4 +22,4 @@ PYTHONPATH=src:examples/integrations python examples/integrations/ultralytics_yo
 
 ## Citation
 
-If you use these examples in a paper or upstream docs, cite BNNR ([BibTeX](../../docs/citation.md)). With grad-cam saliency or Ultralytics, cite those projects as well ([details](../../docs/citation.md)).
+If you use ICD/AICD examples in a paper or upstream docs, cite the [ICD/AICD method paper](https://doi.org/10.5281/zenodo.20581077) and [BNNR software](../../docs/citation.md#bnnr-software). With grad-cam saliency or Ultralytics, cite those projects as well ([details](../../docs/citation.md)).

--- a/examples/integrations/gradcam_to_icd_loop.py
+++ b/examples/integrations/gradcam_to_icd_loop.py
@@ -10,7 +10,7 @@ Outputs:
     gradcam_icd_out/gradcam_overlay.png
     gradcam_icd_out/icd_augmented.png
 
-Citation: cite BNNR and pytorch-grad-cam — see docs/citation.md in the bnnr repo.
+Citation: ICD/AICD paper https://doi.org/10.5281/zenodo.20581077 + BNNR software + pytorch-grad-cam — see docs/citation.md.
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ Repository = "https://github.com/bnnr-team/bnnr"
 Issues = "https://github.com/bnnr-team/bnnr/issues"
 Documentation = "https://github.com/bnnr-team/bnnr/tree/main/docs"
 Changelog = "https://github.com/bnnr-team/bnnr/blob/main/CHANGELOG.md"
+Zenodo = "https://doi.org/10.5281/zenodo.20581372"
+Paper = "https://doi.org/10.5281/zenodo.20581077"
 
 [tool.uv]
 constraint-dependencies = [


### PR DESCRIPTION
## Summary
- Add BNNR software DOI (`10.5281/zenodo.20581372`) to `CITATION.cff`, README badge, `pyproject.toml`, and software BibTeX.
- Add ICD/AICD method paper DOI (`10.5281/zenodo.20581077`) to `docs/citation.md`, ICD docs, and example citation headers.
- Clarify in `AUTHORS.md` that software citations (4 authors) and method paper citations (Walo) use separate DOIs.

## Test plan
- [ ] Verify README DOI badge renders on GitHub
- [ ] Check GitHub "Cite this repository" shows software DOI via `CITATION.cff`
- [ ] Confirm `docs/citation.md` anchors resolve (`#bnnr-software`, `#icd-aicd-method-paper`)


Made with [Cursor](https://cursor.com)