### PR TITLE
fix: make ICD/AICD CPU-bound to remove apply_tensor recursion

### DIFF
--- a/src/bnnr/icd.py
+++ b/src/bnnr/icd.py
@@ -32,7 +32,9 @@ class _BaseICD(BaseAugmentation):
     """
 
     invert_mask: bool = False
-    device_compatible: bool = True
+    # ICD/AICD masking runs on the numpy/OpenCV path and needs per-sample labels,
+    # so it is CPU-bound (not a GPU-native tensor augmentation).
+    device_compatible: bool = False
 
     def __init__(
         self,
@@ -94,17 +96,6 @@ class _BaseICD(BaseAugmentation):
                 RuntimeWarning,
                 stacklevel=2,
             )
-
-    # ------------------------------------------------------------------
-    # Tensor entry-point (delegates to numpy path)
-    # ------------------------------------------------------------------
-
-    def apply_tensor_native(self, images: torch.Tensor) -> torch.Tensor:
-        """GPU-native ICD/AICD masking using cached saliency maps.
-
-        Falls back to CPU path if cache is unavailable or labels are not set.
-        """
-        return self.apply_tensor(images)
 
     # ------------------------------------------------------------------
     # Label helpers

--- a/tests/test_icd.py
+++ b/tests/test_icd.py
@@ -150,3 +150,23 @@ def test_cache_miss_computes_online(dummy_model, temp_dir) -> None:
     assert out.shape == image.shape
     # Verify the miss counter was incremented
     assert aug._cache_miss_count >= 1
+
+
+def test_icd_is_cpu_bound_and_apply_tensor_does_not_recurse(dummy_model) -> None:
+    """ICD/AICD are CPU-bound; apply_tensor must take the numpy path, not recurse."""
+    import torch
+
+    assert ICD.device_compatible is False
+    assert AICD.device_compatible is False
+
+    model, layers = _dummy_model_and_layers(dummy_model)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)  # no-cache warning
+        aug = ICD(model=model, target_layers=layers, cache=None, probability=1.0, random_state=42)
+    aug.set_label(0)
+
+    images = torch.rand(2, 3, 32, 32)
+    out = aug.apply_tensor(images)  # raised RecursionError before the fix
+
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == images.shape


### PR DESCRIPTION
Closes #254.

## Problem
`_BaseICD` set `device_compatible = True` and defined `apply_tensor_native` as `return self.apply_tensor(images)`. Since `BaseAugmentation.apply_tensor` dispatches to `apply_tensor_native` when `device_compatible` is true, the two called each other -> `RecursionError`. The trainer's broad `except` swallowed it, but a plugin user calling `ICD(...).apply_tensor(batch)` crashed, and ICD/AICD were misclassified as GPU-native (wrong AugmentationRunner bucket, misleading docstring).

## Fix (surgical)
- `device_compatible = False` on `_BaseICD` (covers ICD and AICD). They mask on the numpy/OpenCV path and need per-sample labels, so they are genuinely CPU-bound.
- Remove the recursive `apply_tensor_native` override; ICD now uses the inherited numpy fallback in `apply_tensor`.

The trainer and `AugmentationRunner` already route ICD through `apply_batch_with_labels`, so the actual masking behaviour is unchanged.

## Test
`tests/test_icd.py::test_icd_is_cpu_bound_and_apply_tensor_does_not_recurse`: asserts `ICD/AICD.device_compatible is False` and that `ICD.apply_tensor` round-trips a batch via the numpy path without `RecursionError` (raised before the fix).

## Out of scope
The AugmentationRunner applies GPU-bucket augmentations before CPU-bucket ones; with ICD now in the CPU bucket, ICD can run after a genuine GPU aug in a mixed branch (both still apply, only order shifts). Strict list-order application is tracked separately in #264 (PR-11).