### PR TITLE
chore: anchor release-please to v0.4.14 and use v-prefixed tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "80cf94053cddc08b5776ecea6d39a1f64cd05d69",
   "packages": {
     ".": {
       "release-type": "python",
       "package-name": "bnnr",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "extra-files": [
         "src/bnnr/version.py",
         "CITATION.cff",


### PR DESCRIPTION
Fixes the first release-please run proposing **0.5.0** (in PR #280) instead of **0.4.15**.

## Why it went wrong
- No GitHub Release existed for `v0.4.14` (the tag was pushed manually under the old flow), so release-please had no baseline and walked the entire history, aggregating every historical `feat:` into a minor bump and a full-history changelog.
- The default tag format is component-prefixed (`bnnr-v0.4.14`), which does not match the repo's `v0.4.x` convention, so the existing tag was not matched either.

## Fix
- `include-component-in-tag: false` -> tags are `v<version>` (matches existing `v0.4.x`), not `bnnr-v<version>`.
- `last-release-sha` pinned to the `v0.4.14` release commit so only commits after it are considered.
- Also created the missing GitHub Release for `v0.4.14` (anchor + hygiene).

After this merges, release-please recomputes: range = commits since v0.4.14 = one `fix:` -> **0.4.15** with a clean changelog. The stale 0.5.0 PR (#280) will be replaced/closed.

`chore:` so this does not itself trigger a release.