### PR TITLE
Make CLI flags consistent across commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ python3 -m bnnr list-datasets
 python3 -m bnnr list-augmentations -v
 python3 -m bnnr list-presets
 python3 -m bnnr dashboard serve --run-dir reports --port 8080
-python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exported_dashboard
+python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --output exported_dashboard
 ```
 
 ### Doc index

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -173,7 +173,7 @@ python3 -m bnnr list-datasets
 python3 -m bnnr list-augmentations -v
 python3 -m bnnr list-presets
 python3 -m bnnr dashboard serve --run-dir reports --port 8080
-python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exported_dashboard
+python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --output exported_dashboard
 ```
 
 ### Doc index

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -108,7 +108,7 @@ Common event types emitted by current code:
 
 ## Dashboard export artifacts
 
-`python3 -m bnnr dashboard export --run-dir <run_dir> --out <out_dir>` writes:
+`python3 -m bnnr dashboard export --run-dir <run_dir> --output <out_dir>` writes:
 
 - `index.html`
 - `data/events.jsonl`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -82,7 +82,7 @@ Omit `--config` to use built-in quickstart defaults (`m_epochs=3`, `max_iteratio
 - `--with-dashboard / --without-dashboard`
 - `--dashboard-port`
 - `--no-auto-open`
-- `--dashboard-token`
+- `--token`
 - `--batch-size`
 - `--max-train-samples`
 - `--max-val-samples`
@@ -148,7 +148,7 @@ Notes:
 
 ```bash
 python3 -m bnnr dashboard serve --run-dir reports --port 8080
-python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exported_dashboard
+python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --output exported_dashboard
 ```
 
 `dashboard serve` options:
@@ -161,7 +161,7 @@ python3 -m bnnr dashboard export --run-dir reports/run_YYYYMMDD_HHMMSS --out exp
 `dashboard export` options:
 
 - `--run-dir` (required)
-- `--out` (required)
+- `--output` (required)
 - `--frontend-dist`
 
 ## Dashboard usage notes (important)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -78,7 +78,7 @@ python3 -m bnnr dashboard serve --run-dir reports --port 8080
 For `train` path use:
 
 ```bash
-python3 -m bnnr train ... --dashboard-token "change-me"
+python3 -m bnnr train ... --token "change-me"
 ```
 
 ## 5) Pause/resume workflow
@@ -93,7 +93,7 @@ python3 -m bnnr train ... --dashboard-token "change-me"
 ```bash
 python3 -m bnnr dashboard export \
   --run-dir reports/run_YYYYMMDD_HHMMSS \
-  --out exported_dashboard
+  --output exported_dashboard
 ```
 
 Artifacts include:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -188,7 +188,7 @@ For any example with `--with-dashboard`:
 For offline sharing:
 
 ```bash
-python3 -m bnnr dashboard export --run-dir <run_dir> --out exported_dashboard
+python3 -m bnnr dashboard export --run-dir <run_dir> --output exported_dashboard
 ```
 
 ## 7) Example artifacts you should always verify

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -215,7 +215,7 @@ python -m bnnr train \
   --max-val-samples 64 \
   --preset light \
   --with-dashboard \
-  --dashboard-token "change-me"
+  --token "change-me"
 ```
 
 Equivalent replay mode protection:
@@ -248,7 +248,7 @@ Use replay mode when:
 RUN_DIR=$(ls -1dt reports_quickstart/run_* | head -n 1)
 python -m bnnr dashboard export \
   --run-dir "$RUN_DIR" \
-  --out exported_dashboard
+  --output exported_dashboard
 ```
 
 Open `exported_dashboard/index.html`.

--- a/docs/golden_path.md
+++ b/docs/golden_path.md
@@ -172,11 +172,11 @@ See [detection.md](detection.md) for the full guide (adapters, dataset format, a
 
 - `start_dashboard(...)` prints Local URL, Network URL, and terminal QR code when optional `bnnr[dashboard]` deps are installed; otherwise it prints install hints and returns `None` (events are still written for export/replay).
 - For mobile, phone must be on same network.
-- For secured controls, use token via CLI (`--dashboard-token`) or environment (`BNNR_DASHBOARD_TOKEN`) in serve mode.
+- For secured controls, use token via CLI (`--token`) or environment (`BNNR_DASHBOARD_TOKEN`) in serve mode.
 - Export for offline sharing:
 
 ```bash
-python3 -m bnnr dashboard export --run-dir <run_dir> --out exported_dashboard
+python3 -m bnnr dashboard export --run-dir <run_dir> --output exported_dashboard
 ```
 
 ## 5) Hardening checklist

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -82,7 +82,7 @@ Optional replay/export checks:
 
 ```bash
 python3 -m bnnr dashboard serve --run-dir <run_dir_parent> --port 8080
-python3 -m bnnr dashboard export --run-dir <run_dir> --out /tmp/exported_dashboard
+python3 -m bnnr dashboard export --run-dir <run_dir> --output /tmp/exported_dashboard
 ```
 
 ## CI (GitHub Actions)

--- a/examples/README.md
+++ b/examples/README.md
@@ -79,5 +79,5 @@ For each example run:
 4. Export static dashboard and open `index.html`.
 
 ```bash
-python3 -m bnnr dashboard export --run-dir <run_dir> --out exported_dashboard
+python3 -m bnnr dashboard export --run-dir <run_dir> --output exported_dashboard
 ```

--- a/examples/classification/bnnr_cooking_round1_butterfly.ipynb
+++ b/examples/classification/bnnr_cooking_round1_butterfly.ipynb
@@ -633,7 +633,7 @@
       "source": [
         "## 12. Static dashboard export (for a website)\n",
         "\n",
-        "To ship a **non-interactive** snapshot of the dashboard UI with your article or portfolio page, run **python3 -m bnnr dashboard export --run-dir RUN_DIR --out exported_dashboard** in a terminal.\n",
+        "To ship a **non-interactive** snapshot of the dashboard UI with your article or portfolio page, run **python3 -m bnnr dashboard export --run-dir RUN_DIR --output exported_dashboard** in a terminal.\n",
         "\n",
         "Use the timestamped directory that contains your **report.json** as **RUN_DIR** (the `run_dir` variable in this notebook is that path).\n"
       ]

--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -377,7 +377,7 @@ def train_command(
     ),
     dashboard_token: Optional[str] = typer.Option(
         None,
-        "--dashboard-token",
+        "--token",
         help="Token to protect dashboard control endpoints (pause/resume). "
         "Also configurable via BNNR_DASHBOARD_TOKEN env var.",
     ),
@@ -516,7 +516,7 @@ def report_command(
     elif fmt == "html":
         typer.echo(
             "Error: Legacy HTML report was removed. "
-            "Use: bnnr dashboard export --run-dir <run_dir> --out <dir>",
+            "Use: bnnr dashboard export --run-dir <run_dir> --output <dir>",
             err=True,
         )
         raise typer.Exit(code=1)
@@ -567,7 +567,7 @@ def _try_alternate_models(
 @app.command("analyze")
 def analyze_command(
     model: Path = typer.Option(..., "--model", "-m", help="Path to model checkpoint (.pt) or state dict"),
-    data: Path = typer.Option(..., "--data", "-d", help="Path to data directory (ImageFolder) or dataset name (e.g. mnist, cifar10)"),
+    data: Path = typer.Option(..., "--data", help="Path to data directory (ImageFolder) or dataset name (e.g. mnist, cifar10)"),
     output: Path = typer.Option(..., "--output", "-o", help="Output directory for analysis_report.json and report.html"),
     task: str = typer.Option(
         "classification",
@@ -579,7 +579,7 @@ def analyze_command(
     max_worst: int = typer.Option(20, "--max-worst", help="Number of worst predictions to include"),
     no_xai: bool = typer.Option(False, "--no-xai", help="Disable XAI analysis"),
     no_data_quality: bool = typer.Option(False, "--no-data-quality", help="Disable data quality checks"),
-    device: Optional[str] = typer.Option(None, "--device", help="Device: cuda, cpu, auto"),
+    device: Optional[str] = typer.Option(None, "--device", "-d", help="Device: cuda, cpu, auto"),
     batch_size: int = typer.Option(64, "--batch-size", help="Batch size for evaluation"),
     output_summary: bool = typer.Option(
         True,
@@ -829,7 +829,7 @@ def dashboard_serve_command(
 @dashboard_app.command("export")
 def dashboard_export_command(
     run_dir: Path = typer.Option(..., "--run-dir"),
-    out: Path = typer.Option(..., "--out"),
+    out: Path = typer.Option(..., "--output", "-o"),
     frontend_dist: Optional[Path] = typer.Option(None, "--frontend-dist"),
 ) -> None:
     """Export a standalone dashboard snapshot to a directory."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -327,7 +327,7 @@ def test_cli_train_command_without_dashboard_keeps_events_for_export(temp_dir, m
             "export",
             "--run-dir",
             str(run_dir),
-            "--out",
+            "--output",
             str(export_out),
         ],
     )


### PR DESCRIPTION
Aligns flag names and short options across the CLI so the same concept uses the same flag everywhere.

## Changes
- `analyze`: `-d` now maps to `--device` (matching `train`). Previously `-d` meant `--data` here, so the same short flag had two meanings across commands. `--data` remains available as the long form.
- `train`: `--dashboard-token` renamed to `--token` to match `dashboard serve`, which already used `--token`. The `BNNR_DASHBOARD_TOKEN` env var is unchanged.
- `dashboard export`: `--out` renamed to `--output`/`-o` to match `train`, `report`, and `analyze`.

Docs, README, examples, and the integration test are updated to the new flag names.

## Verification
- `bnnr train/analyze/dashboard export --help` show the new flags.
- ruff clean on changed files.
- 76 targeted tests pass (CLI, analyze, dashboard export/serve, integration).