### PR TITLE
benchmark: grand cross-dataset ablation (equal compute, held-out test)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -174,3 +174,75 @@ benchmarks/
 ### Results
 
 _Pending a GPU run._ Run `reproduce_imagewoof.sh`, review `results_imagewoof.json`, then paste the `summarize.py --markdown` table here and into the root `README.md`. Do not hand-write numbers.
+
+---
+
+## Grand benchmark (paper-quality, equal-compute)
+
+The Imagewoof benchmark above compares the **full BNNR product** against fixed-epoch baselines (unequal compute, single dataset). The grand benchmark is the stricter, publication-grade version designed to survive peer review: **equal total GPU-epoch budget across every condition**, a **held-out test split never used for model selection**, an explicit **XAI-ablation condition** (`bnnr_random`), and **cross-dataset generalization**.
+
+### What it isolates
+
+| Claim | Comparison |
+|-------|-----------|
+| XAI-guided selection beats random selection | `bnnr_xai` vs `bnnr_random` (the headline claim) |
+| ICD / AICD each help on their own | `icd_only` / `aicd_only` vs `no_aug` |
+| Branch search beats the best single augmentation | `bnnr_xai` vs best `*_only` |
+| BNNR beats strong external baselines | vs RandAugment, TrivialAugment, AutoAugment |
+| ICD reduces shortcut learning | XAI metrics: edge ratio, gini, coverage |
+| Results generalize across domains | 6 datasets |
+
+### Conditions (10)
+
+`no_aug`, `randaugment`, `trivialaugment`, `autoaugment`, `churchnoise_only`, `icd_only`, `aicd_only`, `icd_aicd_fixed`, `bnnr_random`, `bnnr_xai`.
+
+### Datasets
+
+| Dataset | Classes | Train/class | Res | Domain |
+|---------|---------|-------------|-----|--------|
+| Imagewoof | 10 | 100 | 128px | Fine-grained animals |
+| Oxford Pets | 37 | 100 | 224px | Fine-grained animals |
+| Flowers102 | 102 | 10 | 224px | Flowers (extreme low-data) |
+| DTD | 47 | 120 | 224px | Textures |
+| FGVC-Aircraft | 100 | 33 | 224px | Aircraft |
+| EuroSAT | 10 | 100 | 64px | Satellite |
+
+### Protocol caveats (read before quoting numbers)
+
+- **Equal total compute, not equal per-model epochs.** Every condition spends the same total GPU-epoch budget `B`. The `bnnr_xai` / `bnnr_random` *final* model is trained for 2 phases (baseline + chosen candidate), while single-aug and baseline conditions pour all `B` epochs into one model. Compute is matched; the per-model epoch count is not. This is **conservative** for the "branch search > best single aug" claim.
+- **Held-out test is reserved for final reporting only.** Every condition selects its best epoch on `selection_val`; the held-out test split is evaluated exactly once. No condition early-stops on the test set.
+- **`bnnr_random` is the XAI ablation.** Identical compute and augmentation pool as `bnnr_xai`, but the candidate is chosen at random (seed-controlled). `bnnr_xai` vs `bnnr_random` isolates the contribution of XAI-guided selection from the augmentation pool itself.
+- **From-scratch, low-data by design:** the regime where augmentation strategy actually moves the needle, not a leaderboard entry.
+
+### Run
+
+```bash
+# Sanity check (CPU, tiny subset): exercises every code path
+python benchmarks/run_grand_benchmark.py --dataset imagewoof --smoke
+
+# Primary run: Imagewoof, 10 conditions x 10 seeds (GPU)
+python benchmarks/run_grand_benchmark.py --dataset imagewoof --device cuda
+
+# Generalization datasets (6 conditions x 7 seeds each)
+python benchmarks/run_grand_benchmark.py --dataset pets --device cuda
+
+# Summarize: Wilcoxon signed-rank + bootstrap CI + Holm-Bonferroni
+python benchmarks/summarize_grand.py --results-dir benchmarks/ --markdown
+```
+
+Resume-safe: `results_{dataset}_{regime}.json` is checkpointed after every `(condition, seed)` run. Use `--drive-base-dir` to land results, run logs, and dataset cache under one directory (Colab/Drive).
+
+### Layout
+
+```
+benchmarks/
+  run_grand_benchmark.py   # CLI (resume-safe, equal-compute, held-out test)
+  dataset_loaders.py       # 6-dataset registry, 3-way train/selection_val/held_out_test split
+  metrics_extended.py      # F1-macro, Top-5, Cohen's kappa, ECE, XAI metrics
+  summarize_grand.py       # Wilcoxon + bootstrap CI + Holm-Bonferroni table
+  runs_grand/              # per-run logs + xai/ overlays (gitignored)
+```
+
+### Results
+
+_Pending a GPU run._ Run the primary Imagewoof matrix first, review the JSON, then paste the `summarize_grand.py --markdown` table here. Do not hand-write numbers.

