### PR TITLE
docs: update version references from 0.4.11 to 0.4.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run `bnnr analyze` on a trained model and you get a self-contained HTML report: 
 - **My augmentations are guesswork.** → ICD/AICD condition augmentation on saliency maps, then a branch search keeps only the augmentations that measurably improve your validation metric.
 - **I need to prove model quality to stakeholders or compliance.** → A portable `report.html` plus a structured JSON audit artifact you can attach to a review.
 
-<sub>BNNR also ships a training pipeline (`bnnr train`), a live dashboard, multi-label support, and object detection (YOLO / COCO-mini). Single-label classification is the focus for `analyze`. Supported tasks in **v0.4.11**: single-label classification, multi-label classification, object detection. Full docs: [docs/README.md](docs/README.md) ([analyze](docs/analyze.md) · [detection](docs/detection.md) · [benchmarks](docs/benchmarks.md)).</sub>
+<sub>BNNR also ships a training pipeline (`bnnr train`), a live dashboard, multi-label support, and object detection (YOLO / COCO-mini). Single-label classification is the focus for `analyze`. Supported tasks in **v0.4.12**: single-label classification, multi-label classification, object detection. Full docs: [docs/README.md](docs/README.md) ([analyze](docs/analyze.md) · [detection](docs/detection.md) · [benchmarks](docs/benchmarks.md)).</sub>
 
 ---
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -34,7 +34,7 @@
 
 **BNNR automatically improves your PyTorch vision models using XAI** — find what your model gets wrong, fix it with intelligent augmentation, and prove the result with structured reports and a live dashboard.
 
-Supported tasks (**v0.4.11**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md).
+Supported tasks (**v0.4.12**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md).
 
 **Sample analyze report (no install):** [live HTML preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Product roadmap
 
-**Updated:** 2026-05-31 · **Current release:** v0.4.11
+**Updated:** 2026-05-31 · **Current release:** v0.4.12
 
 BNNR is a PyTorch vision toolkit focused on **model diagnostics first** (`bnnr analyze`), then saliency-guided augmentations (ICD/AICD), with optional training and detection adapters.
 


### PR DESCRIPTION
## Problem

Three documents still referenced `v0.4.11` as the current/supported release, while `pyproject.toml`, `version.py`, the CHANGELOG and the sample report were already on `0.4.12`:

- `README.md` line 47: "Supported tasks in v0.4.11"
- `README.pypi.md` line 37: "Supported tasks (v0.4.11)"
- `docs/roadmap.md` line 3: "Current release: v0.4.11"

## Fix

Bump those three references to `0.4.12` to match the released version. No other content changed.