### PR TITLE
Align list-presets with train --preset

### DIFF
--- a/docs/augmentations.md
+++ b/docs/augmentations.md
@@ -17,9 +17,9 @@ Available names:
 - `standard`
 - `aggressive`
 - `gpu`
-- `demo` — ICD + ChurchNoise (used by `python -m bnnr demo`; also valid for `get_preset("demo")`)
+- `demo` — ICD + ChurchNoise (used by `python -m bnnr demo` and `get_preset("demo")`; not shown by `bnnr list-presets`)
 - `screening` — virtual; maps to aggressive with uniform probability (`get_preset` / API only)
-- `none` — no augmentations (`python -m bnnr train --preset none` only; not a named entry in `list_presets`)
+- `none` — no augmentations (`python -m bnnr train --preset none`; shown by `bnnr list-presets`)
 
 Examples:
 

--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -876,14 +876,19 @@ def list_augmentations(verbose: bool = typer.Option(False, "--verbose", "-v")) -
 
 @app.command("list-presets")
 def list_presets_command() -> None:
-    """List available augmentation presets."""
+    """List augmentation presets accepted by `bnnr train --preset`."""
     from bnnr.presets import list_presets
 
     presets = list_presets()
     typer.echo("Available augmentation presets:")
     typer.echo(f"  {'auto':<15} Auto-select best augmentations for current hardware")
     for name, desc in presets.items():
+        # `demo` needs a model and target_layers, so it is not usable as a plain
+        # `train --preset`; it is served by `bnnr demo` and get_preset("demo").
+        if name == "demo":
+            continue
         typer.echo(f"  {name:<15} {desc}")
+    typer.echo(f"  {'none':<15} No augmentations (train on raw data)")
 
 
 @app.command("list-datasets")

--- a/src/bnnr/presets.py
+++ b/src/bnnr/presets.py
@@ -136,8 +136,9 @@ def get_preset(
     ----------
     name:
         Preset name. One of: ``auto``, ``light``, ``standard``, ``aggressive``,
-        ``gpu``, ``screening``.
+        ``gpu``, ``demo``, ``screening``.
         If ``auto``, calls :func:`auto_select_augmentations`.
+        If ``demo``, requires ``model`` and ``target_layers`` (XAI-guided ICD).
         If ``screening``, returns the ``aggressive`` preset with uniform ``p=0.5``
         — useful for the subset-proxy screening phase where uniform probability
         isolates augmentation *type* from *dosage*.


### PR DESCRIPTION
## Problem
`bnnr list-presets` and `bnnr train --preset` advertised different sets:
- `list-presets` showed `demo`, which needs a model and `target_layers` and is **not** usable as a plain `train --preset` (it silently falls back to `auto`).
- `list-presets` omitted `none`, which `train` accepts.
- The `get_preset` docstring listed yet another set (missing `demo`).

## Change
- `list-presets` now lists exactly what `train --preset` accepts: `auto, light, standard, aggressive, gpu, none`. `demo` is hidden from this command; it stays available through `bnnr demo` and `get_preset("demo")`.
- The public `list_presets()` function is unchanged (still returns the `_PRESETS` table including `demo`), so API callers and existing tests are unaffected.
- `get_preset` docstring and `docs/augmentations.md` updated to match.

## Verification
- `bnnr list-presets` output matches the `train --preset` set; `demo` no longer shown, `none` shown.
- ruff and mypy clean.
- 166 tests pass (contracts, presets, comprehensive); 8 skipped. `list_presets()` still contains `demo` (test_presets_demo).