### PR TITLE
chore(ci): allowlist torch CVE-2025-3000 in pip-audit

### DIFF
--- a/security/pip-audit-allowlist.txt
+++ b/security/pip-audit-allowlist.txt
@@ -4,5 +4,11 @@ PYSEC-2025-203  # torch; fixed in torch 2.9+
 PYSEC-2025-204  # torch; fixed in torch 2.9+
 PYSEC-2025-206  # torch; fixed in torch 2.9+
 PYSEC-2026-139  # torch; fixed in torch 2.9+
+# torch.jit.script memory corruption, affects torch <=2.6.0 (local attack vector).
+# False positive on our torch>=2.0,<3 resolution (2.12.0 is past the fix): the advisory
+# carries only a git range, no PyPI fixed-version. BNNR never calls torch.jit.script.
+# aka GHSA-rrmf-rvhw-rf47. IDs kept comment-free so the CI ignore loop matches them.
+CVE-2025-3000
+PYSEC-2025-194
 # starlette via fastapi[dashboard] — bump when upstream pins fixed release
 PYSEC-2026-161


### PR DESCRIPTION
## Why

`quality-linux` started failing on every PR (and would fail on `main` if re-run) at the pip-audit step:

```
torch 2.12.0  CVE-2025-3000   (Fix Versions: none)
Found 1 known vulnerability in 1 package
```

## Investigation

- **CVE-2025-3000** is a `torch.jit.script` memory-corruption issue with a **local** attack vector, classified against **PyTorch <= 2.6.0** (OSV carries only a git range up to the fix commit, no PyPI fixed-version).
- We resolve `torch>=2.0,<3` and CI runs **torch 2.12.0**, which is past the fix. pip-audit still flags it because the advisory lacks a PyPI fixed-version, so the matcher cannot tell 2.12.0 is patched (false positive).
- `torch.jit.script` is **never called anywhere in BNNR** (`src/`, `examples/`, `benchmarks/`), so it is not reachable in our usage.

This is the same class as the torch PYSEC entries already in the allowlist.

## Change

Add `CVE-2025-3000` and its alias `PYSEC-2025-194` to `security/pip-audit-allowlist.txt`, with comment-free IDs so the CI ignore loop matches them. Verified locally by reproducing the exact CI ignore loop: pip-audit reports the CVE as ignored.

No version bump (chore).