### PR TITLE
Default device to auto instead of cuda

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,7 @@ seed: 42
 - `selection_metric` (default: `accuracy`) — the metric used to select the best augmentation branch. Can be any metric from the tables below.
 - `selection_mode` (`max` or `min`, default: `max`) — use `min` for metrics where lower is better (e.g. `loss`, `zero_one_loss`).
 - `early_stopping_patience` (default: `2`)
-- `device` (`cuda`, `cpu`, `auto`; default: `cuda`)
+- `device` (`cuda`, `cpu`, `auto`; default: `auto`)
 - `seed` (default: `42`)
 - `save_checkpoints` (default: `true`)
 - `verbose` (default: `true`)

--- a/src/bnnr/adapter.py
+++ b/src/bnnr/adapter.py
@@ -47,7 +47,7 @@ class SimpleTorchAdapter:
         criterion: nn.Module,
         optimizer: torch.optim.Optimizer,
         target_layers: list[nn.Module] | None = None,
-        device: str = "cuda",
+        device: str = "auto",
         eval_metrics: list[str] | None = None,
         scheduler: Any | None = None,
         use_amp: bool = False,

--- a/src/bnnr/config_model.py
+++ b/src/bnnr/config_model.py
@@ -31,7 +31,7 @@ class BNNRConfig(BaseModel):
     xai_enabled: bool = True
     xai_samples: int = 4
     xai_method: str = "opticam"
-    device: str = "cuda"
+    device: str = "auto"
     seed: int = 42
     save_checkpoints: bool = True
     verbose: bool = True

--- a/src/bnnr/detection_adapter.py
+++ b/src/bnnr/detection_adapter.py
@@ -145,7 +145,7 @@ class DetectionAdapter:
         model: nn.Module,
         optimizer: torch.optim.Optimizer,
         target_layers: list[nn.Module] | None = None,
-        device: str = "cuda",
+        device: str = "auto",
         scheduler: Any | None = None,
         use_amp: bool = False,
         score_threshold: float = 0.05,
@@ -339,7 +339,7 @@ class UltralyticsDetectionAdapter:
     def __init__(
         self,
         model_name: str = "yolov8n.pt",
-        device: str = "cuda",
+        device: str = "auto",
         score_threshold: float = 0.05,
         num_classes: int | None = None,
         lr: float = 1e-3,


### PR DESCRIPTION
## Problem
`BNNRConfig().device` defaulted to `"cuda"`, so constructing a config (or an adapter) without an explicit device on a machine without a GPU raised `RuntimeError: CUDA requested but not available` at device resolution. Every config factory and the CLI already use `"auto"`, so the bare constructors were the only inconsistent path.

## Change
Default `device` to `"auto"` in:
- `BNNRConfig`
- `SimpleTorchAdapter`
- `DetectionAdapter`
- `UltralyticsDetectionAdapter`

All of these resolve the device through `get_device`, where `"auto"` picks `cuda` when available and `cpu` otherwise. On GPU machines behavior is unchanged; on CPU machines the crash is gone. `docs/configuration.md` updated to list the new default.

## Verification
- `BNNRConfig().device` is now `auto`.
- ruff and mypy clean on the changed modules.
- 294 tests pass (config, adapters, core, comprehensive, quick_run, contracts); 7 skipped.