### PR TITLE
fix: keep canonical augmentation names instead of indexed aliases

### DIFF
--- a/src/bnnr/augmentations.py
+++ b/src/bnnr/augmentations.py
@@ -127,7 +127,13 @@ class AugmentationRegistry:
     def register(cls, name: str) -> Callable[[type[AugT]], type[AugT]]:
         def decorator(aug_cls: type[AugT]) -> type[AugT]:
             cls._registry[name] = aug_cls
-            aug_cls.name = name
+            # Built-ins are registered under a canonical descriptive name plus a
+            # legacy "augmentation_N" alias. Keep the first name a class registers
+            # as its canonical name so logs, events, and reports show e.g.
+            # "church_noise" instead of "augmentation_1"; later alias registrations
+            # only add a lookup key without renaming the class.
+            if "name" not in aug_cls.__dict__:
+                aug_cls.name = name
             return aug_cls
 
         return decorator

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 import torch
@@ -56,6 +58,32 @@ def test_registered_augmentations_apply_shape() -> None:
         out = aug.apply(image)
         assert out.shape == image.shape
         assert out.dtype == np.uint8
+
+
+def test_builtins_report_canonical_names_not_indexed_aliases() -> None:
+    """Built-ins must expose their descriptive canonical name (e.g.
+    "church_noise"), never the legacy "augmentation_N" alias, while the alias
+    still resolves to the same class for backward compatibility."""
+    canonical_to_alias = {
+        "church_noise": "augmentation_1",
+        "basic_augmentation": "augmentation_3",
+        "dif_presets": "augmentation_5",
+        "drust": "augmentation_6",
+        "luxfer_glass": "augmentation_7",
+        "procam": "augmentation_8",
+        "smugs": "augmentation_9",
+        "tea_stains": "augmentation_10",
+    }
+    for canonical, alias in canonical_to_alias.items():
+        registered_cls = AugmentationRegistry.get(canonical)
+        # Class attribute is the canonical name, not the indexed alias.
+        assert registered_cls.name == canonical
+        # The legacy alias still resolves to the same class.
+        assert AugmentationRegistry.get(alias) is registered_cls
+        # Instances report the canonical name regardless of the lookup key used.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            assert AugmentationRegistry.create(alias, probability=0.0).name == canonical
 
 
 def test_probability_in_apply_batch() -> None:


### PR DESCRIPTION
## Problem

Built-in augmentations are registered under both a descriptive canonical name and a legacy `augmentation_N` alias. Decorators apply bottom-up and `register()` overwrote `aug_cls.name` on every call, so the alias decorator on top won: `ChurchNoise.name == "augmentation_1"`, `BasicAugmentation.name == "augmentation_3"`, etc. Trainer logs, `best_path`, events, and checkpoints then recorded the indexed alias instead of the readable name.

## Fix

`register()` now keeps the first name a class registers as its canonical name (guarded on `aug_cls.__dict__`); later alias registrations only add a lookup key without renaming the class. The descriptive names (`church_noise`, `basic_augmentation`, ...) now win everywhere they are surfaced.

Backward compatible: the `augmentation_N` aliases stay in the registry and still resolve via `get()` / `create()`, so existing configs and saved runs keep working. Old reports are unaffected.

## Tests

- New `test_builtins_report_canonical_names_not_indexed_aliases`: every built-in's `.name` is its canonical descriptive name, each legacy `augmentation_N` alias still resolves to the same class, and instances created via either key report the canonical name.
- Full suite green (973 passed, 15 skipped); ruff + mypy clean.

Closes #258