### PR TITLE
Remove redundant example_command from recommendations

### DIFF
--- a/src/bnnr/analysis/html_report.py
+++ b/src/bnnr/analysis/html_report.py
@@ -1307,7 +1307,7 @@ def _rec_block(recs_struct: list[dict[str, Any]], recs_legacy: list[str]) -> str
                       f'padding:4px 10px;background:rgba(34,197,94,0.08);border-radius:6px;'
                       f'border:1px solid rgba(34,197,94,0.2);">'
                       f'{_esc(impact)}</div>')
-            reference = r.get("example_command", "")
+            reference = r.get("literature_note", "")
             if reference:
                 h += (f'<div style="font-size:10px;color:var(--muted);margin-top:4px;'
                       f'font-style:italic;">\U0001f4da {_esc(reference)}</div>')

--- a/src/bnnr/analysis/recommendations.py
+++ b/src/bnnr/analysis/recommendations.py
@@ -299,7 +299,6 @@ def build_recommendations(
                 confidence=best_confidence,
                 priority=priority,
                 linked_finding_ids=finding_ids,
-                example_command=reference,
                 evidence_from_run=evidence_run,
                 literature_note=reference,
             )
@@ -318,7 +317,6 @@ def build_recommendations(
                 expected_impact=f"[Likely] Literature context (not verified on this run): {iq}",
                 confidence="medium",
                 priority=6,
-                example_command=lit["reference"],
                 evidence_from_run=[f"mean_xai_quality={float(mean_q):.3f}"],
                 literature_note=lit["reference"],
             )
@@ -336,7 +334,6 @@ def build_recommendations(
                 expected_impact=f"[Likely] Literature context (not verified on this run): {iq}",
                 confidence="medium",
                 priority=7,
-                example_command=lit["reference"],
                 evidence_from_run=[f"accuracy={float(acc):.3f}"],
                 literature_note=lit["reference"],
             )

--- a/src/bnnr/analysis/schema.py
+++ b/src/bnnr/analysis/schema.py
@@ -59,7 +59,6 @@ class Recommendation:
     confidence: str = "medium"
     priority: int = 0  # lower = higher priority
     linked_finding_ids: list[str] = field(default_factory=list)
-    example_command: str = ""
     evidence_from_run: list[str] = field(default_factory=list)
     literature_note: str = ""
 


### PR DESCRIPTION
## Problem
`Recommendation.example_command` was always assigned the same literature reference string as `literature_note`, and the HTML report rendered it as a citation (the book icon line). So the field never held a command, it only duplicated `literature_note`, and its name was misleading.

## Change
- Remove `example_command` from the `Recommendation` schema.
- Remove the three `example_command=...` assignments in `build_recommendations`.
- The HTML report now reads the citation from `literature_note` (previously unused in HTML).

The rendered report is unchanged (same citation text shown); the JSON report drops the redundant `example_command` key. The report schema is versioned via the package version and no consumer or test depended on the field.

## Verification
- `Recommendation.to_dict()` no longer contains `example_command`; `literature_note` is present and drives the HTML citation.
- ruff and mypy clean on `src/bnnr/analysis/`.
- 103 tests pass (analyze, xai_analysis); test_analyze exercises the full analyze plus `to_html` path.