### PR TITLE
ci: retry pip-audit on transient PyPI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,18 @@ jobs:
             [[ -z "${vuln}" || "${vuln}" =~ ^# ]] && continue
             ALLOWLIST_ARGS+=(--ignore-vuln "${vuln}")
           done < security/pip-audit-allowlist.txt
-          pip-audit "${ALLOWLIST_ARGS[@]}"
+          # pip-audit queries PyPI once per dependency with no built-in retry, so a
+          # single transient PyPI 5xx (ServiceError) fails the whole step. Retry a
+          # few times with backoff before treating it as a real failure.
+          for attempt in 1 2 3; do
+            if pip-audit "${ALLOWLIST_ARGS[@]}"; then
+              exit 0
+            fi
+            echo "pip-audit attempt ${attempt} failed; retrying in $((attempt * 15))s..."
+            sleep $((attempt * 15))
+          done
+          echo "pip-audit failed after 3 attempts"
+          exit 1
 
       - name: Security lint (bandit)
         run: bandit -r src/bnnr -c pyproject.toml -lll -f txt


### PR DESCRIPTION
## Why

main CI (`quality-linux`) failed after the 0.5.1 release, not on a finding but on a crash:

```
requests.exceptions.HTTPError: 503 Server Error: Backend is unhealthy
for url: https://pypi.org/pypi/grad-cam/1.5.5/json
-> pip_audit._service.interface.ServiceError
```

pip-audit queries PyPI once per dependency with no built-in retry, so a single transient PyPI 5xx aborts the whole step even though nothing vulnerable was found. Because `quality-linux` is a required check, a momentary PyPI hiccup blocks all merges.

## Change

Wrap pip-audit in a 3-attempt retry loop with linear backoff (15s/30s). Real vulnerability findings still fail the step after the retries; only transient service errors are absorbed.

CI-only, no version bump.