### PR TITLE
Give CLI report and analyze clean error handling

### DIFF
--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -492,8 +492,23 @@ def report_command(
     output: Optional[Path] = typer.Option(None, "--output", "-o"),
 ) -> None:
     """View or export a BNNR training report."""
-    report = load_report(report_path)
+    if not report_path.exists():
+        typer.echo(f"Error: Report path does not exist: {report_path}", err=True)
+        raise typer.Exit(code=1)
+
     fmt = format.lower()
+    if fmt == "html":
+        typer.echo(
+            "Error: Legacy HTML report was removed. "
+            "Use: bnnr dashboard export --run-dir <run_dir> --output <dir>",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if fmt not in ("summary", "json"):
+        typer.echo("Error: Invalid format. Use one of: summary, json.", err=True)
+        raise typer.Exit(code=1)
+
+    report = load_report(report_path)
     rendered: str
 
     if fmt == "summary":
@@ -505,7 +520,7 @@ def report_command(
                 f"Total checkpoints: {len(report.checkpoints)}",
             ]
         )
-    elif fmt == "json":
+    else:
         payload = {
             "best_path": report.best_path,
             "best_metrics": report.best_metrics,
@@ -513,16 +528,6 @@ def report_command(
             "total_time": report.total_time,
         }
         rendered = json.dumps(payload, indent=2)
-    elif fmt == "html":
-        typer.echo(
-            "Error: Legacy HTML report was removed. "
-            "Use: bnnr dashboard export --run-dir <run_dir> --output <dir>",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-    else:
-        typer.echo("Error: Invalid format. Use one of: summary, json, html.", err=True)
-        raise typer.Exit(code=1)
 
     if output is not None:
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -604,8 +609,8 @@ def analyze_command(
         typer.echo(f"Error: Model path does not exist: {model}", err=True)
         raise typer.Exit(code=1)
 
-    task_norm = task.strip().lower()
-    if task_norm not in ("classification", "multilabel"):
+    task = task.strip()
+    if task not in ("classification", "multilabel"):
         typer.echo(
             "Error: bnnr analyze supports only --task classification or multilabel. "
             f"Got {task!r}. Detection is not supported until the main stack ships it.",


### PR DESCRIPTION
Replaces raw tracebacks with clean, consistent error messages in two CLI commands.

## Changes
- `report`: validates the report path and `--format` **before** calling `load_report`. A missing file or an unsupported format now produces a clean `Error: ...` and exit code 1 instead of a raw traceback (matching how `analyze` already validates its inputs). The catch-all message now lists only `summary, json`; `html` keeps its dedicated migration hint pointing at `dashboard export`.
- `analyze`: `--task` now requires exactly `classification` or `multilabel` (lowercase). Mixed-case input such as `--task Classification` is rejected at the gate with a clean error, instead of passing the gate and then raising a traceback inside `BNNRConfig`.

## Verification
- `report` on a missing path, on an unsupported format, and `-f html` all print clean errors (confirmed by running each).
- `analyze --task Classification` prints a clean gate error with exit code 1.
- ruff clean; 58 targeted tests pass (CLI, analyze, integration, demo).

## Note on overlap with #245
Both this PR and #245 touch the `report` html-error line (#245 renames `--out` to `--output` there). They are independent branches from main, so merging the second one may need a one line manual resolution on that message. The intended final text uses `--output`.