--- a/benchmarks/dataset_loaders.py
+++ b/benchmarks/dataset_loaders.py
@@ -1,0 +1,530 @@
+"""Unified dataset loader registry for the grand benchmark.
+
+Every loader returns ``(train_loader, selection_val_loader, held_out_test_loader)``
+as a 3-tuple of DataLoaders whose datasets are wrapped with ``_IndexedDataset``.
+
+Supported datasets
+------------------
+imagewoof, pets, flowers102, dtd, aircraft, eurosat
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Path bootstrapping
+# ---------------------------------------------------------------------------
+
+_BENCHMARKS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _BENCHMARKS_DIR.parent
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_IMAGEWOOF_URL = "https://s3.amazonaws.com/fast-ai-imageclas/imagewoof2-160.tgz"
+_IMAGEWOOF_DIRNAME = "imagewoof2-160"
+
+
+def _balanced_subset(dataset: Any, n_per_class: int | None, seed: int) -> Any:
+    """Return a class-balanced Subset with at most *n_per_class* samples each."""
+    if n_per_class is None:
+        return dataset
+
+    from torch.utils.data import Subset
+
+    targets = _get_targets(dataset)
+    by_class: dict[int, list[int]] = {}
+    for idx, target in enumerate(targets):
+        by_class.setdefault(int(target), []).append(idx)
+
+    rng = random.Random(seed)
+    chosen: list[int] = []
+    for _cls, idxs in sorted(by_class.items()):
+        pool = idxs[:]
+        rng.shuffle(pool)
+        chosen.extend(pool[:n_per_class])
+    chosen.sort()
+    return Subset(dataset, chosen)
+
+
+def _split_dataset_50_50(dataset: Any) -> tuple[Any, Any]:
+    """Split a dataset 50/50 per class (deterministic, sorted-index).
+
+    Returns ``(selection_val_subset, held_out_test_subset)``.
+    """
+    from torch.utils.data import Subset
+
+    targets = _get_targets(dataset)
+    by_class: dict[int, list[int]] = {}
+    for idx, target in enumerate(targets):
+        by_class.setdefault(int(target), []).append(idx)
+
+    selection_indices: list[int] = []
+    held_out_indices: list[int] = []
+    for _cls, idxs in sorted(by_class.items()):
+        sorted_idxs = sorted(idxs)
+        split_point = len(sorted_idxs) // 2
+        selection_indices.extend(sorted_idxs[:split_point])
+        held_out_indices.extend(sorted_idxs[split_point:])
+
+    selection_indices.sort()
+    held_out_indices.sort()
+    return Subset(dataset, selection_indices), Subset(dataset, held_out_indices)
+
+
+def _get_targets(dataset: Any) -> list[int]:
+    """Extract class labels from a dataset.  Tries common attribute names first."""
+    # Standard torchvision datasets
+    for attr in ("targets", "_labels"):
+        val = getattr(dataset, attr, None)
+        if val is not None:
+            return [int(t) for t in val]
+    # Wrapped Subset
+    if hasattr(dataset, "dataset") and hasattr(dataset, "indices"):
+        inner_targets = _get_targets(dataset.dataset)
+        return [inner_targets[i] for i in dataset.indices]
+    # Last resort: iterate (slow for large datasets)
+    return [int(dataset[i][1]) for i in range(len(dataset))]  # type: ignore[arg-type]
+
+
+def _train_transform(img_size: int, policy: str, is_eurosat: bool = False):
+    """Build a training transform for the given augmentation policy."""
+    from torchvision import transforms
+
+    base = [
+        transforms.RandomResizedCrop(img_size, scale=(0.5, 1.0)),
+        transforms.RandomHorizontalFlip(),
+    ]
+    if policy == "randaugment":
+        base.append(transforms.RandAugment())
+    elif policy == "trivialaugment":
+        base.append(transforms.TrivialAugmentWide())
+    elif policy == "autoaugment":
+        base.append(transforms.AutoAugment(transforms.AutoAugmentPolicy.IMAGENET))
+    elif policy != "base":
+        raise ValueError(f"Unknown policy {policy!r}")
+    base.append(transforms.ToTensor())
+    return transforms.Compose(base)
+
+
+def _val_transform(img_size: int, is_eurosat: bool = False):
+    """Build the standard val/test transform."""
+    from torchvision import transforms
+
+    if is_eurosat:
+        # EuroSAT images are 64 px native; no over-enlargement
+        return transforms.Compose([
+            transforms.Resize(img_size),
+            transforms.CenterCrop(img_size),
+            transforms.ToTensor(),
+        ])
+    return transforms.Compose([
+        transforms.Resize(int(img_size * 1.14)),
+        transforms.CenterCrop(img_size),
+        transforms.ToTensor(),
+    ])
+
+
+def _make_loaders(
+    train_ds: Any,
+    selection_val_ds: Any,
+    held_out_test_ds: Any,
+    *,
+    batch_size: int,
+    seed: int,
+    num_workers: int = 2,
+) -> tuple[Any, Any, Any]:
+    """Wrap datasets in _IndexedDataset and return DataLoaders."""
+    import torch
+    from torch.utils.data import DataLoader
+
+    from bnnr.pipelines import _IndexedDataset
+
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+
+    train_loader = DataLoader(
+        _IndexedDataset(train_ds),
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        generator=generator,
+    )
+    selection_val_loader = DataLoader(
+        _IndexedDataset(selection_val_ds),
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+    )
+    held_out_test_loader = DataLoader(
+        _IndexedDataset(held_out_test_ds),
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+    )
+    return train_loader, selection_val_loader, held_out_test_loader
+
+
+# ---------------------------------------------------------------------------
+# Per-dataset loaders
+# ---------------------------------------------------------------------------
+
+
+def _imagewoof_loaders(
+    *,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+    policy: str,
+    n_per_class_train: int | None,
+    data_dir: Path,
+    num_workers: int = 2,
+) -> tuple[Any, Any, Any]:
+    from torchvision.datasets import ImageFolder
+    from torchvision.datasets.utils import download_and_extract_archive
+
+    root = data_dir / _IMAGEWOOF_DIRNAME
+    if not (root / "train").is_dir() or not (root / "val").is_dir():
+        data_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Downloading Imagewoof2 (160px) -> {data_dir} ...", flush=True)
+        try:
+            download_and_extract_archive(_IMAGEWOOF_URL, download_root=str(data_dir))
+        except Exception as exc:
+            print(f"Download failed: {exc}")
+            raise
+        if not (root / "train").is_dir():
+            raise FileNotFoundError(
+                f"Expected {root}/train after extraction; got {list(data_dir.iterdir())}"
+            )
+
+    train_ds = ImageFolder(str(root / "train"), transform=_train_transform(img_size, policy))
+    val_ds_full = ImageFolder(str(root / "val"), transform=_val_transform(img_size))
+
+    train_ds = _balanced_subset(train_ds, n_per_class_train, seed)
+    selection_val_ds, held_out_test_ds = _split_dataset_50_50(val_ds_full)
+
+    return _make_loaders(
+        train_ds, selection_val_ds, held_out_test_ds,
+        batch_size=batch_size, seed=seed, num_workers=num_workers,
+    )
+
+
+def _pets_loaders(
+    *,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+    policy: str,
+    n_per_class_train: int | None,
+    data_dir: Path,
+    num_workers: int = 2,
+) -> tuple[Any, Any, Any]:
+    from torchvision.datasets import OxfordIIITPet
+
+    train_tf = _train_transform(img_size, policy)
+    val_tf = _val_transform(img_size)
+
+    try:
+        trainval_ds = OxfordIIITPet(
+            str(data_dir), split="trainval", download=True, transform=train_tf,
+        )
+        test_ds = OxfordIIITPet(
+            str(data_dir), split="test", download=True, transform=val_tf,
+        )
+    except Exception as exc:
+        print(f"OxfordIIITPet download failed: {exc}")
+        raise
+
+    # Get targets for trainval: try _labels then fallback
+    trainval_targets = _get_targets(trainval_ds)
+
+    # Build a balanced training subset
+    # Then the remaining trainval images form selection_val
+    if n_per_class_train is not None:
+        from torch.utils.data import Subset
+
+        by_class: dict[int, list[int]] = {}
+        for idx, target in enumerate(trainval_targets):
+            by_class.setdefault(int(target), []).append(idx)
+
+        rng = random.Random(seed)
+        train_indices: list[int] = []
+        val_indices: list[int] = []
+        for _cls, idxs in sorted(by_class.items()):
+            pool = idxs[:]
+            rng.shuffle(pool)
+            train_indices.extend(pool[:n_per_class_train])
+            val_indices.extend(pool[n_per_class_train:])
+        train_indices.sort()
+        val_indices.sort()
+
+        train_ds = Subset(trainval_ds, train_indices)
+        # selection_val uses val transform
+        trainval_val_ds = OxfordIIITPet(
+            str(data_dir), split="trainval", download=False, transform=val_tf,
+        )
+        selection_val_ds = Subset(trainval_val_ds, val_indices)
+    else:
+        # No subsetting: use trainval 50/50 split for selection_val
+        trainval_val_ds = OxfordIIITPet(
+            str(data_dir), split="trainval", download=False, transform=val_tf,
+        )
+        train_ds = trainval_ds
+        selection_val_ds, _ = _split_dataset_50_50(trainval_val_ds)
+
+    held_out_test_ds = test_ds
+
+    return _make_loaders(
+        train_ds, selection_val_ds, held_out_test_ds,
+        batch_size=batch_size, seed=seed, num_workers=num_workers,
+    )
+
+
+def _flowers102_loaders(
+    *,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+    policy: str,
+    n_per_class_train: int | None,
+    data_dir: Path,
+    num_workers: int = 2,
+) -> tuple[Any, Any, Any]:
+    from torchvision.datasets import Flowers102
+
+    train_tf = _train_transform(img_size, policy)
+    val_tf = _val_transform(img_size)
+
+    try:
+        train_ds = Flowers102(str(data_dir), split="train", download=True, transform=train_tf)
+        selection_val_ds = Flowers102(str(data_dir), split="val", download=True, transform=val_tf)
+        held_out_test_ds = Flowers102(str(data_dir), split="test", download=True, transform=val_tf)
+    except Exception as exc:
+        print(f"Flowers102 download failed: {exc}")
+        raise
+
+    # Natural splits already have ~10/class in train; subsetting only if requested
+    if n_per_class_train is not None:
+        train_ds = _balanced_subset(train_ds, n_per_class_train, seed)
+
+    return _make_loaders(
+        train_ds, selection_val_ds, held_out_test_ds,
+        batch_size=batch_size, seed=seed, num_workers=num_workers,
+    )
+
+
+def _dtd_loaders(
+    *,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+    policy: str,
+    n_per_class_train: int | None,
+    data_dir: Path,
+    num_workers: int = 2,
+) -> tuple[Any, Any, Any]:
+    from torchvision.datasets import DTD
+
+    train_tf = _train_transform(img_size, policy)
+    val_tf = _val_transform(img_size)
+
+    try:
+        train_ds = DTD(str(data_dir), split="train", partition=1, download=True, transform=train_tf)
+        selection_val_ds = DTD(str(data_dir), split="val", partition=1, download=True, transform=val_tf)
+        held_out_test_ds = DTD(str(data_dir), split="test", partition=1, download=True, transform=val_tf)
+    except Exception as exc:
+        print(f"DTD download failed: {exc}")
+        raise
+
+    if n_per_class_train is not None:
+        train_ds = _balanced_subset(train_ds, n_per_class_train, seed)
+
+    return _make_loaders(
+        train_ds, selection_val_ds, held_out_test_ds,
+        batch_size=batch_size, seed=seed, num_workers=num_workers,
+    )
+
+
+def _aircraft_loaders(
+    *,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+    policy: str,
+    n_per_class_train: int | None,
+    data_dir: Path,
+    num_workers: int = 2,
+) -> tuple[Any, Any, Any]:
+    from torchvision.datasets import FGVCAircraft
+
+    train_tf = _train_transform(img_size, policy)
+    val_tf = _val_transform(img_size)
+
+    try:
+        train_ds = FGVCAircraft(
+            str(data_dir), split="train", annotation_level="variant",
+            download=True, transform=train_tf,
+        )
+        selection_val_ds = FGVCAircraft(
+            str(data_dir), split="val", annotation_level="variant",
+            download=True, transform=val_tf,
+        )
+        held_out_test_ds = FGVCAircraft(
+            str(data_dir), split="test", annotation_level="variant",
+            download=True, transform=val_tf,
+        )
+    except Exception as exc:
+        print(f"FGVCAircraft download failed: {exc}")
+        raise
+
+    if n_per_class_train is not None:
+        train_ds = _balanced_subset(train_ds, n_per_class_train, seed)
+
+    return _make_loaders(
+        train_ds, selection_val_ds, held_out_test_ds,
+        batch_size=batch_size, seed=seed, num_workers=num_workers,
+    )
+
+
+def _eurosat_loaders(
+    *,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+    policy: str,
+    n_per_class_train: int | None,
+    data_dir: Path,
+    num_workers: int = 2,
+) -> tuple[Any, Any, Any]:
+    from torchvision.datasets import EuroSAT
+
+    train_tf = _train_transform(img_size, policy, is_eurosat=True)
+    val_tf = _val_transform(img_size, is_eurosat=True)
+
+    try:
+        full_ds_train = EuroSAT(str(data_dir), download=True, transform=train_tf)
+        full_ds_val = EuroSAT(str(data_dir), download=False, transform=val_tf)
+    except Exception as exc:
+        print(f"EuroSAT download failed: {exc}")
+        raise
+
+    from torch.utils.data import Subset
+
+    targets = _get_targets(full_ds_train)
+    by_class: dict[int, list[int]] = {}
+    for idx, target in enumerate(targets):
+        by_class.setdefault(int(target), []).append(idx)
+
+    n_train = n_per_class_train if n_per_class_train is not None else 100
+    rng = random.Random(seed)
+
+    train_indices: list[int] = []
+    remainder_indices: list[int] = []
+    for _cls, idxs in sorted(by_class.items()):
+        pool = sorted(idxs)  # deterministic within class
+        rng_pool = pool[:]
+        rng.shuffle(rng_pool)
+        train_indices.extend(rng_pool[:n_train])
+        remainder_indices.extend(sorted(rng_pool[n_train:]))
+
+    train_indices.sort()
+    remainder_indices.sort()
+
+    # Split remainder 50/50 per class (deterministic)
+    rem_by_class: dict[int, list[int]] = {}
+    rem_targets = [targets[i] for i in remainder_indices]
+    for idx, target in zip(remainder_indices, rem_targets):
+        rem_by_class.setdefault(int(target), []).append(idx)
+
+    selection_indices: list[int] = []
+    held_out_indices: list[int] = []
+    for _cls, idxs in sorted(rem_by_class.items()):
+        sorted_idxs = sorted(idxs)
+        split_point = len(sorted_idxs) // 2
+        selection_indices.extend(sorted_idxs[:split_point])
+        held_out_indices.extend(sorted_idxs[split_point:])
+
+    selection_indices.sort()
+    held_out_indices.sort()
+
+    train_ds = Subset(full_ds_train, train_indices)
+    selection_val_ds = Subset(full_ds_val, selection_indices)
+    held_out_test_ds = Subset(full_ds_val, held_out_indices)
+
+    return _make_loaders(
+        train_ds, selection_val_ds, held_out_test_ds,
+        batch_size=batch_size, seed=seed, num_workers=num_workers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_LOADER_MAP = {
+    "imagewoof": _imagewoof_loaders,
+    "pets": _pets_loaders,
+    "flowers102": _flowers102_loaders,
+    "dtd": _dtd_loaders,
+    "aircraft": _aircraft_loaders,
+    "eurosat": _eurosat_loaders,
+}
+
+SUPPORTED_DATASETS = tuple(_LOADER_MAP.keys())
+
+
+def get_loaders(
+    dataset: str,
+    *,
+    img_size: int,
+    batch_size: int,
+    seed: int,
+    policy: str,
+    n_per_class_train: int | None,
+    data_dir: Path,
+    num_workers: int = 2,
+) -> tuple[Any, Any, Any]:
+    """Return ``(train_loader, selection_val_loader, held_out_test_loader)``.
+
+    Parameters
+    ----------
+    dataset:
+        One of ``imagewoof | pets | flowers102 | dtd | aircraft | eurosat``.
+    img_size:
+        Square resize/crop target (dataset-specific default in
+        ``run_grand_benchmark.DATASET_DEFAULTS``).
+    batch_size:
+        DataLoader batch size.
+    seed:
+        Random seed for balanced subsetting and DataLoader generator.
+    policy:
+        Train augmentation policy: ``base | randaugment | trivialaugment | autoaugment``.
+    n_per_class_train:
+        Balanced samples per class in the training split.  ``None`` = all.
+    data_dir:
+        Root directory where datasets are downloaded/cached.
+    num_workers:
+        DataLoader worker count.  Use 0 in smoke/debug mode.
+    """
+    if dataset not in _LOADER_MAP:
+        raise ValueError(
+            f"Unknown dataset {dataset!r}. "
+            f"Supported: {', '.join(SUPPORTED_DATASETS)}"
+        )
+    loader_fn = _LOADER_MAP[dataset]
+    return loader_fn(
+        img_size=img_size,
+        batch_size=batch_size,
+        seed=seed,
+        policy=policy,
+        n_per_class_train=n_per_class_train,
+        data_dir=data_dir,
+        num_workers=num_workers,
+    )

--- a/benchmarks/metrics_extended.py
+++ b/benchmarks/metrics_extended.py
@@ -1,0 +1,295 @@
+"""Extended metrics for the grand benchmark.
+
+All functions take a PyTorch model/loader and return plain ``dict[str, float]``.
+No sklearn required — implemented from scratch with PyTorch + numpy.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+
+# ---------------------------------------------------------------------------
+# Classification metrics
+# ---------------------------------------------------------------------------
+
+
+def compute_classification_metrics(
+    model: nn.Module,
+    loader: DataLoader,
+    num_classes: int,
+    device: str,
+    top_k: int = 5,
+) -> dict[str, float]:
+    """Compute accuracy, f1_macro, top5_accuracy, cohen_kappa, ece.
+
+    Parameters
+    ----------
+    model:
+        PyTorch model in eval mode (called with model.eval() internally).
+    loader:
+        DataLoader whose batches are ``(images, labels, ...)``.
+    num_classes:
+        Number of output classes.
+    device:
+        Torch device string.
+    top_k:
+        k for top-k accuracy; skipped if ``num_classes < top_k``.
+
+    Returns
+    -------
+    dict with keys: accuracy, f1_macro, top5_accuracy (if applicable),
+    cohen_kappa, ece.
+    """
+    model.eval()
+    all_preds: list[torch.Tensor] = []
+    all_labels: list[torch.Tensor] = []
+    all_probs: list[torch.Tensor] = []
+
+    with torch.no_grad():
+        for batch in loader:
+            # Batch may be (images, labels) or (images, labels, indices)
+            imgs = batch[0].to(device)
+            labels = batch[1]
+            logits = model(imgs)
+            probs = torch.softmax(logits, dim=1).cpu()
+            preds = logits.argmax(dim=1).cpu()
+            all_preds.append(preds)
+            all_labels.append(labels if isinstance(labels, torch.Tensor) else torch.tensor(labels))
+            all_probs.append(probs)
+
+    if not all_preds:
+        return {"accuracy": 0.0, "f1_macro": 0.0, "cohen_kappa": 0.0, "ece": 0.0}
+
+    preds_t = torch.cat(all_preds)          # (N,)
+    labels_t = torch.cat(all_labels)        # (N,)
+    probs_t = torch.cat(all_probs)          # (N, C)
+    n_total = len(labels_t)
+
+    # --- accuracy ---
+    correct = (preds_t == labels_t).sum().item()
+    accuracy = correct / n_total
+
+    # --- f1_macro ---
+    f1_macro = _f1_macro(preds_t, labels_t, num_classes)
+
+    # --- top-k accuracy ---
+    result: dict[str, float] = {
+        "accuracy": float(accuracy),
+        "f1_macro": float(f1_macro),
+    }
+    if num_classes >= top_k:
+        topk_correct = _topk_correct(probs_t, labels_t, k=top_k)
+        result["top5_accuracy"] = float(topk_correct / n_total)
+
+    # --- cohen_kappa ---
+    result["cohen_kappa"] = float(_cohen_kappa(preds_t, labels_t, num_classes))
+
+    # --- ECE (10 bins) ---
+    result["ece"] = float(_ece(probs_t, labels_t, n_bins=10))
+
+    return result
+
+
+def _f1_macro(preds: torch.Tensor, labels: torch.Tensor, num_classes: int) -> float:
+    """Macro-averaged F1 from per-class precision and recall."""
+    f1_scores: list[float] = []
+    for c in range(num_classes):
+        tp = ((preds == c) & (labels == c)).sum().item()
+        fp = ((preds == c) & (labels != c)).sum().item()
+        fn = ((preds != c) & (labels == c)).sum().item()
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        if precision + recall > 0:
+            f1 = 2.0 * precision * recall / (precision + recall)
+        else:
+            f1 = 0.0
+        f1_scores.append(f1)
+    return float(np.mean(f1_scores)) if f1_scores else 0.0
+
+
+def _topk_correct(probs: torch.Tensor, labels: torch.Tensor, k: int) -> int:
+    """Count top-k correct predictions."""
+    top_k_preds = probs.topk(k, dim=1).indices  # (N, k)
+    labels_expanded = labels.unsqueeze(1).expand_as(top_k_preds)
+    correct = (top_k_preds == labels_expanded).any(dim=1).sum().item()
+    return int(correct)
+
+
+def _cohen_kappa(preds: torch.Tensor, labels: torch.Tensor, num_classes: int) -> float:
+    """Cohen's kappa = (p_o - p_e) / (1 - p_e)."""
+    n = len(labels)
+    if n == 0:
+        return 0.0
+    p_o = (preds == labels).sum().item() / n  # observed agreement
+
+    # p_e = sum over classes of (P(actual=k) * P(predicted=k))
+    p_e = 0.0
+    for c in range(num_classes):
+        p_actual = (labels == c).sum().item() / n
+        p_predicted = (preds == c).sum().item() / n
+        p_e += p_actual * p_predicted
+
+    if (1.0 - p_e) < 1e-8:
+        return 1.0
+    return float((p_o - p_e) / (1.0 - p_e))
+
+
+def _ece(probs: torch.Tensor, labels: torch.Tensor, n_bins: int = 10) -> float:
+    """Expected Calibration Error with equal-width bins."""
+    confidences, preds = probs.max(dim=1)
+    correct = (preds == labels).float()
+
+    conf_np = confidences.numpy()
+    correct_np = correct.numpy()
+
+    ece_val = 0.0
+    n_total = len(conf_np)
+    bin_edges = np.linspace(0.0, 1.0, n_bins + 1)
+
+    for i in range(n_bins):
+        lo, hi = bin_edges[i], bin_edges[i + 1]
+        mask = (conf_np >= lo) & (conf_np < hi)
+        if i == n_bins - 1:  # include right edge for last bin
+            mask = (conf_np >= lo) & (conf_np <= hi)
+        n_bin = mask.sum()
+        if n_bin == 0:
+            continue
+        acc_bin = float(correct_np[mask].mean())
+        conf_bin = float(conf_np[mask].mean())
+        ece_val += (n_bin / n_total) * abs(conf_bin - acc_bin)
+
+    return float(ece_val)
+
+
+# ---------------------------------------------------------------------------
+# XAI metrics
+# ---------------------------------------------------------------------------
+
+
+def compute_xai_metrics(
+    adapter: Any,
+    loader: DataLoader,
+    sample_indices: list[int],
+    device: str,
+    method: str = "opticam",
+) -> dict[str, float]:
+    """Compute XAI quality metrics over a set of sample indices.
+
+    Parameters
+    ----------
+    adapter:
+        A ``SimpleTorchAdapter``-compatible object with ``get_model()`` and
+        ``get_target_layers()`` methods.
+    loader:
+        DataLoader used to retrieve images by dataset index.
+    sample_indices:
+        Dataset-level indices of the images to analyse.
+    device:
+        Torch device string.
+    method:
+        XAI method passed to ``generate_saliency_maps`` (default: opticam).
+
+    Returns
+    -------
+    dict with keys: edge_ratio, coverage, gini_coefficient, entropy,
+    center_bias.  Returns all-zero dict if no valid samples.
+    """
+    from bnnr.xai import generate_saliency_maps
+    from bnnr.xai_analysis import analyze_saliency_map
+
+    empty = {
+        "xai_edge_ratio": 0.0,
+        "xai_coverage": 0.0,
+        "xai_gini": 0.0,
+        "xai_entropy": 0.0,
+        "xai_center_bias": 0.0,
+    }
+
+    dataset = getattr(loader, "dataset", None)
+    if dataset is None:
+        return empty
+
+    images_t: list[torch.Tensor] = []
+    labels_t: list[torch.Tensor] = []
+    used_indices: list[int] = []
+
+    for ds_idx in sample_indices:
+        try:
+            sample = dataset[ds_idx]
+        except (IndexError, KeyError):
+            continue
+        img = sample[0] if isinstance(sample, (list, tuple)) else sample
+        lbl = sample[1] if isinstance(sample, (list, tuple)) and len(sample) > 1 else 0
+        if not isinstance(img, torch.Tensor):
+            continue
+        images_t.append(img.unsqueeze(0))
+        lbl_val = int(lbl.item()) if isinstance(lbl, torch.Tensor) else int(lbl)
+        labels_t.append(torch.tensor(lbl_val).view(1))
+        used_indices.append(ds_idx)
+
+    if not images_t:
+        return empty
+
+    images_batch = torch.cat(images_t, dim=0)
+    labels_batch = torch.cat(labels_t, dim=0)
+    model = adapter.get_model()
+    target_layers = adapter.get_target_layers()
+    model_device = next(model.parameters()).device
+    model.eval()
+
+    try:
+        maps = generate_saliency_maps(
+            model,
+            images_batch.to(model_device),
+            labels_batch.to(model_device),
+            target_layers,
+            method=method,
+        )
+    except Exception:
+        return empty
+
+    per_sample: list[dict[str, float]] = []
+    center_biases: list[float] = []
+    for map_2d in maps:
+        stats = analyze_saliency_map(map_2d)
+        per_sample.append(stats)
+        center_biases.append(_center_bias(map_2d))
+
+    def _mean(key: str) -> float:
+        vals = [float(s.get(key, 0.0)) for s in per_sample]
+        return float(np.mean(vals)) if vals else 0.0
+
+    return {
+        "xai_edge_ratio": _mean("edge_ratio"),
+        "xai_coverage": _mean("coverage"),
+        "xai_gini": _mean("gini"),
+        "xai_entropy": _mean("entropy"),
+        "xai_center_bias": float(np.mean(center_biases)) if center_biases else 0.0,
+    }
+
+
+def _center_bias(map_2d: np.ndarray) -> float:
+    """Fraction of total saliency mass in the central 50% of the image."""
+    h, w = map_2d.shape
+    total = float(map_2d.sum())
+    if total <= 1e-8:
+        return 0.0
+    # Central 50%: crop out the outer 25% on each side
+    h_lo = h // 4
+    h_hi = h - h // 4
+    w_lo = w // 4
+    w_hi = w - w // 4
+    center_mass = float(map_2d[h_lo:h_hi, w_lo:w_hi].sum())
+    return center_mass / total

