### PR TITLE
fix: declare click as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
   "opencv-python>=4.8.0,<5.0",
   "pydantic>=2.0.0,<3.0",
   "typer>=0.9.0,<1.0",
+  "click>=8.0.0,<9.0",
   "pyyaml>=6.0.0,<7.0",
   "tqdm>=4.65.0,<5.0",
   "grad-cam>=1.5.4,<2.0",


### PR DESCRIPTION
## Problem

A clean `pip install bnnr` produces a broken CLI: every command fails immediately with

```
ModuleNotFoundError: No module named 'click'
```

`cli.py` imports `click` directly and uses `click.Choice` for the `train` command options (`--dataset`, `--task`, `--preset`), but `click` was never declared in `[project].dependencies`. The CLI relied on it being pulled in transitively by `typer`, which the current `typer` release no longer does.

The bug is masked in CI because the `dashboard` extra installs `uvicorn`, and `uvicorn` depends on `click>=7.0`. A user installing the base package gets neither.

## Reproduction

```
python -m venv /tmp/v && /tmp/v/bin/pip install bnnr
/tmp/v/bin/bnnr version
# ModuleNotFoundError: No module named 'click'
```

Installing `click` into the same environment fixes every command.

## Fix

Declare `click>=8.0.0,<9.0` as a runtime dependency. It is a direct import in `cli.py`, so it belongs in the core dependency list.