### PR TITLE
fix: precompute XAI cache after baseline and isolate it per run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- XAI cache for `ICD`/`AICD` is now precomputed **after** the baseline phase (on the trained baseline model) instead of before it (on random initial weights), so saliency-guided masks are no longer driven by an untrained network in from-scratch runs.
+- The cache now defaults to a per-run directory (`<report_dir>/run_<timestamp>/xai_cache`) and carries a `manifest.json` (XAI method, dataset size, image shape); stale maps are dropped on a mismatch. This stops a different model from silently reusing another run's cached saliency under a shared `checkpoint_dir`.
+
 ## [0.4.13] — 2026-06-09
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,11 +124,13 @@ trainer = BNNRTrainer(
 - `xai_enabled` (default: `true`)
 - `xai_samples` (default: `4`)
 - `xai_method` (`opticam`, `gradcam`, `craft`, `nmf`, `nmf_concepts`, `real_craft`; default: `opticam`)
-- `xai_cache_dir` (default: `null`)
+- `xai_cache_dir` (default: `null`): when `null`, the cache lives under the current run directory (`<report_dir>/run_<timestamp>/xai_cache`), so saliency maps are never silently reused across runs. Set an explicit path to share a cache between runs (you own invalidation in that case).
 - `xai_cache_samples` (default: `0` = whole dataset)
 - `xai_cache_max_samples` (default: `50000`)
 - `xai_cache_force_recompute` (default: `false`)
 - `xai_cache_progress` (default: `true`)
+
+The XAI cache is precomputed **after** the baseline phase, so masks from `ICD`/`AICD` are guided by the trained baseline model rather than random initial weights, and is computed once for all branch-search iterations. A `manifest.json` records the XAI method, dataset size, and image shape; if any of these differs from the cached maps (for example a different `xai_method` against an explicit `xai_cache_dir`), the stale maps are dropped and recomputed.
 - `xai_selection_weight` (default: `0.0`, validated to `[0,1]`)
 - `xai_pruning_threshold` (default: `0.0`, validated to `[0,1]`)
 - `adaptive_icd_threshold` (default: `false`)

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -288,13 +288,6 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
         log_dataset_profile(dataset_profile)
     trainer._emit_pipeline_phase("dataset_profiling", "completed")
 
-    trainer._emit_pipeline_phase("xai_cache", "started", "Precomputing XAI cache...")
-    xai_cache = _xai.precompute_xai_cache(trainer)
-    if xai_cache is None:
-        trainer._emit_pipeline_phase("xai_cache", "skipped")
-    else:
-        trainer._emit_pipeline_phase("xai_cache", "completed")
-
     baseline_metrics: dict[str, float]
     best_metrics: dict[str, float]
     if trainer.current_iteration > 0:
@@ -415,6 +408,17 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
     current_branch_id = "root:baseline"
     start_iteration = max(1, trainer.current_iteration or 1)
     resume_iteration = trainer.current_iteration if trainer.current_iteration > 0 else None
+
+    # XAI cache is precomputed AFTER the baseline phase so saliency maps reflect the
+    # trained baseline model rather than random initial weights. It is stored under the
+    # run directory (never reused across runs) and computed once for all iterations,
+    # matching the equal-compute benchmark protocol.
+    trainer._emit_pipeline_phase("xai_cache", "started", "Precomputing XAI cache...")
+    xai_cache = _xai.precompute_xai_cache(trainer)
+    if xai_cache is None:
+        trainer._emit_pipeline_phase("xai_cache", "skipped")
+    else:
+        trainer._emit_pipeline_phase("xai_cache", "completed")
 
     for iteration in tqdm(
         range(start_iteration, trainer.config.max_iterations + 1),

--- a/src/bnnr/training/xai_runner.py
+++ b/src/bnnr/training/xai_runner.py
@@ -654,7 +654,11 @@ def precompute_xai_cache(trainer) -> XAICache | None:
     if not needs_cache:
         return None
 
-    cache_dir = trainer.config.xai_cache_dir or (trainer.config.checkpoint_dir / "xai_cache")
+    # Default the cache under the (timestamped) run directory so saliency maps are
+    # never silently reused across runs. An explicit config.xai_cache_dir still wins.
+    run_dir = getattr(trainer.reporter, "run_dir", None)
+    default_cache_dir = (run_dir / "xai_cache") if run_dir is not None else (trainer.config.checkpoint_dir / "xai_cache")
+    cache_dir = trainer.config.xai_cache_dir or default_cache_dir
     cache = XAICache(cache_dir)
 
     # Resolve n_samples: 0 means "cache all", capped by xai_cache_max_samples

--- a/src/bnnr/xai_cache.py
+++ b/src/bnnr/xai_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 from pathlib import Path
 
@@ -15,6 +16,37 @@ from tqdm import tqdm
 from bnnr.xai import BaseExplainer, generate_saliency_maps
 
 logger = logging.getLogger(__name__)
+
+# Manifest describing what produced the cached maps. A mismatch (different XAI
+# method, dataset size, or image shape) invalidates the cache so stale saliency
+# maps are never reused, e.g. across runs that share an explicit cache dir.
+_MANIFEST_FILENAME = "manifest.json"
+_MANIFEST_SCHEMA = 1
+
+
+def _safe_dataset_size(loader: DataLoader) -> int | None:
+    """Best-effort dataset length; ``None`` when the loader has no sized dataset."""
+    try:
+        return int(len(loader.dataset))  # type: ignore[arg-type]
+    except (TypeError, AttributeError):
+        return None
+
+
+def _safe_image_shape(loader: DataLoader) -> list[int] | None:
+    """Best-effort image shape from the first sample; ``None`` if unavailable."""
+    dataset = getattr(loader, "dataset", None)
+    if dataset is None:
+        return None
+    try:
+        sample = dataset[0]
+    except Exception:
+        return None
+    img = sample[0] if isinstance(sample, (list, tuple)) else sample
+    shape = getattr(img, "shape", None)
+    if shape is None:
+        return None
+    return [int(x) for x in shape]
+
 
 # Prefer xxhash (much faster) if available, else fall back to sha256.
 # Benchmarks show sha256 is faster than md5 on modern CPUs with
@@ -42,6 +74,49 @@ class XAICache:
 
     def _index_cache_path(self, sample_index: int, label: int) -> Path:
         return self.cache_dir / f"idx_{sample_index}_{label}.npy"
+
+    # ------------------------------------------------------------------
+    # Manifest-based invalidation
+    # ------------------------------------------------------------------
+
+    def _manifest_path(self) -> Path:
+        return self.cache_dir / _MANIFEST_FILENAME
+
+    def _load_manifest(self) -> dict | None:
+        path = self._manifest_path()
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _ensure_cache_consistent(
+        self,
+        *,
+        method: str,
+        dataset_size: int | None,
+        image_shape: list[int] | None,
+        force_recompute: bool,
+    ) -> None:
+        """Drop cached maps whose provenance differs from the current request.
+
+        Writes a manifest of ``{method, dataset_size, image_shape}``. When an
+        existing manifest does not match (or ``force_recompute`` is set), all
+        ``*.npy`` maps are removed so they are recomputed from the current
+        model/method/dataset instead of silently reused.
+        """
+        desired = {
+            "schema": _MANIFEST_SCHEMA,
+            "method": method,
+            "dataset_size": dataset_size,
+            "image_shape": image_shape,
+        }
+        if not force_recompute and self._load_manifest() == desired:
+            return
+        for npy in self.cache_dir.glob("*.npy"):
+            npy.unlink(missing_ok=True)
+        self._manifest_path().write_text(json.dumps(desired), encoding="utf-8")
 
     # ------------------------------------------------------------------
     # Lazy-caching: persist a single saliency map computed on-the-fly
@@ -119,6 +194,16 @@ class XAICache:
             is exhausted).
         """
         model.eval()
+
+        # Invalidate stale maps (different method/dataset/image shape) before any
+        # fast-skip so we never reuse another run's saliency.
+        self._ensure_cache_consistent(
+            method=method,
+            dataset_size=_safe_dataset_size(train_loader),
+            image_shape=_safe_image_shape(train_loader),
+            force_recompute=force_recompute,
+        )
+
         written = 0
         processed = 0
         skipped_batches = 0

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -51,3 +51,76 @@ def test_run_single_iteration_returns_best_epoch(mock_trainer: MagicMock) -> Non
     assert state == {"w": 1}
     assert mock_train.call_count == 2
     assert mock_eval.call_count == 2
+
+
+def test_precompute_runs_after_baseline_and_under_run_dir(temp_dir, monkeypatch) -> None:
+    """XAI cache is precomputed after the baseline phase and stored under run_dir."""
+    import torch
+    import torch.nn as nn
+    from torch.utils.data import DataLoader, TensorDataset
+
+    import bnnr.training.loop as loop_mod
+    from bnnr.core import BNNRConfig, BNNRTrainer, SimpleTorchAdapter
+    from bnnr.icd import ICD
+
+    class TinyCNN(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv1 = nn.Conv2d(3, 6, 3, padding=1)
+            self.pool = nn.AdaptiveAvgPool2d((1, 1))
+            self.fc = nn.Linear(6, 4)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            x = torch.relu(self.conv1(x))
+            return self.fc(self.pool(x).flatten(1))
+
+    torch.manual_seed(0)
+    x = torch.rand(12, 3, 8, 8)
+    y = torch.randint(0, 4, (12,))
+    loader = DataLoader(TensorDataset(x, y), batch_size=4, shuffle=False)
+    model = TinyCNN()
+    adapter = SimpleTorchAdapter(
+        model=model,
+        criterion=nn.CrossEntropyLoss(),
+        optimizer=torch.optim.Adam(model.parameters(), lr=1e-3),
+        target_layers=[model.conv1],
+        device="cpu",
+    )
+    cfg = BNNRConfig(
+        m_epochs=1,
+        max_iterations=1,
+        xai_enabled=True,
+        device="cpu",
+        checkpoint_dir=temp_dir / "ckpt",
+        report_dir=temp_dir / "reports",
+        save_checkpoints=False,
+    )
+    icd = ICD(model=model, target_layers=[model.conv1], probability=1.0, random_state=0)
+
+    order: list[str] = []
+    real_train = loop_mod.train_epoch
+    real_precompute = loop_mod._xai.precompute_xai_cache
+
+    def traced_train(trainer, ldr, augmentations=None):
+        order.append("train")
+        return real_train(trainer, ldr, augmentations)
+
+    def traced_precompute(trainer):
+        order.append("precompute")
+        return real_precompute(trainer)
+
+    monkeypatch.setattr(loop_mod, "train_epoch", traced_train)
+    monkeypatch.setattr(loop_mod._xai, "precompute_xai_cache", traced_precompute)
+
+    trainer = BNNRTrainer(adapter, loader, loader, [icd], cfg)
+    trainer.run()
+
+    assert "precompute" in order
+    # At least one (baseline) train epoch ran before the cache was precomputed.
+    assert order.index("train") < order.index("precompute")
+
+    run_cache = trainer.reporter.run_dir / "xai_cache"
+    assert run_cache.exists()
+    assert (run_cache / "manifest.json").exists()
+    # Default cache must not land in the shared checkpoint_dir.
+    assert not (cfg.checkpoint_dir / "xai_cache").exists()

--- a/tests/test_xai_cache.py
+++ b/tests/test_xai_cache.py
@@ -2,11 +2,29 @@
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
-from bnnr.xai_cache import XAICache
+from bnnr.xai_cache import (
+    _MANIFEST_SCHEMA,
+    XAICache,
+    _safe_dataset_size,
+    _safe_image_shape,
+)
+
+
+def _write_matching_manifest(cache: XAICache, loader: DataLoader, method: str) -> None:
+    """Mark the cache as produced by *method* on *loader* so it is reusable."""
+    manifest = {
+        "schema": _MANIFEST_SCHEMA,
+        "method": method,
+        "dataset_size": _safe_dataset_size(loader),
+        "image_shape": _safe_image_shape(loader),
+    }
+    cache._manifest_path().write_text(json.dumps(manifest), encoding="utf-8")
 
 
 def test_xai_cache_save_and_get(temp_dir) -> None:
@@ -33,12 +51,16 @@ def test_xai_cache_get_by_sample_index(temp_dir) -> None:
 
 def test_precompute_cache_skips_when_existing_entries_cover_target(temp_dir, dummy_model, monkeypatch) -> None:
     cache = XAICache(temp_dir / "xai_cache")
-    for idx in range(3):
-        np.save(cache.cache_dir / f"existing_{idx}.npy", np.zeros((4, 4), dtype=np.float32))
 
     x = torch.rand(3, 3, 8, 8)
     y = torch.randint(0, 2, (3,))
     loader = DataLoader(TensorDataset(x, y), batch_size=3)
+
+    # A matching manifest marks the existing entries as same-provenance, so the
+    # count-based fast-skip is allowed to reuse them.
+    _write_matching_manifest(cache, loader, "opticam")
+    for idx in range(3):
+        np.save(cache.cache_dir / f"existing_{idx}.npy", np.zeros((4, 4), dtype=np.float32))
 
     called = {"value": False}
 
@@ -58,4 +80,93 @@ def test_precompute_cache_skips_when_existing_entries_cover_target(temp_dir, dum
     )
 
     assert written == 0
+    assert called["value"] is False
+
+
+def test_precompute_writes_manifest(temp_dir, dummy_model, monkeypatch) -> None:
+    cache = XAICache(temp_dir / "xai_cache")
+    x = torch.rand(2, 3, 8, 8)
+    y = torch.randint(0, 2, (2,))
+    loader = DataLoader(TensorDataset(x, y), batch_size=2)
+
+    monkeypatch.setattr(
+        "bnnr.xai_cache.generate_saliency_maps",
+        lambda *_a, **_k: np.zeros((2, 8, 8), dtype=np.float32),
+    )
+    cache.precompute_cache(
+        model=dummy_model,
+        train_loader=loader,
+        target_layers=[dummy_model.conv1],
+        n_samples=2,
+        method="opticam",
+    )
+
+    manifest = json.loads(cache._manifest_path().read_text(encoding="utf-8"))
+    assert manifest["schema"] == _MANIFEST_SCHEMA
+    assert manifest["method"] == "opticam"
+    assert manifest["dataset_size"] == 2
+    assert manifest["image_shape"] == [3, 8, 8]
+
+
+def test_precompute_invalidates_on_manifest_mismatch(temp_dir, dummy_model, monkeypatch) -> None:
+    cache = XAICache(temp_dir / "xai_cache")
+    x = torch.rand(3, 3, 8, 8)
+    y = torch.randint(0, 2, (3,))
+    loader = DataLoader(TensorDataset(x, y), batch_size=3)
+
+    # Stale maps left by a run that used a different XAI method.
+    _write_matching_manifest(cache, loader, "craft")
+    for idx in range(3):
+        np.save(cache.cache_dir / f"idx_{idx}_0.npy", np.zeros((4, 4), dtype=np.float32))
+
+    called = {"value": False}
+
+    def _fake_generate(*_args, **_kwargs):
+        called["value"] = True
+        return np.zeros((3, 8, 8), dtype=np.float32)
+
+    monkeypatch.setattr("bnnr.xai_cache.generate_saliency_maps", _fake_generate)
+    written = cache.precompute_cache(
+        model=dummy_model,
+        train_loader=loader,
+        target_layers=[dummy_model.conv1],
+        n_samples=3,
+        method="opticam",
+    )
+
+    # Method changed (craft -> opticam): stale maps were dropped and recomputed.
+    assert called["value"] is True
+    assert written == 3
+    assert json.loads(cache._manifest_path().read_text(encoding="utf-8"))["method"] == "opticam"
+
+
+def test_precompute_reuses_on_manifest_match(temp_dir, dummy_model, monkeypatch) -> None:
+    cache = XAICache(temp_dir / "xai_cache")
+    x = torch.rand(3, 3, 8, 8)
+    y = torch.zeros(3, dtype=torch.long)
+    loader = DataLoader(TensorDataset(x, y), batch_size=3)
+
+    monkeypatch.setattr(
+        "bnnr.xai_cache.generate_saliency_maps",
+        lambda *_a, **_k: np.zeros((3, 8, 8), dtype=np.float32),
+    )
+    first = cache.precompute_cache(
+        model=dummy_model, train_loader=loader, target_layers=[dummy_model.conv1],
+        n_samples=3, method="opticam",
+    )
+    assert first == 3
+
+    called = {"value": False}
+
+    def _fake_generate(*_args, **_kwargs):
+        called["value"] = True
+        return np.zeros((3, 8, 8), dtype=np.float32)
+
+    monkeypatch.setattr("bnnr.xai_cache.generate_saliency_maps", _fake_generate)
+    second = cache.precompute_cache(
+        model=dummy_model, train_loader=loader, target_layers=[dummy_model.conv1],
+        n_samples=3, method="opticam",
+    )
+    # Same provenance: nothing recomputed.
+    assert second == 0
     assert called["value"] is False


### PR DESCRIPTION
Closes #252.

## Problem
`ICD`/`AICD` saliency maps were precomputed **before** the baseline phase (`training/loop.py`), so for from-scratch training the masks were guided by the saliency of an untrained model for the whole run. The cache also defaulted to the shared `checkpoint_dir/xai_cache` with keys (`idx_<sample>_<label>` / `<hash>_<label>`) that carry no model or run discriminator, so a later run with a different model could silently reuse stale maps.

## Change (surgical)
1. Move the `precompute_xai_cache` call to after the baseline phase, just before the iteration loop, so maps reflect the trained baseline model. Runs in both fresh and resume paths; nothing before the loop consumes the cache.
2. Default the cache to the per-run directory (`<report_dir>/run_<timestamp>/xai_cache`) instead of the shared `checkpoint_dir`. An explicit `config.xai_cache_dir` still wins.
3. Add a `manifest.json` (xai method, dataset size, image shape) written by `precompute_cache`; on a mismatch (or `force_recompute`) stale `*.npy` maps are dropped and recomputed. No model hash, so resume stays consistent.

Computed once per run for all iterations, matching the equal-compute benchmark protocol (no per-iteration refresh).

## Tests
- `tests/test_xai_cache.py`: manifest written; mismatch drops stale maps and recomputes; match reuses (no recompute); existing fast-skip test updated to establish provenance first.
- `tests/test_training_loop.py`: end-to-end tiny ICD run asserts precompute happens after baseline training and the cache lands under `run_dir` (not `checkpoint_dir`).

## Scope
Correctness only. Cache eviction / size bound (FINDING-11) is split to #275.

## Out of scope / follow-up
Per-iteration cache refresh was deliberately not added (matches benchmark protocol).