### PR TITLE
Release v0.4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.14] — 2026-06-09
+
 ### Fixed
 
 - XAI cache for `ICD`/`AICD` is now precomputed **after** the baseline phase (on the trained baseline model) instead of before it (on random initial weights), so saliency-guided masks are no longer driven by an untrained network in from-scratch runs.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
 repository-code: "https://github.com/bnnr-team/bnnr"
 url: "https://github.com/bnnr-team/bnnr"
 license: MIT
-version: 0.4.13
+version: 0.4.14
 date-released: 2026-06-09
 doi: 10.5281/zenodo.20581372
 
@@ -32,7 +32,7 @@ preferred-citation:
   title: "BNNR (Bulletproof Neural Network Recipe)"
   year: 2026
   url: "https://github.com/bnnr-team/bnnr"
-  version: 0.4.13
+  version: 0.4.14
   doi: 10.5281/zenodo.20581372
 
 references:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run `bnnr analyze` on a trained model and you get a self-contained HTML report: 
 - **My augmentations are guesswork.** → ICD/AICD condition augmentation on saliency maps, then a branch search keeps only the augmentations that measurably improve your validation metric.
 - **I need to prove model quality to stakeholders or compliance.** → A portable `report.html` plus a structured JSON audit artifact you can attach to a review.
 
-<sub>BNNR also ships a training pipeline (`bnnr train`), a live dashboard, multi-label support, and object detection (YOLO / COCO-mini). Single-label classification is the focus for `analyze`. Supported tasks in **v0.4.13**: single-label classification, multi-label classification, object detection. Full docs: [docs/README.md](docs/README.md) ([analyze](docs/analyze.md) · [detection](docs/detection.md) · [benchmarks](docs/benchmarks.md)).</sub>
+<sub>BNNR also ships a training pipeline (`bnnr train`), a live dashboard, multi-label support, and object detection (YOLO / COCO-mini). Single-label classification is the focus for `analyze`. Supported tasks in **v0.4.14**: single-label classification, multi-label classification, object detection. Full docs: [docs/README.md](docs/README.md) ([analyze](docs/analyze.md) · [detection](docs/detection.md) · [benchmarks](docs/benchmarks.md)).</sub>
 
 ---
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -34,7 +34,7 @@
 
 **BNNR automatically improves your PyTorch vision models using XAI** — find what your model gets wrong, fix it with intelligent augmentation, and prove the result with structured reports and a live dashboard.
 
