### PR TITLE
fix: raise torch floor to 2.10.0 for security fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,10 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Image Recognition",
 ]
 dependencies = [
-  "torch>=2.0.0,<3.0",
+  # Floor raised to 2.10.0: torch <2.9.1 / <2.10.0 carry memory-corruption
+  # advisories (CVE-2025-2999 unpack_sequence, CVE-2025-3001 lstm_cell), fixed
+  # in 2.9.1 / 2.10.0 respectively.
+  "torch>=2.10.0,<3.0",
   "torchvision>=0.15.0,<1.0",
   "numpy>=1.24.0,<3.0",
   "opencv-python>=4.8.0,<5.0",


### PR DESCRIPTION
## Why

Dependabot opened three torch advisories (memory corruption, local attack vector):

| Alert | Function | Affected | Fixed in |
|-------|----------|----------|----------|
| CVE-2025-2999 | `unpack_sequence` | < 2.9.1 | 2.9.1 |
| CVE-2025-3001 | `lstm_cell` | < 2.10.0 | 2.10.0 |
| CVE-2025-3000 | `torch.jit.script` | <= 2.12.0 | none |

Our pin was `torch>=2.0.0,<3.0`, so the dependency tree could resolve (and Dependabot computed) torch 2.8.0, which is vulnerable to the first two.

## Change

Raise the floor to `torch>=2.10.0,<3.0` so any resolution lands past both fixes. The first two advisories no longer apply once the floor is 2.10.0.

`CVE-2025-3000` (`torch.jit.script`) has no fixed release; it is a local-vector issue and BNNR never calls `torch.jit.script`. It stays allowlisted in pip-audit and can be dismissed in Dependabot as "no fix / not affected".

torchvision floor is left as-is; the resolver upgrades it to a torch-2.10-compatible release automatically.