### PR TITLE
fix: stop pulling fastapi into the core training loop

### DIFF
--- a/src/bnnr/dashboard/backend.py
+++ b/src/bnnr/dashboard/backend.py
@@ -17,6 +17,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel as _PydanticBaseModel
 
+from bnnr.dashboard.constants import PAUSE_SIGNAL_FILENAME
 from bnnr.dashboard.exporter import export_dashboard_snapshot
 from bnnr.events import IncrementalReplayState, load_events, load_events_from_offset
 from bnnr.path_security import child_path, validate_run_id
@@ -44,9 +45,6 @@ _TRIM_FIELDS = ("epochs", "samples", "sample_predictions", "xai")
 
 # Max confusion entries to keep (most recent)
 _MAX_CONFUSION_ENTRIES = 30
-
-# Signal file name used for pause/resume
-PAUSE_SIGNAL_FILENAME = ".bnnr_pause"
 
 
 class ControlAction(_PydanticBaseModel):

--- a/src/bnnr/dashboard/constants.py
+++ b/src/bnnr/dashboard/constants.py
@@ -1,0 +1,13 @@
+"""Dependency-free constants shared by the dashboard and the trainer.
+
+This module deliberately has no imports beyond the standard library so the
+core training loop can read the pause-signal filename without importing the
+FastAPI backend (and therefore without requiring the optional ``dashboard``
+dependencies).
+"""
+
+from __future__ import annotations
+
+# Signal file the dashboard writes into a run directory to request a pause.
+# The trainer polls for it at epoch boundaries; see BNNRTrainer._check_pause.
+PAUSE_SIGNAL_FILENAME = ".bnnr_pause"

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -164,7 +164,7 @@ class BNNRTrainer:
         Pause.  This method is called at epoch boundaries so training
         can be suspended without altering the core training logic.
         """
-        from bnnr.dashboard.backend import PAUSE_SIGNAL_FILENAME
+        from bnnr.dashboard.constants import PAUSE_SIGNAL_FILENAME
 
         pause_file = self.reporter.run_dir / PAUSE_SIGNAL_FILENAME
         if not pause_file.exists():


### PR DESCRIPTION
## Problem

On a base install (without the optional `dashboard` extra), every training run crashes:

```
ModuleNotFoundError: No module named 'fastapi'
```

`BNNRTrainer._check_pause` read the pause-signal filename with:

```python
from bnnr.dashboard.backend import PAUSE_SIGNAL_FILENAME
```

`dashboard/backend.py` imports `fastapi` at module level, so importing it just to read one string constant requires FastAPI. `_check_pause` runs at every epoch boundary, so `bnnr train`, `bnnr demo`, `bnnr quickstart` and `quick_run` all abort partway through training.

CI did not catch this because it installs the `dashboard` extra, which provides FastAPI.

## Reproduction

In an environment without the `dashboard` extra:

```
pytest tests/test_core.py::test_bnnr_trainer_run_one_iteration
# ModuleNotFoundError: No module named 'fastapi' at trainer.py:167 -> backend.py:15
```

## Fix

Move `PAUSE_SIGNAL_FILENAME` into a new dependency-free `dashboard/constants.py`. The trainer and the backend both import it from there. The constant is still re-exported from `dashboard.backend`, so existing imports keep working.

Verified with FastAPI uninstalled: the six previously failing core tests in `test_core.py` and `test_contracts.py` pass, and `from bnnr.dashboard.backend import PAUSE_SIGNAL_FILENAME` still resolves when FastAPI is present.