-Supported tasks (**v0.4.13**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md).
+Supported tasks (**v0.4.14**): single-label classification, multi-label classification, and object detection (COCO-mini / YOLO). See [Documentation](https://github.com/bnnr-team/bnnr/blob/main/docs/README.md).
 
 **Sample analyze report (no install):** [live HTML preview](https://raw.githack.com/bnnr-team/bnnr/refs/heads/main/docs/assets/analyze-report-sample.html)
 

--- a/docs/assets/analyze-report-sample.html
+++ b/docs/assets/analyze-report-sample.html
@@ -396,7 +396,7 @@ tr:hover td { background: rgba(240,160,105,0.03); }
 <div>
 <h1>BNNR Analysis Report</h1>
 <div class="report-meta">
-<span>v0.4.13</span>
+<span>v0.4.14</span>
 <span>Classification</span>
 <span>10 classes · 10,000 samples</span>
 </div></div></div>
@@ -436,6 +436,6 @@ tr:hover td { background: rgba(240,160,105,0.03); }
 <div class="rec-grid"><div class="rec-card"><div class="rec-header"><span class="rec-priority" style="min-width:22px;text-align:center;">1</span><span class="rec-title">Reduce top class confusions: 4, 9, 7, 5, 8, 3</span> <span class="badge badge-ok">Observed</span></div><div class="rec-why">label 4 recall=80%. label 9 recall=86%. label 7 recall=78%.</div><div class="rec-evidence" style="font-size:11px;color:var(--muted);margin-top:4px;"><strong>From this run:</strong> label 4 recall=80%; label 9 recall=86%; label 7 recall=78%; count=145; count=144</div><div class="rec-action">→ Inspect XAI overlays for both classes (see Confusion Analysis section). Pair-specific augmentation or metric learning (ArcFace; Deng et al., CVPR 2019) increases inter-class separation.</div><div style="font-size:12px;color:var(--green);margin-top:6px;padding:4px 10px;background:rgba(34,197,94,0.08);border-radius:6px;border:1px solid rgba(34,197,94,0.2);">[Observed] Literature context (not verified on this run): Targeted data collection or metric learning often reduces specific confusions; quantify with your confusion matrix after changes.</div><div style="font-size:10px;color:var(--muted);margin-top:4px;font-style:italic;">📚 Deng et al., ArcFace, CVPR 2019</div></div></div>
 </div>
 </div></div>
-<div class="footer"><div class="brand">BNNR — Train → Explain → Improve → Prove</div><div class="tagline">Helping your model earn its place in production.</div><div style="margin-top:8px;">BNNR v0.4.13</div></div>
+<div class="footer"><div class="brand">BNNR — Train → Explain → Improve → Prove</div><div class="tagline">Helping your model earn its place in production.</div><div style="margin-top:8px;">BNNR v0.4.14</div></div>
 </div>
 </body></html>

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,6 +1,6 @@
 # Citing BNNR
 
-If you use BNNR in research, a report, or a downstream integration guide, cite the appropriate entry below. Pin a [release tag](https://github.com/bnnr-team/bnnr/releases) (for example `v0.4.13`) when you need a fixed software version.
+If you use BNNR in research, a report, or a downstream integration guide, cite the appropriate entry below. Pin a [release tag](https://github.com/bnnr-team/bnnr/releases) (for example `v0.4.14`) when you need a fixed software version.
 
 Authors (software): Mateusz Walo, Diana Morzhak, Dominika Zydorczyk, Zuzanna Saczuk ([team record](../AUTHORS.md)).
 
@@ -38,7 +38,7 @@ Plain text (papers without BibTeX):
   title = {{BNNR}: Bulletproof Neural Network Recipe},
   year = {2026},
   url = {https://github.com/bnnr-team/bnnr},
-  version = {0.4.13},
+  version = {0.4.14},
   doi = {10.5281/zenodo.20581372},
   license = {MIT}
 }

--- a/docs/plugin_icd.md
+++ b/docs/plugin_icd.md
@@ -87,7 +87,7 @@ If you use ICD/AICD from BNNR in research, cite the **method paper**, **BNNR sof
   title = {{BNNR}: Bulletproof Neural Network Recipe},
   year = {2026},
   url = {https://github.com/bnnr-team/bnnr},
-  version = {0.4.13},
+  version = {0.4.14},
   doi = {10.5281/zenodo.20581372},
   license = {MIT}
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Product roadmap
 
-**Updated:** 2026-06-09 · **Current release:** v0.4.13
+**Updated:** 2026-06-09 · **Current release:** v0.4.14
 
 BNNR is a PyTorch vision toolkit focused on **model diagnostics first** (`bnnr analyze`), then saliency-guided augmentations (ICD/AICD), with optional training and detection adapters.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bnnr"
-version = "0.4.13"
+version = "0.4.14"
 description = "BNNR: XAI-driven augmentation & diagnostics for PyTorch vision - find model failures, fix with saliency-guided augmentation (ICD/AICD), prove with auditable reports."
 readme = "README.pypi.md"
 license = { text = "MIT" }

--- a/src/bnnr/version.py
+++ b/src/bnnr/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the BNNR package version (also used as analyze report schema version)."""
 
-__version__ = "0.4.13"
+__version__ = "0.4.14"


### PR DESCRIPTION
Patch release bundling the XAI cache correctness fix (#252 / #276).

## Version bump
- `src/bnnr/version.py`, `pyproject.toml`, `CITATION.cff` (software + preferred-citation): 0.4.13 -> 0.4.14
- README task-support notes updated to v0.4.14
- CHANGELOG `[0.4.14]` entry rolled from Unreleased

## Included since 0.4.13
- fix: precompute XAI cache after the baseline phase and isolate it per run (#276)

After merge, pushing the `v0.4.14` tag triggers the `publish-pypi` job.