### PR TITLE
test: skip dashboard tests when fastapi is not installed

### DIFF
--- a/tests/test_dashboard_backend.py
+++ b/tests/test_dashboard_backend.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from bnnr.dashboard.backend import (
+import pytest
+
+pytest.importorskip("fastapi")
+
+from bnnr.dashboard.backend import (  # noqa: E402
     _normalize_run_root,
     _trim_state_for_api,
     list_runs,

--- a/tests/test_dashboard_path_security.py
+++ b/tests/test_dashboard_path_security.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import json
 
 import pytest
-from fastapi import HTTPException
 
-from bnnr.dashboard.backend import _resolve_run_dir, _safe_artifact_path
-from bnnr.dashboard.exporter import export_dashboard_snapshot
-from bnnr.events import load_events
+pytest.importorskip("fastapi")
+
+from fastapi import HTTPException  # noqa: E402
+
+from bnnr.dashboard.backend import _resolve_run_dir, _safe_artifact_path  # noqa: E402
+from bnnr.dashboard.exporter import export_dashboard_snapshot  # noqa: E402
+from bnnr.events import load_events  # noqa: E402
 from bnnr.path_security import child_path, validate_run_id
 
 


### PR DESCRIPTION
## Problem

Running the test suite without the optional `dashboard` extra aborts during collection:

```
ERROR tests/test_dashboard_backend.py
ERROR tests/test_dashboard_path_security.py
!!!! Interrupted: 2 errors during collection !!!!
```

Both modules import `fastapi` (directly, or transitively via `bnnr.dashboard.backend`) at module level. The `dev` extra does not include `fastapi`, so `pip install -e ".[dev]"` followed by `pytest` fails outright before running anything. The ultralytics, kornia and albumentations tests already guard their optional imports, so this was the inconsistent case.

## Fix

Add `pytest.importorskip("fastapi")` at the top of both modules, following the existing pattern. With FastAPI absent, the two modules now skip (`2 skipped`) and full collection succeeds (`940 tests collected`, exit 0). `ruff check` passes on both files.