--- a/benchmarks/run_grand_benchmark.py
+++ b/benchmarks/run_grand_benchmark.py
@@ -1,0 +1,1595 @@
+#!/usr/bin/env python3
+"""Grand benchmark for BNNR — 6 datasets × 2 regimes, paper-quality, equal-compute.
+
+This script proves the core BNNR claims:
+  - ICD/AICD individually improve accuracy vs no_aug
+  - XAI-guided selection (bnnr_xai) > random selection (bnnr_random)
+  - Branch search > best single augmentation
+  - Results generalise across datasets
+
+Conditions (10 total)
+---------------------
+    no_aug            RandomResizedCrop + flip only, B epochs
+    randaugment       + torchvision RandAugment, B epochs
+    trivialaugment    + torchvision TrivialAugmentWide, B epochs
+    autoaugment       + torchvision AutoAugment (ImageNet policy), B epochs
+    churchnoise_only  ChurchNoise as always-on batch aug, B epochs
+    icd_only          ICD as always-on batch aug, B epochs
+    aicd_only         AICD as always-on batch aug, B epochs
+    icd_aicd_fixed    ICD+AICD together, no search, B epochs
+    bnnr_random       Branch search, random candidate selection, equal compute B
+    bnnr_xai          Branch search, XAI-guided selection, equal compute B
+
+Datasets
+--------
+    imagewoof, pets, flowers102, dtd, aircraft, eurosat
+
+Examples
+--------
+    # Smoke test — CPU-friendly, runs in seconds
+    python benchmarks/run_grand_benchmark.py --dataset imagewoof --smoke --dry-run
+
+    # Full imagewoof benchmark (10 seeds, GPU)
+    python benchmarks/run_grand_benchmark.py --dataset imagewoof \\
+        --seeds 42,43,44,45,46,47,48,49,50,51 --device cuda
+
+    # Generalization dataset (7 seeds)
+    python benchmarks/run_grand_benchmark.py --dataset pets --device cuda
+
+    # Summarize
+    python benchmarks/summarize_grand.py --results-dir benchmarks/
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import random
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Path bootstrapping
+# ---------------------------------------------------------------------------
+
+BENCHMARKS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = BENCHMARKS_DIR.parent
+if str(BENCHMARKS_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCHMARKS_DIR))
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from lib import (  # noqa: E402
+    ConditionSpec,
+    _make_run_dir,
+    _result_entry,
+    _run_config,
+    export_attention_maps,
+    git_head,
+    load_results,
+    save_results,
+    torch_info,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+N_CANDIDATES = 3
+_CANDIDATE_NAMES = ["ICD", "AICD", "ChurchNoise"]
+
+# Indices into held_out_test loader for XAI overlay export
+_XAI_SAMPLE_INDICES = [0, 50, 100, 150, 200, 250]
+
+# ---------------------------------------------------------------------------
+# Dataset-specific defaults
+# ---------------------------------------------------------------------------
+
+DATASET_DEFAULTS: dict[str, dict[str, Any]] = {
+    "imagewoof": {"img_size": 128, "train_per_class": 100, "num_classes": 10},
+    "pets":      {"img_size": 224, "train_per_class": 100, "num_classes": 37},
+    "flowers102":{"img_size": 224, "train_per_class": 10,  "num_classes": 102},
+    "dtd":       {"img_size": 224, "train_per_class": 120, "num_classes": 47},
+    "aircraft":  {"img_size": 224, "train_per_class": 33,  "num_classes": 100},
+    "eurosat":   {"img_size": 64,  "train_per_class": 100, "num_classes": 10},
+}
+
+# Default conditions per dataset
+_GENERALIZATION_CONDITIONS = [
+    "no_aug", "randaugment", "icd_only", "aicd_only", "bnnr_random", "bnnr_xai",
+]
+
+DATASET_DEFAULT_CONDITIONS: dict[str, list[str]] = {
+    "imagewoof": [
+        "no_aug", "randaugment", "trivialaugment", "autoaugment",
+        "churchnoise_only", "icd_only", "aicd_only", "icd_aicd_fixed",
+        "bnnr_random", "bnnr_xai",
+    ],
+    "pets":      _GENERALIZATION_CONDITIONS,
+    "flowers102":_GENERALIZATION_CONDITIONS,
+    "dtd":       _GENERALIZATION_CONDITIONS,
+    "aircraft":  _GENERALIZATION_CONDITIONS,
+    "eurosat":   _GENERALIZATION_CONDITIONS,
+}
+
+# Default seeds per dataset
+DATASET_DEFAULT_SEEDS: dict[str, list[int]] = {
+    "imagewoof": list(range(42, 52)),  # 10 seeds
+    "pets":      list(range(42, 49)),  # 7 seeds
+    "flowers102":list(range(42, 49)),
+    "dtd":       list(range(42, 49)),
+    "aircraft":  list(range(42, 49)),
+    "eurosat":   list(range(42, 49)),
+}
+
+# ---------------------------------------------------------------------------
+# Conditions registry
+# ---------------------------------------------------------------------------
+
+CONDITIONS: dict[str, ConditionSpec] = {
+    "no_aug": ConditionSpec(
+        id="no_aug",
+        label="Without augmentation (crop + flip only)",
+        strategy="plain_training",
+        description=(
+            "Standard from-scratch training: RandomResizedCrop + RandomHorizontalFlip. "
+            "No extra augmentation, no branch search. Trained for B epochs straight."
+        ),
+        augmentation_names=(),
+        max_iterations=0,
+    ),
+    "randaugment": ConditionSpec(
+        id="randaugment",
+        label="RandAugment (torchvision)",
+        strategy="randaugment",
+        description=(
+            "External baseline: base crop+flip + torchvision RandAugment. "
+            "Policy-based random augmentation, no saliency guidance. B epochs straight."
+        ),
+        augmentation_names=("RandAugment",),
+        max_iterations=0,
+    ),
+    "trivialaugment": ConditionSpec(
+        id="trivialaugment",
+        label="TrivialAugmentWide (torchvision)",
+        strategy="trivialaugment",
+        description=(
+            "External baseline: base crop+flip + TrivialAugmentWide. "
+            "Parameter-free random augmentation. B epochs straight."
+        ),
+        augmentation_names=("TrivialAugmentWide",),
+        max_iterations=0,
+    ),
+    "autoaugment": ConditionSpec(
+        id="autoaugment",
+        label="AutoAugment ImageNet (torchvision)",
+        strategy="plain_training",
+        description=(
+            "External baseline: base crop+flip + AutoAugment (ImageNet policy). "
+            "Searched augmentation policy. B epochs straight."
+        ),
+        augmentation_names=("AutoAugment",),
+        max_iterations=0,
+    ),
+    "churchnoise_only": ConditionSpec(
+        id="churchnoise_only",
+        label="ChurchNoise only (non-XAI ablation)",
+        strategy="plain_training",
+        description=(
+            "Ablation: ChurchNoise as always-on batch augmentation for B epochs. "
+            "Isolates the non-XAI BNNR component."
+        ),
+        augmentation_names=("ChurchNoise",),
+        max_iterations=0,
+    ),
+    "icd_only": ConditionSpec(
+        id="icd_only",
+        label="ICD only (saliency ablation)",
+        strategy="plain_training",
+        description=(
+            "Ablation: ICD as always-on batch augmentation for B epochs. "
+            "Masks high-saliency regions. No branch search."
+        ),
+        augmentation_names=("ICD",),
+        max_iterations=0,
+    ),
+    "aicd_only": ConditionSpec(
+        id="aicd_only",
+        label="AICD only (saliency ablation)",
+        strategy="plain_training",
+        description=(
+            "Ablation: AICD as always-on batch augmentation for B epochs. "
+            "Masks background (low-saliency) regions. No branch search."
+        ),
+        augmentation_names=("AICD",),
+        max_iterations=0,
+    ),
+    "icd_aicd_fixed": ConditionSpec(
+        id="icd_aicd_fixed",
+        label="ICD+AICD fixed (no search)",
+        strategy="plain_training",
+        description=(
+            "Ablation: ICD and AICD together as always-on batch augmentation. "
+            "No branch search — isolates search contribution."
+        ),
+        augmentation_names=("ICD", "AICD"),
+        max_iterations=0,
+    ),
+    "bnnr_xai": ConditionSpec(
+        id="bnnr_xai",
+        label="BNNR XAI-guided (equal compute)",
+        strategy="bnnr_branch_search",
+        description=(
+            "BNNR branch search with XAI-guided candidate selection. "
+            "Equal compute: B epochs total split into (1 + N_candidates) phases. "
+            "Candidate with highest selection_val score is chosen."
+        ),
+        augmentation_names=("ICD", "AICD", "ChurchNoise"),
+        max_iterations=N_CANDIDATES,
+    ),
+    "bnnr_random": ConditionSpec(
+        id="bnnr_random",
+        label="BNNR random selection (XAI ablation)",
+        strategy="bnnr_branch_search",
+        description=(
+            "BNNR branch search with RANDOM candidate selection (seed-controlled). "
+            "Identical compute and augmentation pool as bnnr_xai. "
+            "bnnr_xai vs bnnr_random isolates XAI-guided selection contribution."
+        ),
+        augmentation_names=("ICD", "AICD", "ChurchNoise"),
+        max_iterations=N_CANDIDATES,
+    ),
+}
+
+_POLICY_BY_CONDITION = {
+    "no_aug": "base",
+    "randaugment": "randaugment",
+    "trivialaugment": "trivialaugment",
+    "autoaugment": "autoaugment",
+    "churchnoise_only": "base",
+    "icd_only": "base",
+    "aicd_only": "base",
+    "icd_aicd_fixed": "base",
+}
+
+# ---------------------------------------------------------------------------
+# Model builder
+# ---------------------------------------------------------------------------
+
+
+def _build_resnet(arch: str, num_classes: int, pretrained: bool) -> Any:
+    """torchvision ResNet with ImageNet normalization baked in."""
+    import torch
+    from torch import nn
+    from torchvision import models
+
+    if arch == "resnet18":
+        weights = models.ResNet18_Weights.IMAGENET1K_V1 if pretrained else None
+        backbone = models.resnet18(weights=weights)
+    elif arch == "resnet50":
+        weights = models.ResNet50_Weights.IMAGENET1K_V2 if pretrained else None
+        backbone = models.resnet50(weights=weights)
+    else:
+        raise ValueError(f"Unsupported arch {arch!r} (use resnet18 or resnet50)")
+
+    backbone.fc = nn.Linear(backbone.fc.in_features, num_classes)
+
+    class _NormalizedResNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.backbone = backbone
+            self.register_buffer("mean", torch.tensor(_IMAGENET_MEAN).view(1, 3, 1, 1))
+            self.register_buffer("std", torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1))
+
+        def forward(self, x: Any) -> Any:
+            x = (x - self.mean) / self.std
+            return self.backbone(x)
+
+    return _NormalizedResNet()
+
+
+def _target_layers(model: Any) -> list[Any]:
+    return [model.backbone.layer4[-1]]
+
+
+def _build_adapter(
+    *,
+    arch: str,
+    num_classes: int,
+    pretrained: bool,
+    lr: float,
+    device: str,
+    epochs: int,
+) -> Any:
+    import torch
+    from torch import nn
+
+    from bnnr.adapter import SimpleTorchAdapter
+
+    model = _build_resnet(arch, num_classes, pretrained)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(
+        model.parameters(), lr=lr, momentum=0.9, weight_decay=5e-4
+    )
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=max(1, epochs)
+    )
+    return SimpleTorchAdapter(
+        model=model,
+        criterion=criterion,
+        optimizer=optimizer,
+        target_layers=_target_layers(model),
+        device=device,
+        scheduler=scheduler,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config builder
+# ---------------------------------------------------------------------------
+
+
+def _base_config(*, epochs: int, device: str) -> Any:
+    from bnnr.config_model import BNNRConfig
+
+    return BNNRConfig(
+        task="classification",
+        device=device,
+        m_epochs=epochs,
+        selection_metric="accuracy",
+        metrics=["accuracy", "f1_macro", "loss"],
+        xai_method="opticam",
+        candidate_pruning_enabled=True,
+        candidate_pruning_relative_threshold=0.8,
+        candidate_pruning_warmup_epochs=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core training helper
+# ---------------------------------------------------------------------------
+
+
+def _run_epochs_on_loader(
+    *,
+    adapter: Any,
+    train_loader: Any,
+    eval_loader: Any,
+    augmentations: list[Any],
+    epochs: int,
+    selection_metric: str,
+    log_prefix: str = "",
+) -> tuple[dict[str, float], int, dict[str, Any] | None]:
+    """Train for *epochs* epochs; return (best_val_metrics, best_epoch, best_state)."""
+    from bnnr.core import BNNRTrainer
+    from bnnr.training.loop import evaluate, train_epoch
+
+    cfg_dummy = _base_config(epochs=epochs, device=adapter.device)
+    trainer = BNNRTrainer(adapter, train_loader, eval_loader, augmentations, cfg_dummy)
+
+    best_val: dict[str, float] = {}
+    best_epoch = 0
+    best_state: dict[str, Any] | None = None
+    sel = selection_metric
+
+    for epoch in range(1, epochs + 1):
+        train_epoch(trainer, train_loader, augmentations=augmentations if augmentations else None)
+        val_metrics = evaluate(trainer, eval_loader)
+        epoch_end_fn = getattr(adapter, "epoch_end", None)
+        if callable(epoch_end_fn):
+            epoch_end_fn()
+        score = float(val_metrics.get(sel, 0.0))
+        print(
+            f"  {log_prefix}epoch {epoch}/{epochs} — {sel}={score:.4f}  "
+            f"loss={val_metrics.get('loss', 0.0):.4f}",
+            flush=True,
+        )
+        if not best_val or score >= best_val.get(sel, -1.0):
+            best_val = copy.deepcopy(val_metrics)
+            best_epoch = epoch
+            best_state = copy.deepcopy(adapter.model.state_dict())
+
+    if best_state is not None:
+        adapter.model.load_state_dict(best_state)
+
+    return best_val, best_epoch, best_state
+
+
+# ---------------------------------------------------------------------------
+# Stamp helper
+# ---------------------------------------------------------------------------
+
+
+def _stamp(
+    entry: dict[str, Any],
+    *,
+    dataset: str,
+    arch: str,
+    img_size: int,
+    pretrained: bool,
+    regime: str,
+) -> dict[str, Any]:
+    """Override CIFAR-10 defaults baked into lib._result_entry."""
+    entry["dataset"] = dataset
+    entry["model"] = arch
+    entry["img_size"] = img_size
+    entry["pretrained"] = pretrained
+    entry["regime"] = regime
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Extended metrics helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_extended_metrics(
+    adapter: Any,
+    held_out_test_loader: Any,
+    num_classes: int,
+    device: str,
+    no_xai: bool,
+) -> dict[str, Any]:
+    """Run extended classification + XAI metrics; return flat dict."""
+    from metrics_extended import compute_classification_metrics, compute_xai_metrics
+
+    cls_metrics = compute_classification_metrics(
+        adapter.get_model(),
+        held_out_test_loader,
+        num_classes=num_classes,
+        device=device,
+        top_k=5,
+    )
+
+    if no_xai:
+        xai_metrics = {
+            "xai_edge_ratio": None,
+            "xai_coverage": None,
+            "xai_gini": None,
+            "xai_entropy": None,
+            "xai_center_bias": None,
+        }
+    else:
+        xai_metrics = compute_xai_metrics(
+            adapter,
+            held_out_test_loader,
+            sample_indices=_XAI_SAMPLE_INDICES,
+            device=device,
+            method="opticam",
+        )
+
+    return {
+        "test_accuracy": cls_metrics.get("accuracy"),
+        "test_f1_macro": cls_metrics.get("f1_macro"),
+        "test_top5_accuracy": cls_metrics.get("top5_accuracy"),
+        "test_cohen_kappa": cls_metrics.get("cohen_kappa"),
+        "test_ece": cls_metrics.get("ece"),
+        **xai_metrics,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Plain condition runner
+# ---------------------------------------------------------------------------
+
+
+def _run_plain_condition(
+    *,
+    condition: ConditionSpec,
+    policy: str,
+    extra_batch_augmentations: list[Any],
+    seed: int,
+    args: argparse.Namespace,
+    output_root: Path,
+    num_classes: int,
+    xai_cache: Any | None = None,
+) -> dict[str, Any]:
+    """Run a plain (non-BNNR-search) condition for B epochs, report on held_out_test."""
+    from dataset_loaders import get_loaders
+
+    from bnnr.utils import set_seed
+
+    run_dir = _make_run_dir(output_root, condition.id, seed)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    budget = args.budget
+    cfg = _base_config(epochs=budget, device=args.device)
+    cfg = _run_config(cfg, seed=seed, device=args.device, run_dir=run_dir, xai=False)
+
+    set_seed(seed)
+    num_workers = 0 if args.smoke else 2
+    train_loader, selection_val_loader, held_out_test_loader = get_loaders(
+        args.dataset,
+        img_size=args.img_size,
+        batch_size=args.batch_size,
+        seed=seed,
+        policy=policy,
+        n_per_class_train=args.train_per_class,
+        data_dir=args.data_dir,
+        num_workers=num_workers,
+    )
+
+    # For ICD/AICD conditions: pre-compute XAI cache if not already supplied
+    local_cache = xai_cache
+    if extra_batch_augmentations and local_cache is None and not args.no_xai:
+        # Check if any augmentation is ICD/AICD-based
+        needs_cache = any(
+            hasattr(aug, "cache") for aug in extra_batch_augmentations
+        )
+        if needs_cache:
+            local_cache = _precompute_xai_cache(
+                args=args,
+                seed=seed,
+                run_dir=run_dir,
+                num_classes=num_classes,
+                train_loader=train_loader,
+            )
+
+    aug_label = (
+        "+".join(a.name for a in extra_batch_augmentations)
+        if extra_batch_augmentations
+        else "none"
+    )
+    header = (
+        f"\n{'='*60}\n"
+        f"  {condition.id.upper()} (grand benchmark)\n"
+        f"  dataset={args.dataset}  policy={policy}  batch_augs={aug_label}\n"
+        f"  budget={budget} epochs  seed={seed}  device={cfg.device}\n"
+        f"{'='*60}"
+    )
+    print(header, flush=True)
+
+    # If augmentations reference a cache (ICD/AICD), replace the cache now
+    if local_cache is not None:
+        for aug in extra_batch_augmentations:
+            if hasattr(aug, "cache"):
+                aug.cache = local_cache
+
+    adapter = _build_adapter(
+        arch=args.arch,
+        num_classes=num_classes,
+        pretrained=args.pretrained,
+        lr=args.lr,
+        device=cfg.device,
+        epochs=budget,
+    )
+
+    t0 = time.perf_counter()
+    # Best-epoch model selection happens on selection_val only; the held-out
+    # test set is never seen during training/early-stopping. This keeps the
+    # protocol identical to the BNNR conditions (no test-set peeking).
+    sel_val, best_epoch, _ = _run_epochs_on_loader(
+        adapter=adapter,
+        train_loader=train_loader,
+        eval_loader=selection_val_loader,
+        augmentations=extra_batch_augmentations,
+        epochs=budget,
+        selection_metric="accuracy",
+    )
+
+    # Final metric: evaluate the val-selected model on held_out_test exactly once.
+    from bnnr.core import BNNRTrainer
+    from bnnr.training.loop import evaluate as _evaluate
+
+    _dummy_trainer = BNNRTrainer(adapter, train_loader, held_out_test_loader, [], cfg)
+    held_out_metrics = _evaluate(_dummy_trainer, held_out_test_loader)
+    best_val = copy.deepcopy(held_out_metrics)
+    sel_val_metric = float(sel_val.get("accuracy", 0.0))
+    elapsed_s = time.perf_counter() - t0
+
+    if not args.no_xai:
+        xai_meta = export_attention_maps(
+            adapter,
+            held_out_test_loader,
+            sample_indices=_XAI_SAMPLE_INDICES,
+            output_dir=run_dir / "xai",
+            xai_method="opticam",
+        )
+    else:
+        xai_meta = {"xai_dir": None, "overlay_paths": [], "aggregate_stats": {}}
+
+    extended = _compute_extended_metrics(
+        adapter, held_out_test_loader, num_classes, cfg.device, args.no_xai
+    )
+
+    summary = {
+        "condition": condition.id,
+        "best_epoch": best_epoch,
+        "best_metrics": best_val,
+        "total_gpu_epochs": budget,
+        "epochs_per_phase": budget,
+        "selection_mode": "fixed",
+        "held_out_test_metric": float(best_val.get("accuracy", 0.0)),
+        "xai": xai_meta,
+    }
+    summary_path = run_dir / "run_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    extra: dict[str, Any] = {
+        "total_gpu_epochs": budget,
+        "epochs_per_phase": budget,
+        "selection_mode": "fixed",
+        "selected_candidate": None,
+        "selection_val_metric": sel_val_metric,
+        "held_out_test_metric": float(best_val.get("accuracy", 0.0)),
+        "git_head": git_head(),
+        "hardware": torch_info(),
+        **extended,
+    }
+
+    entry = _result_entry(
+        condition=condition,
+        cfg=cfg,
+        best_val=best_val,
+        best_epoch=best_epoch,
+        elapsed_s=elapsed_s,
+        run_dir=run_dir,
+        report_path=summary_path,
+        best_path=f"plain:{policy}:{aug_label}",
+        xai_meta=xai_meta,
+        extra=extra,
+    )
+    return _stamp(
+        entry,
+        dataset=args.dataset,
+        arch=args.arch,
+        img_size=args.img_size,
+        pretrained=args.pretrained,
+        regime=args.regime,
+    )
+
+
+# ---------------------------------------------------------------------------
+# XAI single-augmentation condition (icd_only / aicd_only / icd_aicd_fixed)
+# ---------------------------------------------------------------------------
+
+
+def _run_xai_aug_warmup_condition(
+    *,
+    condition: ConditionSpec,
+    aug_type: str,  # "icd" | "aicd" | "icd_aicd"
+    seed: int,
+    args: argparse.Namespace,
+    output_root: Path,
+    num_classes: int,
+) -> dict[str, Any]:
+    """Single XAI augmentation with warmup — correct equal-compute design.
+
+    Phase 0 (B//(1+N) epochs): train without augmentation → XAI cache from
+    this model. Phase 1 (remaining epochs): continue training with ICD/AICD
+    using cached saliency from the warmup model. Total = B epochs.
+
+    This mirrors what bnnr_xai does internally (baseline phase → XAI-guided
+    augmentation phase) so the comparison is methodologically fair: both use
+    saliency from a model trained for B//(1+N) epochs, not random weights.
+    """
+    import json as _json
+
+    from dataset_loaders import get_loaders
+
+    from bnnr.augmentations import ChurchNoise  # noqa: F401 (import check)
+    from bnnr.icd import AICD, ICD
+    from bnnr.utils import set_seed
+    from bnnr.xai_cache import XAICache
+
+    run_dir = _make_run_dir(output_root, condition.id, seed)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    budget = args.budget
+    warmup_epochs = budget // (1 + N_CANDIDATES)
+    aug_epochs = budget - warmup_epochs  # remaining budget for augmented training
+    if warmup_epochs < 1:
+        warmup_epochs = 1
+    if aug_epochs < 1:
+        aug_epochs = 1
+
+    cfg_warmup = _base_config(epochs=warmup_epochs, device=args.device)
+    cfg_warmup = _run_config(cfg_warmup, seed=seed, device=args.device,
+                             run_dir=run_dir, xai=False)
+
+    set_seed(seed)
+    num_workers = 0 if args.smoke else 2
+    train_loader, selection_val_loader, held_out_test_loader = get_loaders(
+        args.dataset,
+        img_size=args.img_size,
+        batch_size=args.batch_size,
+        seed=seed,
+        policy="base",
+        n_per_class_train=args.train_per_class,
+        data_dir=args.data_dir,
+        num_workers=num_workers,
+    )
+
+    adapter = _build_adapter(
+        arch=args.arch,
+        num_classes=num_classes,
+        pretrained=args.pretrained,
+        lr=args.lr,
+        device=cfg_warmup.device,
+        epochs=warmup_epochs,
+    )
+
+    header = (
+        f"\n{'='*60}\n"
+        f"  {condition.id.upper()} (grand benchmark, warmup+aug)\n"
+        f"  dataset={args.dataset}  aug_type={aug_type}\n"
+        f"  warmup_epochs={warmup_epochs}  aug_epochs={aug_epochs}\n"
+        f"  total_gpu_epochs={warmup_epochs + aug_epochs}\n"
+        f"  seed={seed}  device={cfg_warmup.device}\n"
+        f"{'='*60}"
+    )
+    print(header, flush=True)
+
+    t0 = time.perf_counter()
+
+    # ---- Phase 0: warmup (no augmentation) ----
+    # Best-epoch selection on selection_val; held_out_test stays untouched.
+    print(f"  [Phase 0/warmup] {warmup_epochs} epochs...", flush=True)
+    warmup_val, warmup_best_epoch, _ = _run_epochs_on_loader(
+        adapter=adapter,
+        train_loader=train_loader,
+        eval_loader=selection_val_loader,
+        augmentations=[],
+        epochs=warmup_epochs,
+        selection_metric="accuracy",
+        log_prefix="[warmup] ",
+    )
+    warmup_score = float(warmup_val.get("accuracy", 0.0))
+    warmup_state = copy.deepcopy(adapter.state_dict())
+    print(f"  [Phase 0] warmup selection_val accuracy={warmup_score:.4f}", flush=True)
+
+    # ---- Pre-compute XAI cache from warmup model ----
+    xai_cache_dir = run_dir / "xai_cache"
+    xai_cache = XAICache(xai_cache_dir)
+    if not args.no_xai:
+        print("  [XAI cache] Pre-computing saliency maps from warmup model...", flush=True)
+        n_cached = xai_cache.precompute_cache(
+            adapter.get_model(),
+            train_loader,
+            adapter.get_target_layers(),
+            method="opticam",
+            show_progress=True,
+        )
+        print(f"  [XAI cache] {n_cached} maps cached", flush=True)
+
+    # ---- Phase 1: augmented training, continuing from warmup weights ----
+    aug_adapter = _build_adapter(
+        arch=args.arch,
+        num_classes=num_classes,
+        pretrained=args.pretrained,
+        lr=args.lr,
+        device=cfg_warmup.device,
+        epochs=aug_epochs,
+    )
+    aug_adapter.model.load_state_dict(warmup_state["model"])
+
+    _model = aug_adapter.get_model()
+    _layers = aug_adapter.get_target_layers()
+    _cache = xai_cache if not args.no_xai else None
+
+    if aug_type == "icd":
+        augmentations = [ICD(model=_model, target_layers=_layers,
+                             threshold_percentile=75.0, probability=0.5,
+                             random_state=seed, cache=_cache)]
+    elif aug_type == "aicd":
+        augmentations = [AICD(model=_model, target_layers=_layers,
+                              threshold_percentile=75.0, probability=0.5,
+                              random_state=seed + 1, cache=_cache)]
+    elif aug_type == "icd_aicd":
+        augmentations = [
+            ICD(model=_model, target_layers=_layers,
+                threshold_percentile=75.0, probability=0.5,
+                random_state=seed, cache=_cache),
+            AICD(model=_model, target_layers=_layers,
+                 threshold_percentile=75.0, probability=0.5,
+                 random_state=seed + 1, cache=_cache),
+        ]
+    else:
+        raise ValueError(f"Unknown aug_type {aug_type!r}")
+
+    print(f"  [Phase 1/aug] {aug_epochs} epochs with {aug_type}...", flush=True)
+    # Best-epoch selection on selection_val; held_out_test is evaluated once below.
+    sel_val, best_epoch, _ = _run_epochs_on_loader(
+        adapter=aug_adapter,
+        train_loader=train_loader,
+        eval_loader=selection_val_loader,
+        augmentations=augmentations,
+        epochs=aug_epochs,
+        selection_metric="accuracy",
+        log_prefix=f"[{aug_type}] ",
+    )
+
+    # Final metric: val-selected model evaluated on held_out_test exactly once.
+    from bnnr.core import BNNRTrainer
+    from bnnr.training.loop import evaluate as _evaluate
+
+    _dummy_trainer = BNNRTrainer(
+        aug_adapter, train_loader, held_out_test_loader, [], cfg_warmup
+    )
+    held_out_metrics = _evaluate(_dummy_trainer, held_out_test_loader)
+    best_val = copy.deepcopy(held_out_metrics)
+    sel_val_metric = float(sel_val.get("accuracy", 0.0))
+    elapsed_s = time.perf_counter() - t0
+
+    total_gpu_epochs = warmup_epochs + aug_epochs
+    print(
+        f"    {condition.id} seed={seed}: held_out_test="
+        f"{best_val.get('accuracy', 0.0):.4f}  (selection_val={sel_val_metric:.4f})",
+        flush=True,
+    )
+
+    if not args.no_xai:
+        xai_meta = export_attention_maps(
+            aug_adapter,
+            held_out_test_loader,
+            sample_indices=_XAI_SAMPLE_INDICES,
+            output_dir=run_dir / "xai",
+            xai_method="opticam",
+        )
+    else:
+        xai_meta = {"xai_dir": None, "overlay_paths": [], "aggregate_stats": {}}
+
+    extended = _compute_extended_metrics(
+        aug_adapter, held_out_test_loader, num_classes, cfg_warmup.device, args.no_xai
+    )
+
+    summary = {
+        "condition": condition.id,
+        "aug_type": aug_type,
+        "warmup_epochs": warmup_epochs,
+        "aug_epochs": aug_epochs,
+        "warmup_score": warmup_score,
+        "held_out_test_metric": float(best_val.get("accuracy", 0.0)),
+        "total_gpu_epochs": total_gpu_epochs,
+        "xai": xai_meta,
+    }
+    summary_path = run_dir / "run_summary.json"
+    summary_path.write_text(_json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    extra: dict[str, Any] = {
+        "total_gpu_epochs": total_gpu_epochs,
+        "epochs_per_phase": warmup_epochs,
+        "selection_mode": "warmup_fixed",
+        "selected_candidate": aug_type,
+        "selection_val_metric": sel_val_metric,
+        "held_out_test_metric": float(best_val.get("accuracy", 0.0)),
+        "warmup_epochs": warmup_epochs,
+        "aug_epochs": aug_epochs,
+        "git_head": git_head(),
+        "hardware": torch_info(),
+        **extended,
+    }
+
+    cfg_report = _base_config(epochs=aug_epochs, device=args.device)
+    cfg_report = _run_config(cfg_report, seed=seed, device=args.device,
+                             run_dir=run_dir, xai=False)
+    entry = _result_entry(
+        condition=condition,
+        cfg=cfg_report,
+        best_val=best_val,
+        best_epoch=best_epoch,
+        elapsed_s=elapsed_s,
+        run_dir=run_dir,
+        report_path=summary_path,
+        best_path=f"warmup+{aug_type}",
+        xai_meta=xai_meta,
+        extra=extra,
+    )
+    return _stamp(
+        entry,
+        dataset=args.dataset,
+        arch=args.arch,
+        img_size=args.img_size,
+        pretrained=args.pretrained,
+        regime=args.regime,
+    )
+
+
+# ---------------------------------------------------------------------------
+# XAI cache pre-computation helper
+# ---------------------------------------------------------------------------
+
+
+def _precompute_xai_cache(
+    *,
+    args: argparse.Namespace,
+    seed: int,
+    run_dir: Path,
+    num_classes: int,
+    train_loader: Any,
+) -> Any:
+    """Pre-compute XAI cache from a fresh baseline adapter."""
+    from bnnr.xai_cache import XAICache
+
+    tmp_adapter = _build_adapter(
+        arch=args.arch,
+        num_classes=num_classes,
+        pretrained=args.pretrained,
+        lr=args.lr,
+        device=args.device,
+        epochs=1,
+    )
+    xai_cache_dir = run_dir / "xai_cache"
+    xai_cache = XAICache(xai_cache_dir)
+    print("  [XAI cache] Pre-computing saliency maps...", flush=True)
+    n_cached = xai_cache.precompute_cache(
+        tmp_adapter.get_model(),
+        train_loader,
+        tmp_adapter.get_target_layers(),
+        method="opticam",
+        show_progress=True,
+    )
+    print(f"  [XAI cache] {n_cached} maps cached to {xai_cache_dir}", flush=True)
+    return xai_cache
+
+
+# ---------------------------------------------------------------------------
+# BNNR equal-compute runner
+# ---------------------------------------------------------------------------
+
+
+def _run_bnnr_equal_compute(
+    *,
+    condition: ConditionSpec,
+    seed: int,
+    args: argparse.Namespace,
+    output_root: Path,
+    selection_mode: str,  # "xai" | "random"
+    num_classes: int,
+) -> dict[str, Any]:
+    """BNNR with equal compute budget.
+
+    Total budget = B epochs split into (1 + N_CANDIDATES) phases.
+    Phase 0 (baseline): B // (1 + N_CANDIDATES) epochs on selection_val.
+    Phases 1..N: each candidate trained for B // (1 + N_CANDIDATES) epochs.
+    Selection: xai -> best selection_val score; random -> Random(seed).randint.
+    Final metric: evaluate selected model on held_out_test.
+    """
+    from dataset_loaders import get_loaders
+
+    from bnnr.utils import set_seed
+    from bnnr.xai_cache import XAICache
+
+    run_dir = _make_run_dir(output_root, condition.id, seed)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    budget = args.budget
+    epochs_per_phase = budget // (1 + N_CANDIDATES)
+    if epochs_per_phase < 1:
+        epochs_per_phase = 1
+    total_gpu_epochs = (1 + N_CANDIDATES) * epochs_per_phase
+
+    cfg = _base_config(epochs=epochs_per_phase, device=args.device)
+    cfg = _run_config(cfg, seed=seed, device=args.device, run_dir=run_dir, xai=False)
+
+    set_seed(seed)
+    num_workers = 0 if args.smoke else 2
+    train_loader, selection_val_loader, held_out_test_loader = get_loaders(
+        args.dataset,
+        img_size=args.img_size,
+        batch_size=args.batch_size,
+        seed=seed,
+        policy="base",
+        n_per_class_train=args.train_per_class,
+        data_dir=args.data_dir,
+        num_workers=num_workers,
+    )
+
+    baseline_adapter = _build_adapter(
+        arch=args.arch,
+        num_classes=num_classes,
+        pretrained=args.pretrained,
+        lr=args.lr,
+        device=cfg.device,
+        epochs=epochs_per_phase,
+    )
+
+    header = (
+        f"\n{'='*60}\n"
+        f"  BNNR {selection_mode.upper()} (grand benchmark, equal-compute)\n"
+        f"  dataset={args.dataset}  budget={budget}  epochs_per_phase={epochs_per_phase}\n"
+        f"  N_CANDIDATES={N_CANDIDATES}  total_gpu_epochs={total_gpu_epochs}\n"
+        f"  seed={seed}  device={cfg.device}\n"
+        f"{'='*60}"
+    )
+    print(header, flush=True)
+
+    t0 = time.perf_counter()
+
+    # ---- Phase 0: baseline ----
+    print(f"  [Phase 0/baseline] {epochs_per_phase} epochs (no extra aug)...", flush=True)
+    baseline_val, _, _ = _run_epochs_on_loader(
+        adapter=baseline_adapter,
+        train_loader=train_loader,
+        eval_loader=selection_val_loader,
+        augmentations=[],
+        epochs=epochs_per_phase,
+        selection_metric="accuracy",
+        log_prefix="[baseline] ",
+    )
+    baseline_score = float(baseline_val.get("accuracy", 0.0))
+    baseline_state = copy.deepcopy(baseline_adapter.state_dict())
+    print(f"  [Phase 0] baseline selection_val accuracy={baseline_score:.4f}", flush=True)
+
+    # ---- Pre-compute XAI cache ----
+    xai_cache_dir = run_dir / "xai_cache"
+    xai_cache = XAICache(xai_cache_dir)
+    print("  [XAI cache] Pre-computing saliency maps...", flush=True)
+    n_cached = xai_cache.precompute_cache(
+        baseline_adapter.get_model(),
+        train_loader,
+        baseline_adapter.get_target_layers(),
+        method="opticam",
+        show_progress=True,
+    )
+    print(f"  [XAI cache] {n_cached} maps cached to {xai_cache_dir}", flush=True)
+
+    # ---- Phases 1..N_CANDIDATES ----
+    candidate_scores: list[float] = []
+    candidate_states: list[dict[str, Any]] = []
+    candidate_val_metrics: list[dict[str, float]] = []
+
+    for i in range(N_CANDIDATES):
+        cand_name = _CANDIDATE_NAMES[i]
+        print(
+            f"  [Phase {i+1}/{N_CANDIDATES} — {cand_name}] {epochs_per_phase} epochs...",
+            flush=True,
+        )
+        cand_adapter = _build_adapter(
+            arch=args.arch,
+            num_classes=num_classes,
+            pretrained=args.pretrained,
+            lr=args.lr,
+            device=cfg.device,
+            epochs=epochs_per_phase,
+        )
+        # Restore only model weights; fresh optimizer+scheduler per phase
+        cand_adapter.model.load_state_dict(baseline_state["model"])
+
+        from bnnr.augmentations import ChurchNoise
+        from bnnr.icd import AICD, ICD
+
+        _cand_model = cand_adapter.get_model()
+        _cand_layers = cand_adapter.get_target_layers()
+        phase_candidates = [
+            ICD(model=_cand_model, target_layers=_cand_layers,
+                threshold_percentile=75.0, probability=0.5,
+                random_state=seed, cache=xai_cache),
+            AICD(model=_cand_model, target_layers=_cand_layers,
+                 threshold_percentile=75.0, probability=0.5,
+                 random_state=seed + 1, cache=xai_cache),
+            ChurchNoise(probability=0.5, intensity=0.5,
+                        noise_strength_range=(3.0, 8.0), random_state=seed + 2),
+        ]
+        aug = phase_candidates[i]
+
+        val_metrics, _, state = _run_epochs_on_loader(
+            adapter=cand_adapter,
+            train_loader=train_loader,
+            eval_loader=selection_val_loader,
+            augmentations=[aug],
+            epochs=epochs_per_phase,
+            selection_metric="accuracy",
+            log_prefix=f"[{cand_name}] ",
+        )
+        score = float(val_metrics.get("accuracy", 0.0))
+        candidate_scores.append(score)
+        candidate_states.append(copy.deepcopy(cand_adapter.state_dict()))
+        candidate_val_metrics.append(copy.deepcopy(val_metrics))
+        print(f"  [{cand_name}] selection_val accuracy={score:.4f}", flush=True)
+
+    # ---- Selection ----
+    if selection_mode == "xai":
+        best_idx = int(max(range(N_CANDIDATES), key=lambda k: candidate_scores[k]))
+        selected_candidate = _CANDIDATE_NAMES[best_idx]
+        selection_val_metric = candidate_scores[best_idx]
+        print(
+            f"  [XAI selection] best={selected_candidate}  score={selection_val_metric:.4f}",
+            flush=True,
+        )
+    elif selection_mode == "random":
+        best_idx = random.Random(seed).randint(0, N_CANDIDATES - 1)
+        selected_candidate = _CANDIDATE_NAMES[best_idx]
+        selection_val_metric = candidate_scores[best_idx]
+        print(
+            f"  [Random selection] chosen={selected_candidate} (idx={best_idx})  "
+            f"score={selection_val_metric:.4f}",
+            flush=True,
+        )
+    else:
+        raise ValueError(f"Unknown selection_mode {selection_mode!r}")
+
+    # ---- Final evaluation on held_out_test ----
+    final_adapter = _build_adapter(
+        arch=args.arch,
+        num_classes=num_classes,
+        pretrained=args.pretrained,
+        lr=args.lr,
+        device=cfg.device,
+        epochs=epochs_per_phase,
+    )
+    final_adapter.load_state_dict(candidate_states[best_idx])
+
+    from bnnr.core import BNNRTrainer
+    from bnnr.training.loop import evaluate as _evaluate
+
+    final_cfg = _base_config(epochs=epochs_per_phase, device=args.device)
+    final_cfg = _run_config(
+        final_cfg, seed=seed, device=args.device, run_dir=run_dir, xai=False
+    )
+    _dummy_trainer = BNNRTrainer(
+        final_adapter, train_loader, held_out_test_loader, [], final_cfg
+    )
+    held_out_metrics = _evaluate(_dummy_trainer, held_out_test_loader)
+    held_out_test_metric = float(held_out_metrics.get("accuracy", 0.0))
+
+    elapsed_s = time.perf_counter() - t0
+    print(
+        f"  [held_out_test] accuracy={held_out_test_metric:.4f}  elapsed={elapsed_s:.1f}s",
+        flush=True,
+    )
+
+    # ---- XAI overlays ----
+    if not args.no_xai:
+        xai_meta = export_attention_maps(
+            final_adapter,
+            held_out_test_loader,
+            sample_indices=_XAI_SAMPLE_INDICES,
+            output_dir=run_dir / "xai",
+            xai_method="opticam",
+        )
+    else:
+        xai_meta = {"xai_dir": None, "overlay_paths": [], "aggregate_stats": {}}
+
+    extended = _compute_extended_metrics(
+        final_adapter, held_out_test_loader, num_classes, cfg.device, args.no_xai
+    )
+
+    # ---- Save summary ----
+    summary = {
+        "condition": condition.id,
+        "selection_mode": selection_mode,
+        "selected_candidate": selected_candidate,
+        "selection_val_metric": selection_val_metric,
+        "held_out_test_metric": held_out_test_metric,
+        "baseline_score": baseline_score,
+        "candidate_scores": dict(zip(_CANDIDATE_NAMES, candidate_scores)),
+        "total_gpu_epochs": total_gpu_epochs,
+        "epochs_per_phase": epochs_per_phase,
+        "xai": xai_meta,
+    }
+    summary_path = run_dir / "run_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    held_out_as_best_val = copy.deepcopy(held_out_metrics)
+
+    extra: dict[str, Any] = {
+        "total_gpu_epochs": total_gpu_epochs,
+        "epochs_per_phase": epochs_per_phase,
+        "selection_mode": selection_mode,
+        "selected_candidate": selected_candidate,
+        "selection_val_metric": selection_val_metric,
+        "held_out_test_metric": held_out_test_metric,
+        "baseline_score": baseline_score,
+        "candidate_scores": dict(zip(_CANDIDATE_NAMES, candidate_scores)),
+        "git_head": git_head(),
+        "hardware": torch_info(),
+        **extended,
+    }
+
+    entry = _result_entry(
+        condition=condition,
+        cfg=final_cfg,
+        best_val=held_out_as_best_val,
+        best_epoch=None,
+        elapsed_s=elapsed_s,
+        run_dir=run_dir,
+        report_path=summary_path,
+        best_path=f"bnnr_{selection_mode}:{selected_candidate}",
+        xai_meta=xai_meta,
+        extra=extra,
+    )
+    return _stamp(
+        entry,
+        dataset=args.dataset,
+        arch=args.arch,
+        img_size=args.img_size,
+        pretrained=args.pretrained,
+        regime=args.regime,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def run_condition(
+    *,
+    condition_id: str,
+    seed: int,
+    args: argparse.Namespace,
+    output_root: Path,
+    num_classes: int,
+) -> dict[str, Any]:
+    spec = CONDITIONS[condition_id]
+
+    if condition_id == "bnnr_xai":
+        return _run_bnnr_equal_compute(
+            condition=spec, seed=seed, args=args,
+            output_root=output_root, selection_mode="xai", num_classes=num_classes,
+        )
+    if condition_id == "bnnr_random":
+        return _run_bnnr_equal_compute(
+            condition=spec, seed=seed, args=args,
+            output_root=output_root, selection_mode="random", num_classes=num_classes,
+        )
+
+    # ICD/AICD conditions use warmup+aug design so saliency comes from a
+    # trained (not random-weight) model — methodologically equivalent to
+    # bnnr_xai's baseline phase.
+    if condition_id == "icd_only":
+        return _run_xai_aug_warmup_condition(
+            condition=spec, aug_type="icd", seed=seed, args=args,
+            output_root=output_root, num_classes=num_classes,
+        )
+    if condition_id == "aicd_only":
+        return _run_xai_aug_warmup_condition(
+            condition=spec, aug_type="aicd", seed=seed, args=args,
+            output_root=output_root, num_classes=num_classes,
+        )
+    if condition_id == "icd_aicd_fixed":
+        return _run_xai_aug_warmup_condition(
+            condition=spec, aug_type="icd_aicd", seed=seed, args=args,
+            output_root=output_root, num_classes=num_classes,
+        )
+
+    policy = _POLICY_BY_CONDITION[condition_id]
+
+    # ChurchNoise does not need XAI — plain condition
+    extra_batch_augmentations: list[Any] = []
+    if condition_id == "churchnoise_only":
+        from bnnr.augmentations import ChurchNoise
+        extra_batch_augmentations = [
+            ChurchNoise(probability=0.5, intensity=0.5,
+                        noise_strength_range=(3.0, 8.0), random_state=seed)
+        ]
+
+    return _run_plain_condition(
+        condition=spec,
+        policy=policy,
+        extra_batch_augmentations=extra_batch_augmentations,
+        seed=seed,
+        args=args,
+        output_root=output_root,
+        num_classes=num_classes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark document
+# ---------------------------------------------------------------------------
+
+
+def _benchmark_document(args: argparse.Namespace, num_classes: int) -> dict[str, Any]:
+    epochs_per_phase = args.budget // (1 + N_CANDIDATES)
+    return {
+        "benchmark_id": f"grand_benchmark_{args.dataset}_{args.regime}",
+        "benchmark_version": "grand_v1",
+        "model": f"{args.arch} (torchvision, pretrained={args.pretrained})",
+        "dataset": args.dataset,
+        "num_classes": num_classes,
+        "img_size": args.img_size,
+        "batch_size": args.batch_size,
+        "optimizer": f"SGD(lr={args.lr}, momentum=0.9, wd=5e-4)",
+        "scheduler": "CosineAnnealingLR",
+        "budget_epochs_total": args.budget,
+        "epochs_per_phase": epochs_per_phase,
+        "n_candidates": N_CANDIDATES,
+        "candidate_names": _CANDIDATE_NAMES,
+        "primary_metric": "held_out_test accuracy (best epoch within each phase)",
+        "normalization": "ImageNet mean/std applied inside the model",
+        "attention_method": "OptiCAM overlays on fixed held_out_test indices",
+        "target_layer": "backbone.layer4[-1]",
+        "regime": args.regime,
+        "conditions": {
+            cid: {
+                "label": spec.label,
+                "strategy": spec.strategy,
+                "max_iterations": spec.max_iterations,
+                "augmentations": list(spec.augmentation_names),
+                "description": spec.description,
+            }
+            for cid, spec in CONDITIONS.items()
+        },
+        "protocol_caveats": [
+            "Equal total GPU-epoch budget B for all conditions.",
+            f"BNNR trains B//(1+N_candidates) = {epochs_per_phase} epochs per phase.",
+            "All conditions select their best epoch on selection_val; the "
+            "held-out test set is evaluated exactly once for final reporting.",
+            "bnnr_random provides a compute-matched baseline for bnnr_xai.",
+            "Epoch-budget asymmetry: under equal total compute, the bnnr_xai/"
+            "bnnr_random final model is trained for 2 phases (baseline + chosen "
+            f"candidate = {2 * epochs_per_phase} epochs) while single-aug and "
+            "baseline conditions train the full B epochs on one model. The "
+            "compute is matched, the per-model epoch count is not; this is "
+            "conservative for the 'branch search > best single aug' claim.",
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Wall-clock estimate
+# ---------------------------------------------------------------------------
+
+
+def _estimate(args: argparse.Namespace, n_seeds: int, conds: list[str]) -> str:
+    bnnr_conds = {"bnnr_xai", "bnnr_random"}
+    bnnr_count = sum(1 for c in conds if c in bnnr_conds)
+    plain_count = len(conds) - bnnr_count
+    plain_epochs_total = plain_count * args.budget * n_seeds
+    bnnr_epochs_total = bnnr_count * args.budget * n_seeds
+    total_epoch_minutes = (plain_epochs_total + bnnr_epochs_total) * 1.0
+    if args.device != "cpu":
+        total_epoch_minutes *= 0.15
+    return (
+        f"~{total_epoch_minutes/60:.1f}h wall-clock estimate "
+        f"({len(conds)} conditions x {n_seeds} seeds, {args.device}, "
+        f"budget={args.budget})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Grand benchmark: BNNR across 6 datasets × 2 regimes (paper-quality)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--dataset",
+        required=True,
+        choices=list(DATASET_DEFAULTS.keys()),
+        help="Dataset to benchmark",
+    )
+    parser.add_argument(
+        "--regime",
+        choices=["scratch", "pretrained"],
+        default="scratch",
+        help="Training regime (default: scratch)",
+    )
+    parser.add_argument(
+        "--conditions",
+        default=None,
+        help=(
+            "Comma-separated conditions (default: all for dataset+regime combo). "
+            f"Available: {', '.join(CONDITIONS)}"
+        ),
+    )
+    parser.add_argument(
+        "--budget",
+        type=int,
+        default=None,
+        help="Total GPU-epoch budget per condition (default: 40 scratch, 20 pretrained)",
+    )
+    parser.add_argument(
+        "--seeds",
+        default=None,
+        help="Comma-separated seeds (default: dataset-specific)",
+    )
+    parser.add_argument("--arch", default="resnet18", choices=["resnet18", "resnet50"])
+    parser.add_argument(
+        "--img-size",
+        type=int,
+        default=None,
+        help="Square resize/crop target (dataset-specific default)",
+    )
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--lr", type=float, default=0.05)
+    parser.add_argument(
+        "--train-per-class",
+        type=int,
+        default=None,
+        help="Balanced train images per class (dataset-specific default)",
+    )
+    parser.add_argument(
+        "--no-xai",
+        action="store_true",
+        help="Skip OptiCAM overlay export (faster)",
+    )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=None,
+        help="Path to results JSON (default: benchmarks/results_{dataset}_{regime}.json)",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=None,
+        help="Run output dir (default: benchmarks/runs_grand/{dataset}_{regime})",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=None,
+        help="Directory for dataset downloads (default: <repo>/data)",
+    )
+    parser.add_argument(
+        "--drive-base-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Colab/Drive convenience: sets results, output-root, data-dir "
+            "under a single directory."
+        ),
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Fast sanity run: 1 epoch, 2 seeds, 5/class, img_size=64",
+    )
+    parser.add_argument("--device", default="auto", help="auto | cuda | cpu")
+    parser.add_argument("--dry-run", action="store_true", help="Print plan and exit")
+    args = parser.parse_args()
+
+    # ---- Dataset-specific defaults ----
+    ds_defaults = DATASET_DEFAULTS[args.dataset]
+    if args.img_size is None:
+        args.img_size = ds_defaults["img_size"]
+    if args.train_per_class is None:
+        args.train_per_class = ds_defaults["train_per_class"]
+    num_classes: int = ds_defaults["num_classes"]
+
+    # ---- Budget default ----
+    if args.budget is None:
+        args.budget = 20 if args.regime == "pretrained" else 40
+
+    # ---- Pretrained flag from regime ----
+    args.pretrained = args.regime == "pretrained"
+
+    # ---- drive-base-dir convenience ----
+    if args.drive_base_dir is not None:
+        args.drive_base_dir.mkdir(parents=True, exist_ok=True)
+        if args.results is None:
+            args.results = args.drive_base_dir / f"results_{args.dataset}_{args.regime}.json"
+        if args.output_root is None:
+            args.output_root = args.drive_base_dir / f"runs_grand/{args.dataset}_{args.regime}"
+        if args.data_dir is None:
+            args.data_dir = args.drive_base_dir / "data"
+
+    # ---- Path defaults (if not set by drive-base-dir) ----
+    if args.results is None:
+        args.results = BENCHMARKS_DIR / f"results_{args.dataset}_{args.regime}.json"
+    if args.output_root is None:
+        args.output_root = BENCHMARKS_DIR / f"runs_grand/{args.dataset}_{args.regime}"
+    if args.data_dir is None:
+        args.data_dir = REPO_ROOT / "data"
+
+    # ---- Smoke overrides ----
+    if args.smoke:
+        args.budget = (1 + N_CANDIDATES) * 1  # 4 total, 1 epoch per phase
+        args.img_size = 64
+        args.train_per_class = 5
+        if args.seeds is None:
+            args.seeds = "42,43"
+        if args.conditions is None:
+            args.conditions = "no_aug,bnnr_xai"  # minimal smoke
+
+    # ---- Seeds ----
+    if args.seeds is not None:
+        seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
+    else:
+        seeds = DATASET_DEFAULT_SEEDS[args.dataset]
+
+    # ---- Conditions ----
+    if args.conditions is not None:
+        conds = [c.strip() for c in args.conditions.split(",") if c.strip()]
+    else:
+        conds = DATASET_DEFAULT_CONDITIONS[args.dataset]
+    for c in conds:
+        if c not in CONDITIONS:
+            parser.error(f"Unknown condition {c!r}. Available: {', '.join(CONDITIONS)}")
+
+    # ---- Device ----
+    if not hasattr(args, "device"):
+        args.device = "auto"
+    # Resolve auto
+    try:
+        import torch
+        if args.device == "auto":
+            args.device = "cuda" if torch.cuda.is_available() else "cpu"
+    except ImportError:
+        args.device = "cpu"
+
+    # ---- Print plan ----
+    epochs_per_phase = args.budget // (1 + N_CANDIDATES)
+    print("Grand Benchmark — BNNR cross-dataset ablation (paper-quality)")
+    print(f"  dataset={args.dataset}  regime={args.regime}  arch={args.arch}")
+    print(f"  pretrained={args.pretrained}  img_size={args.img_size}")
+    print(f"  num_classes={num_classes}  train_per_class={args.train_per_class}")
+    print(f"  seeds={seeds}  conditions={conds}")
+    print(
+        f"  budget={args.budget} epochs  epochs_per_phase={epochs_per_phase}  "
+        f"N_candidates={N_CANDIDATES}  device={args.device}"
+    )
+    print(f"  {_estimate(args, len(seeds), conds)}")
+    print(f"  results -> {args.results}")
+
+    if args.dry_run:
+        return
+
+    # ---- Run ----
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    data = load_results(args.results)
+    doc = _benchmark_document(args, num_classes)
+    data.update(doc)
+    data.setdefault("runs", [])
+    data["hardware"] = torch_info()
+    data["git_head"] = git_head()
+    data["generated_at"] = datetime.now(timezone.utc).isoformat()
+
+    # Resume safety
+    done = {
+        (r["condition"], r["seed"], r.get("regime", "scratch"))
+        for r in data["runs"]
+        if "val_metric" in r and "error" not in r
+    }
+
+    for seed in seeds:
+        for cid in conds:
+            key = (cid, seed, args.regime)
+            if key in done:
+                print(f"SKIP {cid} seed={seed} regime={args.regime} (already done)")
+                continue
+            print(f"\n>>> dataset={args.dataset}  condition={cid}  seed={seed}  regime={args.regime}")
+            try:
+                entry = run_condition(
+                    condition_id=cid,
+                    seed=seed,
+                    args=args,
+                    output_root=args.output_root,
+                    num_classes=num_classes,
+                )
+            except Exception as exc:  # noqa: BLE001
+                import traceback
+                print(f"    FAILED ({cid}, seed={seed}): {exc}", file=sys.stderr)
+                traceback.print_exc()
+                entry = {
+                    "condition": cid,
+                    "seed": seed,
+                    "regime": args.regime,
+                    "dataset": args.dataset,
+                    "model": args.arch,
+                    "error": str(exc),
+                }
+            data["runs"].append(entry)
+            save_results(args.results, data)  # checkpoint after every run
+            val = entry.get("val_metric")
+            held = entry.get("held_out_test_metric")
+            if val is not None:
+                print(f"    {cid} seed={seed}: val_metric(held_out)={val:.4f}")
+            elif held is not None:
+                print(f"    {cid} seed={seed}: held_out_test_accuracy={held:.4f}")
+
+    n_valid = sum(1 for r in data["runs"] if "val_metric" in r and "error" not in r)
+    print(f"\nDone. {n_valid} valid run records in {args.results}")
+    print(
+        f"Summarize: python benchmarks/summarize_grand.py "
+        f"--results-dir benchmarks/ --datasets {args.dataset}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/summarize_grand.py
+++ b/benchmarks/summarize_grand.py
@@ -1,0 +1,869 @@
+#!/usr/bin/env python3
+"""Cross-dataset analysis for the grand BNNR benchmark.
+
+Loads all ``results_*.json`` files from a directory and produces:
+  1. Per-dataset table (conditions × metrics, Wilcoxon + Holm-Bonferroni)
+  2. Cross-dataset summary table (median accuracy per dataset, mean Δ vs no_aug)
+  3. XAI correlation section (Spearman ρ between edge_ratio and accuracy)
+  4. Key comparison section (bnnr_xai vs bnnr_random, per dataset, with p-values)
+  5. Compute transparency (total_gpu_epochs per condition)
+
+Examples
+--------
+    python benchmarks/summarize_grand.py --results-dir benchmarks/ --markdown
+
+    python benchmarks/summarize_grand.py \\
+        --results-dir benchmarks/ --datasets imagewoof,pets --regime scratch
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+BENCHMARKS_DIR = Path(__file__).resolve().parent
+
+ALL_DATASETS = ["imagewoof", "pets", "flowers102", "dtd", "aircraft", "eurosat"]
+
+ALL_CONDITIONS_ORDERED = [
+    "no_aug",
+    "randaugment",
+    "trivialaugment",
+    "autoaugment",
+    "churchnoise_only",
+    "icd_only",
+    "aicd_only",
+    "icd_aicd_fixed",
+    "bnnr_random",
+    "bnnr_xai",
+]
+
+DISPLAY_NAMES = {
+    "no_aug":          "No augmentation (crop + flip)",
+    "randaugment":     "RandAugment (torchvision)",
+    "trivialaugment":  "TrivialAugmentWide (torchvision)",
+    "autoaugment":     "AutoAugment (ImageNet policy)",
+    "churchnoise_only":"ChurchNoise only (non-XAI ablation)",
+    "icd_only":        "ICD only",
+    "aicd_only":       "AICD only",
+    "icd_aicd_fixed":  "ICD+AICD fixed (no search)",
+    "bnnr_xai":        "BNNR XAI-guided (equal compute)",
+    "bnnr_random":     "BNNR random selection (XAI ablation)",
+}
+
+# Conditions compared against bnnr_xai in significance tests
+COMPARISON_CONDITIONS = [
+    "no_aug", "randaugment", "trivialaugment", "autoaugment",
+    "churchnoise_only", "icd_only", "aicd_only", "icd_aicd_fixed", "bnnr_random",
+]
+
+
+# ---------------------------------------------------------------------------
+# Statistical helpers (from summarize_v2.py — self-contained copy)
+# ---------------------------------------------------------------------------
+
+
+def _wilcoxon_signed_rank(
+    x: list[float], y: list[float]
+) -> tuple[float, float, float] | None:
+    """Paired Wilcoxon signed-rank test (two-sided).
+
+    Returns (W_statistic, p_value, rank_biserial_r) or None if n < 2.
+    """
+    if len(x) != len(y):
+        raise ValueError("x and y must have equal length for paired test")
+    if len(x) < 2:
+        return None
+
+    diffs = [float(xi) - float(yi) for xi, yi in zip(x, y)]
+
+    try:
+        from scipy.stats import wilcoxon as _scipy_wilcoxon
+
+        nonzero = [d for d in diffs if d != 0.0]
+        if len(nonzero) == 0:
+            return 0.0, 1.0, 0.0
+        result = _scipy_wilcoxon(nonzero, alternative="two-sided")
+        W = float(result.statistic)
+        p = float(result.pvalue)
+        n = len(nonzero)
+        r = 1.0 - 2.0 * W / (n * (n + 1)) if n > 0 else 0.0
+        return W, p, r
+    except ImportError:
+        pass
+
+    nonzero = [d for d in diffs if d != 0.0]
+    n = len(nonzero)
+    if n == 0:
+        return 0.0, 1.0, 0.0
+
+    abs_d = [abs(d) for d in nonzero]
+    order = sorted(range(n), key=lambda i: abs_d[i])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j < n and abs_d[order[j]] == abs_d[order[i]]:
+            j += 1
+        avg_rank = (i + j + 1) / 2.0
+        for k in range(i, j):
+            ranks[order[k]] = avg_rank
+        i = j
+
+    W_plus = sum(ranks[i] for i in range(n) if nonzero[i] > 0)
+    W_minus = sum(ranks[i] for i in range(n) if nonzero[i] < 0)
+    W = min(W_plus, W_minus)
+
+    if n <= 15:
+        p = _wilcoxon_exact_p(n, W)
+    else:
+        mu = n * (n + 1) / 4.0
+        sigma2 = n * (n + 1) * (2 * n + 1) / 24.0
+        if sigma2 == 0:
+            p = 1.0
+        else:
+            z = (W - mu + 0.5) / math.sqrt(sigma2)
+            p = _normal_two_sided_p(abs(z))
+
+    r = 1.0 - 2.0 * W / (n * (n + 1))
+    return W, min(1.0, p), r
+
+
+def _wilcoxon_exact_p(n: int, W: float) -> float:
+    total = 1 << n
+    count = 0
+    ranks = list(range(1, n + 1))
+    max_sum = sum(ranks)
+    for mask in range(total):
+        w_plus = sum(ranks[i] for i in range(n) if mask >> i & 1)
+        w_minus = max_sum - w_plus
+        w_stat = min(w_plus, w_minus)
+        if w_stat <= W:
+            count += 1
+    return float(count) / float(total)
+
+
+def _normal_two_sided_p(z: float) -> float:
+    return float(math.erfc(z / math.sqrt(2.0)))
+
+
+def _holm_bonferroni(p_values: list[float]) -> list[float]:
+    n = len(p_values)
+    indexed = sorted(enumerate(p_values), key=lambda t: t[1])
+    adjusted = [0.0] * n
+    running_max = 0.0
+    for rank, (orig_idx, p) in enumerate(indexed):
+        adj = p * (n - rank)
+        running_max = max(running_max, adj)
+        adjusted[orig_idx] = min(1.0, running_max)
+    return adjusted
+
+
+def _bootstrap_median_diff_ci(
+    x: list[float],
+    y: list[float],
+    *,
+    n_boot: int = 10_000,
+    ci: float = 0.95,
+    rng_seed: int = 0,
+) -> tuple[float, float]:
+    rng = np.random.default_rng(rng_seed)
+    n = len(x)
+    xa = np.array(x)
+    ya = np.array(y)
+    diffs = np.empty(n_boot)
+    for i in range(n_boot):
+        idx = rng.integers(0, n, size=n)
+        diffs[i] = float(np.median(xa[idx]) - np.median(ya[idx]))
+    alpha = 1.0 - ci
+    lo = float(np.quantile(diffs, alpha / 2))
+    hi = float(np.quantile(diffs, 1.0 - alpha / 2))
+    return lo, hi
+
+
+def _iqr(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    return float(np.quantile(values, 0.75)) - float(np.quantile(values, 0.25))
+
+
+def _sig_stars(p: float | None) -> str:
+    if p is None:
+        return "n/a"
+    if p < 0.001:
+        return "***"
+    if p < 0.01:
+        return "**"
+    if p < 0.05:
+        return "*"
+    return "ns"
+
+
+def _p_label(p: float | None) -> str:
+    if p is None:
+        return "n/a"
+    if p < 0.001:
+        return "p<0.001"
+    return f"p={p:.3f}"
+
+
+def _spearman_r(x: list[float], y: list[float]) -> float | None:
+    """Spearman rank correlation."""
+    if len(x) < 3:
+        return None
+    xa = np.array(x, dtype=float)
+    ya = np.array(y, dtype=float)
+
+    def _rank(arr: np.ndarray) -> np.ndarray:
+        order = np.argsort(arr)
+        ranks = np.empty_like(order, dtype=float)
+        ranks[order] = np.arange(1, len(arr) + 1, dtype=float)
+        return ranks
+
+    rx = _rank(xa)
+    ry = _rank(ya)
+    rx_m = rx - rx.mean()
+    ry_m = ry - ry.mean()
+    denom = math.sqrt((rx_m ** 2).sum() * (ry_m ** 2).sum())
+    if denom < 1e-12:
+        return 0.0
+    return float((rx_m * ry_m).sum() / denom)
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def _load_all_runs(results_dir: Path, regime_filter: str) -> list[dict[str, Any]]:
+    """Scan *results_dir* for ``results_*.json`` and return valid run records."""
+    runs: list[dict[str, Any]] = []
+    for path in sorted(results_dir.glob("results_*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            print(f"  Warning: could not read {path}")
+            continue
+        for r in data.get("runs") or []:
+            if "val_metric" not in r or "error" in r:
+                continue
+            run_regime = r.get("regime", "scratch")
+            if regime_filter != "all" and run_regime != regime_filter:
+                continue
+            runs.append(r)
+    return runs
+
+
+# ---------------------------------------------------------------------------
+# Per-dataset analysis
+# ---------------------------------------------------------------------------
+
+
+def _analyze_dataset(
+    dataset: str,
+    runs: list[dict[str, Any]],
+    *,
+    no_bootstrap: bool,
+    n_boot: int,
+    markdown: bool,
+) -> None:
+    """Print per-dataset condition table with statistics."""
+    ds_runs = [r for r in runs if r.get("dataset") == dataset]
+    if not ds_runs:
+        print(f"\n  [No data for {dataset}]\n")
+        return
+
+    # Group by condition → seed → metric
+    by_cond: dict[str, dict[int, float]] = defaultdict(dict)
+    gpu_epochs_by_cond: dict[str, list[int]] = defaultdict(list)
+    for r in ds_runs:
+        cid = r["condition"]
+        seed = int(r["seed"])
+        metric = float(r.get("held_out_test_metric") or r.get("val_metric") or 0.0)
+        by_cond[cid][seed] = metric
+        ep = r.get("total_gpu_epochs")
+        if ep is not None:
+            gpu_epochs_by_cond[cid].append(int(ep))
+
+    print(f"\n{'='*70}")
+    print(f"  DATASET: {dataset.upper()}")
+    print(f"  Conditions found: {', '.join(sorted(by_cond))}")
+    print(f"{'='*70}")
+
+    # Wilcoxon tests: bnnr_xai vs each comparison condition
+    bnnr_xai_by_seed = by_cond.get("bnnr_xai", {})
+    wilcoxon_results: dict[str, dict[str, Any]] = {}
+    comp_conds_present = [c for c in COMPARISON_CONDITIONS if c in by_cond]
+
+    for cid in comp_conds_present:
+        other_by_seed = by_cond.get(cid, {})
+        shared = sorted(set(bnnr_xai_by_seed.keys()) & set(other_by_seed.keys()))
+        if len(shared) < 2:
+            wilcoxon_results[cid] = {"W": None, "p": None, "r": None, "n": len(shared)}
+            continue
+        bx = [bnnr_xai_by_seed[s] for s in shared]
+        ot = [other_by_seed[s] for s in shared]
+        wres = _wilcoxon_signed_rank(bx, ot)
+        if wres is None:
+            wilcoxon_results[cid] = {"W": None, "p": None, "r": None, "n": len(shared)}
+        else:
+            W, p, r = wres
+            ci_lo, ci_hi = (float("nan"), float("nan"))
+            if not no_bootstrap and len(shared) >= 2:
+                ci_lo, ci_hi = _bootstrap_median_diff_ci(bx, ot, n_boot=n_boot, rng_seed=42)
+            wilcoxon_results[cid] = {
+                "W": W, "p": p, "r": r, "n": len(shared),
+                "ci_lo": ci_lo, "ci_hi": ci_hi,
+                "bnnr_xai_vals": bx,
+                "other_vals": ot,
+            }
+
+    # Holm-Bonferroni correction
+    if comp_conds_present:
+        p_raw = [(wilcoxon_results[c].get("p") or 1.0) for c in comp_conds_present]
+        p_holm = _holm_bonferroni(p_raw)
+        for i, cid in enumerate(comp_conds_present):
+            wilcoxon_results[cid]["p_holm"] = p_holm[i]
+
+    # Reference median for delta
+    no_aug_vals = list(by_cond.get("no_aug", {}).values())
+    ref_median = statistics.median(no_aug_vals) if no_aug_vals else None
+
+    # Build rows
+    rows = []
+    conds_to_show = [c for c in ALL_CONDITIONS_ORDERED if c in by_cond]
+    for cid in conds_to_show:
+        vals = list(by_cond[cid].values())
+        if not vals:
+            continue
+        med = statistics.median(vals)
+        iqr_v = _iqr(vals)
+        mn = statistics.mean(vals)
+        std = statistics.stdev(vals) if len(vals) > 1 else 0.0
+        n = len(vals)
+
+        delta_s = "—"
+        if ref_median is not None and cid != "no_aug":
+            delta_s = f"{(med - ref_median) * 100:+.2f}pp"
+
+        wr = wilcoxon_results.get(cid, {})
+        p_adj = wr.get("p_holm")
+        r_v = wr.get("r")
+        p_adj_s = f"{_p_label(p_adj)} {_sig_stars(p_adj)}" if p_adj is not None else "—"
+        r_s = f"{r_v:.2f}" if r_v is not None else "—"
+        ci_lo_v = wr.get("ci_lo", float("nan"))
+        ci_hi_v = wr.get("ci_hi", float("nan"))
+        ci_s = (
+            f"[{ci_lo_v*100:+.2f}, {ci_hi_v*100:+.2f}]pp"
+            if not (math.isnan(ci_lo_v) or math.isnan(ci_hi_v))
+            else "—"
+        )
+
+        gpu_epochs_list = gpu_epochs_by_cond.get(cid, [])
+        gpu_ep_s = str(int(statistics.median(gpu_epochs_list))) if gpu_epochs_list else "?"
+
+        rows.append({
+            "cid": cid,
+            "label": DISPLAY_NAMES.get(cid, cid),
+            "median": med,
+            "iqr": iqr_v,
+            "mean": mn,
+            "std": std,
+            "n": n,
+            "delta": delta_s,
+            "p_holm": p_adj_s,
+            "r": r_s,
+            "ci": ci_s,
+            "gpu_epochs": gpu_ep_s,
+            "per_seed": ", ".join(f"{v*100:.2f}%" for v in sorted(vals)),
+        })
+
+    if markdown:
+        _print_markdown_table(rows)
+    else:
+        _print_text_table(rows)
+
+    # Key comparison: bnnr_xai vs bnnr_random
+    _print_xai_vs_random(wilcoxon_results, by_cond, bnnr_xai_by_seed)
+
+
+def _print_text_table(rows: list[dict[str, Any]]) -> None:
+    w = 38
+    header = (
+        f"{'Condition':<{w}} {'Median':>8} {'±IQR':>8} {'Mean':>8} {'±Std':>7} "
+        f"{'n':>3} {'Δ vs no_aug':>12} {'p(Holm)':>18} {'r':>6} {'GPU-ep':>8}"
+    )
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        med_s = f"{row['median']*100:.2f}%"
+        iqr_s = f"±{row['iqr']*100:.2f}"
+        mn_s = f"{row['mean']*100:.2f}%"
+        std_s = f"±{row['std']*100:.2f}"
+        print(
+            f"{row['label']:<{w}} {med_s:>8} {iqr_s:>8} {mn_s:>8} {std_s:>7} "
+            f"{row['n']:>3} {row['delta']:>12} {row['p_holm']:>18} {row['r']:>6} "
+            f"{row['gpu_epochs']:>8}"
+        )
+        print(f"  per-seed: {row['per_seed']}")
+    print()
+
+
+def _print_markdown_table(rows: list[dict[str, Any]]) -> None:
+    print(
+        "| Condition | Median | ±IQR | mean±std | n | "
+        "Δ vs no_aug | p (Holm) vs bnnr_xai | r | Bootstrap 95% CI | GPU-epochs |"
+    )
+    print(
+        "|-----------|--------|------|----------|---|"
+        "------------|---------------------|---|-----------------|-----------|"
+    )
+    for row in rows:
+        med_s = f"{row['median']*100:.2f}%"
+        iqr_s = f"±{row['iqr']*100:.2f}pp"
+        mn_s = f"{row['mean']*100:.2f}% ±{row['std']*100:.2f}"
+        print(
+            f"| {row['label']} "
+            f"| {med_s} "
+            f"| {iqr_s} "
+            f"| {mn_s} "
+            f"| {row['n']} "
+            f"| {row['delta']} "
+            f"| {row['p_holm']} "
+            f"| {row['r']} "
+            f"| {row['ci']} "
+            f"| {row['gpu_epochs']} |"
+        )
+
+
+def _print_xai_vs_random(
+    wilcoxon_results: dict[str, dict[str, Any]],
+    by_cond: dict[str, dict[int, float]],
+    bnnr_xai_by_seed: dict[int, float],
+) -> None:
+    wr = wilcoxon_results.get("bnnr_random")
+    if wr is None or wr.get("W") is None:
+        print("  bnnr_xai vs bnnr_random: insufficient data.\n")
+        return
+
+    shared = sorted(
+        set(bnnr_xai_by_seed.keys()) & set(by_cond.get("bnnr_random", {}).keys())
+    )
+    bx = [bnnr_xai_by_seed[s] for s in shared]
+    br = [by_cond["bnnr_random"][s] for s in shared]
+    med_xai = statistics.median(bx)
+    med_rand = statistics.median(br)
+    delta = (med_xai - med_rand) * 100
+
+    p_holm = wr.get("p_holm", wr.get("p"))
+    r_v = wr.get("r")
+    ci_lo = wr.get("ci_lo", float("nan"))
+    ci_hi = wr.get("ci_hi", float("nan"))
+
+    print(f"  KEY: bnnr_xai ({med_xai*100:.2f}%) vs bnnr_random ({med_rand*100:.2f}%)  "
+          f"Δ={delta:+.2f}pp  n={len(shared)}  "
+          f"{_p_label(p_holm)} {_sig_stars(p_holm)}  r={r_v:.2f}")
+    if not (math.isnan(ci_lo) or math.isnan(ci_hi)):
+        print(f"  Bootstrap 95% CI for Δ median: [{ci_lo*100:+.2f}, {ci_hi*100:+.2f}]pp")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Cross-dataset summary table
+# ---------------------------------------------------------------------------
+
+
+def _cross_dataset_table(
+    all_runs: list[dict[str, Any]],
+    datasets: list[str],
+    *,
+    markdown: bool,
+) -> None:
+    """Print a condition × dataset accuracy matrix with mean Δ."""
+    print("\n" + "=" * 80)
+    print("  CROSS-DATASET SUMMARY  (median held_out_test accuracy per dataset)")
+    print("=" * 80)
+
+    # Collect medians: by_cond_ds[cond][dataset] = median accuracy
+    by_cond_ds: dict[str, dict[str, float | None]] = defaultdict(lambda: {ds: None for ds in datasets})
+    no_aug_medians: dict[str, float] = {}
+
+    for ds in datasets:
+        ds_runs = [r for r in all_runs if r.get("dataset") == ds]
+        for cid in ALL_CONDITIONS_ORDERED:
+            vals = [
+                float(r.get("held_out_test_metric") or r.get("val_metric") or 0.0)
+                for r in ds_runs if r["condition"] == cid
+            ]
+            if vals:
+                by_cond_ds[cid][ds] = statistics.median(vals)
+        no_aug_vals = [
+            float(r.get("held_out_test_metric") or r.get("val_metric") or 0.0)
+            for r in ds_runs if r["condition"] == "no_aug"
+        ]
+        if no_aug_vals:
+            no_aug_medians[ds] = statistics.median(no_aug_vals)
+
+    conds_with_data = [
+        c for c in ALL_CONDITIONS_ORDERED
+        if any(by_cond_ds[c].get(ds) is not None for ds in datasets)
+    ]
+
+    if markdown:
+        header = "| Condition | " + " | ".join(datasets) + " | Mean Δ |"
+        sep = "|-----------|" + "|".join(["-------"] * len(datasets)) + "|--------|"
+        print(header)
+        print(sep)
+        for cid in conds_with_data:
+            cells: list[str] = []
+            deltas: list[float] = []
+            for ds in datasets:
+                med = by_cond_ds[cid].get(ds)
+                if med is None:
+                    cells.append("—")
+                else:
+                    ref = no_aug_medians.get(ds)
+                    if ref is not None and cid != "no_aug":
+                        d = (med - ref) * 100
+                        deltas.append(d)
+                        cells.append(f"{med*100:.2f}% ({d:+.1f}pp)")
+                    else:
+                        cells.append(f"{med*100:.2f}%")
+            mean_delta_s = f"{statistics.mean(deltas):+.2f}pp" if deltas else "—"
+            print(f"| {DISPLAY_NAMES.get(cid, cid)} | " + " | ".join(cells) + f" | {mean_delta_s} |")
+    else:
+        col_w = 16
+        header_parts = ["Condition".ljust(38)]
+        for ds in datasets:
+            header_parts.append(ds[:col_w].center(col_w + 2))
+        header_parts.append("Mean Δ".rjust(10))
+        header_line = " ".join(header_parts)
+        print(header_line)
+        print("-" * len(header_line))
+        for cid in conds_with_data:
+            row_parts = [DISPLAY_NAMES.get(cid, cid)[:38].ljust(38)]
+            deltas: list[float] = []
+            for ds in datasets:
+                med = by_cond_ds[cid].get(ds)
+                if med is None:
+                    row_parts.append("  —".center(col_w + 2))
+                else:
+                    ref = no_aug_medians.get(ds)
+                    if ref is not None and cid != "no_aug":
+                        d = (med - ref) * 100
+                        deltas.append(d)
+                        row_parts.append(f"{med*100:.1f}%({d:+.1f})".center(col_w + 2))
+                    else:
+                        row_parts.append(f"{med*100:.1f}%".center(col_w + 2))
+            mean_delta_s = f"{statistics.mean(deltas):+.2f}pp" if deltas else "—"
+            row_parts.append(mean_delta_s.rjust(10))
+            print(" ".join(row_parts))
+    print()
+
+
+# ---------------------------------------------------------------------------
+# XAI correlation section
+# ---------------------------------------------------------------------------
+
+
+def _xai_correlation_section(
+    all_runs: list[dict[str, Any]],
+    datasets: list[str],
+    *,
+    markdown: bool,
+) -> None:
+    """Print Spearman ρ between xai_edge_ratio and test_accuracy per dataset."""
+    print("\n" + "=" * 70)
+    print("  XAI ANALYSIS: edge_ratio vs accuracy correlations")
+    print("=" * 70)
+
+    for ds in datasets:
+        ds_runs = [
+            r for r in all_runs
+            if r.get("dataset") == ds
+            and r.get("xai_edge_ratio") is not None
+            and (r.get("test_accuracy") or r.get("held_out_test_metric")) is not None
+        ]
+        if not ds_runs:
+            print(f"  {ds}: no XAI data")
+            continue
+
+        edge_ratios = [float(r["xai_edge_ratio"]) for r in ds_runs]
+        accuracies = [
+            float(r.get("test_accuracy") or r.get("held_out_test_metric") or 0.0)
+            for r in ds_runs
+        ]
+        rho = _spearman_r(edge_ratios, accuracies)
+        rho_s = f"ρ={rho:.3f}" if rho is not None else "ρ=n/a"
+
+        # Mean edge_ratio per condition
+        by_cond: dict[str, list[float]] = defaultdict(list)
+        for r in ds_runs:
+            by_cond[r["condition"]].append(float(r["xai_edge_ratio"]))
+
+        cond_means = {
+            c: float(np.mean(v)) for c, v in by_cond.items() if v
+        }
+        cond_strs = [
+            f"{c}={cond_means[c]:.3f}"
+            for c in ALL_CONDITIONS_ORDERED if c in cond_means
+        ]
+        print(f"  {ds}: {rho_s} (n={len(ds_runs)}) | edge_ratio by condition: {', '.join(cond_strs)}")
+
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Key comparison: bnnr_xai vs bnnr_random per dataset
+# ---------------------------------------------------------------------------
+
+
+def _key_comparison_section(
+    all_runs: list[dict[str, Any]],
+    datasets: list[str],
+    *,
+    no_bootstrap: bool,
+    n_boot: int,
+    markdown: bool,
+) -> None:
+    """bnnr_xai vs bnnr_random, per dataset, with Wilcoxon p-values."""
+    print("\n" + "=" * 70)
+    print("  KEY COMPARISON: bnnr_xai vs bnnr_random (per dataset)")
+    print("  (Isolates the contribution of XAI-guided selection)")
+    print("=" * 70)
+
+    rows = []
+    for ds in datasets:
+        ds_runs = [r for r in all_runs if r.get("dataset") == ds]
+
+        xai_by_seed: dict[int, float] = {}
+        rand_by_seed: dict[int, float] = {}
+        for r in ds_runs:
+            seed = int(r["seed"])
+            metric = float(r.get("held_out_test_metric") or r.get("val_metric") or 0.0)
+            if r["condition"] == "bnnr_xai":
+                xai_by_seed[seed] = metric
+            elif r["condition"] == "bnnr_random":
+                rand_by_seed[seed] = metric
+
+        shared = sorted(set(xai_by_seed) & set(rand_by_seed))
+        if len(shared) < 2:
+            rows.append({
+                "dataset": ds,
+                "n": len(shared),
+                "med_xai": None, "med_rand": None,
+                "delta": None, "p": None, "r": None, "stars": "—",
+                "ci_lo": float("nan"), "ci_hi": float("nan"),
+            })
+            continue
+
+        bx = [xai_by_seed[s] for s in shared]
+        br = [rand_by_seed[s] for s in shared]
+        med_xai = statistics.median(bx)
+        med_rand = statistics.median(br)
+        delta = (med_xai - med_rand) * 100
+
+        wres = _wilcoxon_signed_rank(bx, br)
+        ci_lo, ci_hi = float("nan"), float("nan")
+        if wres is not None and not no_bootstrap:
+            ci_lo, ci_hi = _bootstrap_median_diff_ci(bx, br, n_boot=n_boot, rng_seed=42)
+        W, p, r = wres if wres is not None else (None, None, None)
+        rows.append({
+            "dataset": ds,
+            "n": len(shared),
+            "med_xai": med_xai, "med_rand": med_rand,
+            "delta": delta, "p": p, "r": r,
+            "stars": _sig_stars(p),
+            "ci_lo": ci_lo, "ci_hi": ci_hi,
+        })
+
+    if markdown:
+        print("| Dataset | n | bnnr_xai | bnnr_random | Δ | p | stars | r | Bootstrap 95% CI |")
+        print("|---------|---|----------|-------------|---|---|-------|---|-----------------|")
+        for row in rows:
+            if row["med_xai"] is None:
+                print(f"| {row['dataset']} | {row['n']} | — | — | — | — | — | — | — |")
+                continue
+            ci_s = (
+                f"[{row['ci_lo']*100:+.2f}, {row['ci_hi']*100:+.2f}]pp"
+                if not (math.isnan(row["ci_lo"]) or math.isnan(row["ci_hi"]))
+                else "—"
+            )
+            print(
+                f"| {row['dataset']} "
+                f"| {row['n']} "
+                f"| {row['med_xai']*100:.2f}% "
+                f"| {row['med_rand']*100:.2f}% "
+                f"| {row['delta']:+.2f}pp "
+                f"| {_p_label(row['p'])} "
+                f"| {row['stars']} "
+                f"| {row['r']:.2f} "
+                f"| {ci_s} |"
+            )
+    else:
+        print(
+            f"{'Dataset':<12} {'n':>3} {'bnnr_xai':>10} {'bnnr_random':>12} "
+            f"{'Δ':>8} {'p':>10} {'sig':>5} {'r':>6}"
+        )
+        print("-" * 75)
+        for row in rows:
+            if row["med_xai"] is None:
+                print(f"  {row['dataset']:<12} {row['n']:>3}  insufficient data")
+                continue
+            ci_s = ""
+            if not (math.isnan(row["ci_lo"]) or math.isnan(row["ci_hi"])):
+                ci_s = f"  CI=[{row['ci_lo']*100:+.2f},{row['ci_hi']*100:+.2f}]pp"
+            print(
+                f"  {row['dataset']:<12} {row['n']:>3} "
+                f"{row['med_xai']*100:>9.2f}% "
+                f"{row['med_rand']*100:>11.2f}% "
+                f"{row['delta']:>+7.2f}pp "
+                f"{_p_label(row['p']):>10} "
+                f"{row['stars']:>5} "
+                f"{row['r']:>5.2f}"
+                f"{ci_s}"
+            )
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Compute transparency
+# ---------------------------------------------------------------------------
+
+
+def _compute_transparency_section(
+    all_runs: list[dict[str, Any]],
+    datasets: list[str],
+) -> None:
+    """Print median total_gpu_epochs per condition."""
+    print("\n" + "=" * 70)
+    print("  COMPUTE TRANSPARENCY: median total_gpu_epochs per condition")
+    print("=" * 70)
+    for ds in datasets:
+        ds_runs = [r for r in all_runs if r.get("dataset") == ds]
+        if not ds_runs:
+            continue
+        by_cond: dict[str, list[int]] = defaultdict(list)
+        for r in ds_runs:
+            ep = r.get("total_gpu_epochs")
+            if ep is not None:
+                by_cond[r["condition"]].append(int(ep))
+        parts = [
+            f"{c}={int(statistics.median(by_cond[c]))}"
+            for c in ALL_CONDITIONS_ORDERED
+            if c in by_cond and by_cond[c]
+        ]
+        if parts:
+            print(f"  {ds}: {', '.join(parts)}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        default=BENCHMARKS_DIR,
+        help="Directory containing results_*.json files (default: benchmarks/)",
+    )
+    parser.add_argument(
+        "--datasets",
+        default=None,
+        help="Comma-separated datasets to include (default: all found)",
+    )
+    parser.add_argument(
+        "--regime",
+        default="all",
+        choices=["scratch", "pretrained", "all"],
+        help="Filter by regime (default: all)",
+    )
+    parser.add_argument("--markdown", action="store_true", help="Output markdown tables")
+    parser.add_argument("--no-bootstrap", action="store_true", help="Skip bootstrap CI")
+    parser.add_argument(
+        "--bootstrap-n",
+        type=int,
+        default=10_000,
+        help="Bootstrap resampling iterations (default 10000)",
+    )
+    args = parser.parse_args()
+
+    if not args.results_dir.exists():
+        raise SystemExit(f"Results directory not found: {args.results_dir}")
+
+    all_runs = _load_all_runs(args.results_dir, args.regime)
+    if not all_runs:
+        raise SystemExit(
+            f"No valid runs found in {args.results_dir} "
+            f"(regime filter: {args.regime}).\n"
+            "Run: python benchmarks/run_grand_benchmark.py --dataset imagewoof --smoke"
+        )
+
+    # Determine which datasets to analyse
+    if args.datasets is not None:
+        datasets = [d.strip() for d in args.datasets.split(",") if d.strip()]
+    else:
+        found = sorted({r.get("dataset", "unknown") for r in all_runs})
+        datasets = [d for d in ALL_DATASETS if d in found]
+        if not datasets:
+            datasets = found
+
+    print(f"\nGrand Benchmark Summary  |  regime={args.regime}")
+    print(f"Results dir: {args.results_dir}")
+    print(f"Datasets: {', '.join(datasets)}")
+    print(f"Total valid runs: {len(all_runs)}")
+
+    # 1. Per-dataset tables
+    for ds in datasets:
+        _analyze_dataset(
+            ds, all_runs,
+            no_bootstrap=args.no_bootstrap,
+            n_boot=args.bootstrap_n,
+            markdown=args.markdown,
+        )
+
+    # 2. Cross-dataset summary table
+    _cross_dataset_table(all_runs, datasets, markdown=args.markdown)
+
+    # 3. XAI correlation section
+    _xai_correlation_section(all_runs, datasets, markdown=args.markdown)
+
+    # 4. Key comparison: bnnr_xai vs bnnr_random
+    _key_comparison_section(
+        all_runs, datasets,
+        no_bootstrap=args.no_bootstrap,
+        n_boot=args.bootstrap_n,
+        markdown=args.markdown,
+    )
+
+    # 5. Compute transparency
+    _compute_transparency_section(all_runs, datasets)
+
+    # Footer
+    print(
+        "\nStatistical notes:"
+        "\n  Tests: Wilcoxon signed-rank (paired, two-sided) — scipy if available, "
+        "else exact enumeration (n<=15) or normal approx."
+        "\n  Multiple testing: Holm-Bonferroni correction over all pairwise tests vs bnnr_xai."
+        "\n  Bootstrap CI: paired (bnnr_xai - baseline) median difference."
+        "\n  Effect size r: rank-biserial correlation = 1 - 2W/(n*(n+1))."
+        "\n  Significance: *** p<0.001, ** p<0.01, * p<0.05, ns p>=0.05."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replaces #233 with a clean branch off current `main` (the old branch was 6 commits behind and carried unrelated `src/`, `docs/`, version, and `uv.lock` changes that would have regressed v0.4.13). Only the benchmark files land here.

## What this adds

A paper-grade benchmark harness for the full BNNR augmentation ablation under a fair protocol.

- **10 conditions:** `no_aug`, `randaugment`, `trivialaugment`, `autoaugment`, `churchnoise_only`, `icd_only`, `aicd_only`, `icd_aicd_fixed`, `bnnr_random`, `bnnr_xai`.
- **6 datasets** via a unified loader registry (imagewoof, pets, flowers102, dtd, aircraft, eurosat), each with a 3-way `train / selection_val / held_out_test` split.
- **Equal total GPU-epoch budget** across every condition.
- **`bnnr_random`** is the XAI ablation: identical compute and augmentation pool as `bnnr_xai` but random candidate selection, so `bnnr_xai` vs `bnnr_random` isolates XAI-guided selection.
- **Extended metrics** (F1-macro, Top-5, Cohen kappa, ECE) plus XAI metrics (edge ratio, gini, coverage, entropy, center bias).
- **`summarize_grand.py`:** Wilcoxon signed-rank, bootstrap 95% CI, Holm-Bonferroni, rank-biserial effect size, compute-transparency table.

## Protocol correctness (changed vs #233)

The original #233 selected the best epoch on the **held-out test set** for the plain and single-aug conditions, while only the BNNR conditions used `selection_val`. That contradicted the script's own "held-out test reserved for final reporting" claim and biased baselines upward. Fixed here: **every condition selects its best epoch on `selection_val`; the held-out test split is evaluated exactly once.** No condition early-stops on the test set.

A runtime bug in the summarizer (undefined name in the compute-transparency line) and a few dead-code lint findings were also fixed.

The per-model epoch asymmetry under equal compute (the bnnr_xai/bnnr_random final model trains fewer epochs than single-aug conditions) is documented as an explicit protocol caveat.

## Verification

Smoke run on CPU end-to-end across all three code paths (plain, warmup, equal-compute) for `no_aug`, `icd_only`, `bnnr_xai`, `bnnr_random`: exit 0, every condition reports distinct `selection_val` and `held_out_test` metrics, equal compute confirmed (4 GPU-epochs each), `summarize_grand.py` produces the full table without error.

## Hypotheses this run can prove

| Claim | Comparison |
|-------|-----------|
| XAI-guided selection beats random selection | `bnnr_xai` vs `bnnr_random` |
| ICD / AICD each help on their own | `icd_only` / `aicd_only` vs `no_aug` |
| Branch search beats the best single augmentation | `bnnr_xai` vs best `*_only` |
| BNNR beats strong external baselines | vs RandAugment, TrivialAugment, AutoAugment |
| ICD reduces shortcut learning | XAI metrics |
| Results generalize across domains | 6 datasets |

Numbers land after a GPU run; the primary Imagewoof matrix (10 conditions x 10 seeds) gives the headline `bnnr_xai` vs `bnnr_random` comparison first.
