### PR TITLE
fix: implement real local_mean fill in DetectionICD

### DIFF
--- a/src/bnnr/detection_icd.py
+++ b/src/bnnr/detection_icd.py
@@ -153,7 +153,7 @@ class _DetectionBaseICD(BboxAwareAugmentation):
         if strategy == "gaussian_blur":
             return self._gaussian_blur_fill(out, mask)
         if strategy == "local_mean":
-            return self._global_mean_fill(out, mask)
+            return self._local_mean_fill(out, mask)
         if strategy == "global_mean":
             return self._global_mean_fill(out, mask)
         if strategy == "noise":
@@ -167,6 +167,52 @@ class _DetectionBaseICD(BboxAwareAugmentation):
             k_size += 1
         blurred = cv2.GaussianBlur(image, (k_size, k_size), 0)
         image[mask] = blurred[mask]
+        return image
+
+    def _local_mean_fill(self, image: np.ndarray, mask: np.ndarray) -> np.ndarray:
+        """Fill each masked tile with the mean colour of its non-masked neighbours.
+
+        Ported from the classification ICD; only depends on the tile grid, not
+        on how the saliency map was produced.
+        """
+        ts = self.tile_size
+        h, w = image.shape[:2]
+        n_rows = max(1, h // ts)
+        n_cols = max(1, w // ts)
+
+        # Build a tile-level mask (True = masked)
+        tile_masked = np.zeros((n_rows, n_cols), dtype=bool)
+        for r in range(n_rows):
+            y0, y1 = r * ts, min((r + 1) * ts, h)
+            for c in range(n_cols):
+                x0, x1 = c * ts, min((c + 1) * ts, w)
+                tile_masked[r, c] = mask[y0:y1, x0:x1].any()
+
+        for r in range(n_rows):
+            y0, y1 = r * ts, min((r + 1) * ts, h)
+            for c in range(n_cols):
+                if not tile_masked[r, c]:
+                    continue
+                x0, x1 = c * ts, min((c + 1) * ts, w)
+                # Collect colours from neighbouring non-masked tiles
+                neighbour_pixels: list[np.ndarray] = []
+                for dr in (-1, 0, 1):
+                    for dc in (-1, 0, 1):
+                        nr, nc = r + dr, c + dc
+                        if 0 <= nr < n_rows and 0 <= nc < n_cols:
+                            if not tile_masked[nr, nc]:
+                                ny0, ny1 = nr * ts, min((nr + 1) * ts, h)
+                                nx0, nx1 = nc * ts, min((nc + 1) * ts, w)
+                                neighbour_pixels.append(
+                                    image[ny0:ny1, nx0:nx1].reshape(-1, image.shape[2])
+                                )
+                if neighbour_pixels:
+                    mean_colour = np.concatenate(neighbour_pixels, axis=0).mean(axis=0)
+                else:
+                    # All neighbours are masked, fall back to global mean
+                    mean_colour = image.mean(axis=(0, 1))
+                image[y0:y1, x0:x1][mask[y0:y1, x0:x1]] = mean_colour.astype(image.dtype)
+
         return image
 
     def _global_mean_fill(self, image: np.ndarray, mask: np.ndarray) -> np.ndarray:

--- a/tests/test_detection_augmentations.py
+++ b/tests/test_detection_augmentations.py
@@ -335,6 +335,47 @@ class TestDetectionICD:
         # With no boxes, saliency is all zeros → no masking
         assert out_img.shape == sample_image.shape
 
+    def test_local_mean_differs_from_global_mean(self) -> None:
+        """local_mean must be a real strategy, not a silent alias of global_mean.
+
+        Image: dark left half (10), bright right half (240). The box sits in the
+        bright half, so local_mean fills masked tiles with bright neighbour
+        colours while global_mean fills with the overall mean (~125).
+        threshold_percentile=90 keeps the tile threshold above zero so only
+        the box tiles are masked (lower percentiles mask every tile when the
+        box saliency map is mostly zeros)."""
+        image = np.full((64, 64, 3), 10, dtype=np.uint8)
+        image[:, 32:] = 240
+        target = {
+            "boxes": np.array([[40.0, 16.0, 56.0, 48.0]], dtype=np.float32),
+            "labels": np.array([1], dtype=np.int64),
+        }
+
+        local = DetectionICD(
+            probability=1.0, threshold_percentile=90.0, tile_size=8,
+            fill_strategy="local_mean", random_state=42,
+        )
+        global_ = DetectionICD(
+            probability=1.0, threshold_percentile=90.0, tile_size=8,
+            fill_strategy="global_mean", random_state=42,
+        )
+        out_local, _ = local.apply_with_targets(image.copy(), dict(target))
+        out_global, _ = global_.apply_with_targets(image.copy(), dict(target))
+
+        # The strategies must not be aliases of each other.
+        assert not np.array_equal(out_local, out_global)
+
+        # local_mean fills the masked tiles with their bright neighbours'
+        # colour (240), which in this locally uniform region is a no-op.
+        assert np.array_equal(out_local, image)
+
+        # global_mean visibly drops the masked tiles to the overall mean (~125).
+        assert not np.array_equal(out_global, image)
+        box_region_local = out_local[24:40, 44:52].mean()
+        box_region_global = out_global[24:40, 44:52].mean()
+        assert box_region_local > 180
+        assert box_region_global < 180
+
     def test_aicd_different_from_icd(self, sample_image, sample_target) -> None:
         """ICD and AICD should produce different results (different masks)."""
         icd = DetectionICD(


### PR DESCRIPTION
## Problem

`DetectionICD`/`DetectionAICD` accept `fill_strategy="local_mean"` in `_VALID_FILL_STRATEGIES`, but `_apply_fill` mapped it to `_global_mean_fill`. Users selecting `local_mean` in detection silently got `global_mean` instead of the documented behaviour (the classification ICD has a real implementation).

## Fix

Port the classification `_local_mean_fill` to `_DetectionBaseICD`: each masked tile is filled with the mean colour of its non-masked neighbouring tiles, with a global-mean fallback when every neighbour is masked. The logic only depends on the tile grid (`tile_size`), not on how the saliency map was produced, so the port is verbatim.

`docs/detection.md` fill-strategy table needs no change: it already lists `local_mean`, which now actually works as documented.

## Test

`test_local_mean_differs_from_global_mean`: dark/bright half image with the box in the bright half. `local_mean` fills masked tiles with their bright neighbours' colour (a no-op in the locally uniform region), while `global_mean` visibly drops them to the overall mean (~125). Asserts the two strategies produce different outputs and the expected per-strategy semantics.

Full suite green (974 passed, 15 skipped); ruff + mypy clean.

Closes #255