### PR TITLE
fix: load checkpoints with weights_only=True first

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ skips = [
   "B404",  # subprocess import — dashboard npm build
   "B602",  # shell=True only on Windows for npm.cmd
   "B607",  # npm on PATH
-  "B614",  # torch.load — user checkpoints by design
+  "B614",  # torch.load via safe_torch_load(): weights_only=True first, warns before any weights_only=False fallback
   "B310",  # curated example_data download URL
 ]
 

--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -655,9 +655,11 @@ def analyze_command(
         raise typer.Exit(code=1) from exc
 
     try:
-        import torch
+        from bnnr.utils import safe_torch_load
 
-        ckpt = torch.load(model, map_location="cpu", weights_only=False)
+        # External model file: try the safe weights_only=True path first; the
+        # helper warns and falls back to weights_only=False only if needed.
+        ckpt = safe_torch_load(model, map_location="cpu")
     except Exception as exc:
         typer.echo(f"Error loading model: {exc}", err=True)
         raise typer.Exit(code=1) from exc

--- a/src/bnnr/training/checkpoint.py
+++ b/src/bnnr/training/checkpoint.py
@@ -13,6 +13,8 @@ import numpy as np
 import torch
 from torch import Tensor
 
+from bnnr.utils import numpy_rng_safe_globals, safe_torch_load
+
 if TYPE_CHECKING:
     from bnnr.trainer import BNNRTrainer
 
@@ -120,9 +122,15 @@ def save_checkpoint(
 
 def load_checkpoint(trainer: BNNRTrainer, checkpoint_path: Path) -> dict[str, Any]:
     """Load a BNNR checkpoint and restore model + RNG state on *trainer*."""
+    # BNNR checkpoints hold tensors + plain metadata + numpy RNG state, so the
+    # safe weights_only=True path works once the numpy RNG globals are allowed.
     state = cast(
         dict[str, Any],
-        torch.load(checkpoint_path, map_location="cpu", weights_only=False),
+        safe_torch_load(
+            checkpoint_path,
+            map_location="cpu",
+            extra_safe_globals=numpy_rng_safe_globals(),
+        ),
     )
     expected_checkpoint_keys = {"model_state", "iteration", "augmentation_name"}
     if not isinstance(state, dict) or not expected_checkpoint_keys.issubset(state.keys()):

--- a/src/bnnr/utils.py
+++ b/src/bnnr/utils.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import random
+import warnings
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import torch
@@ -85,6 +89,56 @@ def get_device(device: str = "auto") -> torch.device:
     if device == "cpu":
         return torch.device("cpu")
     raise ValueError(f"Unsupported device: {device}")
+
+
+def numpy_rng_safe_globals() -> list[Any]:
+    """Globals needed to unpickle a numpy RNG state under ``weights_only=True``.
+
+    BNNR checkpoints embed ``np.random.get_state()`` (a tuple holding a uint32
+    ndarray), which the restricted ``weights_only=True`` unpickler rejects
+    unless these benign numpy globals are allowlisted.  Resolved at runtime so
+    the set stays correct across numpy 1.x/2.x (``_reconstruct`` moved from
+    ``numpy.core`` to ``numpy._core`` in 2.0; the concrete dtype class differs).
+    """
+    globals_: list[Any] = [np.ndarray, np.dtype, type(np.dtype("uint32"))]
+    for modpath in ("numpy._core.multiarray", "numpy.core.multiarray"):
+        try:
+            globals_.append(importlib.import_module(modpath)._reconstruct)
+            break
+        except Exception:
+            continue
+    return globals_
+
+
+def safe_torch_load(
+    path: Any,
+    *,
+    map_location: Any = "cpu",
+    extra_safe_globals: Sequence[Any] | None = None,
+) -> Any:
+    """Load a torch checkpoint, preferring the safe ``weights_only=True`` path.
+
+    Tries ``weights_only=True`` first (allowlisting *extra_safe_globals* for
+    known-benign payloads such as numpy RNG state).  If the file cannot be
+    loaded that way -- e.g. it pickles arbitrary Python objects -- falls back to
+    ``weights_only=False`` and warns, naming the file, since that path can
+    execute arbitrary code embedded in an untrusted checkpoint.
+    """
+    safe_globals = list(extra_safe_globals or [])
+    try:
+        if safe_globals:
+            with torch.serialization.safe_globals(safe_globals):
+                return torch.load(path, map_location=map_location, weights_only=True)
+        return torch.load(path, map_location=map_location, weights_only=True)
+    except Exception as exc:
+        warnings.warn(
+            f"Could not load {path} with weights_only=True ({type(exc).__name__}); "
+            f"falling back to weights_only=False. This executes arbitrary code if "
+            f"the checkpoint comes from an untrusted source.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return torch.load(path, map_location=map_location, weights_only=False)
 
 
 def tensor_to_numpy(tensor: Tensor) -> np.ndarray:

--- a/tests/test_safe_torch_load.py
+++ b/tests/test_safe_torch_load.py
@@ -1,0 +1,66 @@
+"""Tests for the weights_only-first torch.load helper (FINDING-21)."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from bnnr.utils import numpy_rng_safe_globals, safe_torch_load
+
+
+class _ArbitraryObject:
+    """A module-level (picklable) stand-in for arbitrary checkpoint content."""
+
+    def __init__(self) -> None:
+        self.payload = "arbitrary"
+
+
+def _bnnr_like_payload() -> dict:
+    """A payload shaped like a BNNR checkpoint: tensors + numpy RNG state."""
+    return {
+        "model_state": {"w": torch.zeros(3)},
+        "iteration": 1,
+        "augmentation_name": "icd",
+        "rng_state": {
+            "python": random.getstate(),
+            "numpy": np.random.get_state(),
+            "torch_cpu": torch.random.get_rng_state(),
+            "torch_cuda": [],
+        },
+    }
+
+
+def test_bnnr_checkpoint_roundtrips_weights_only(
+    temp_dir: Path, recwarn: pytest.WarningsRecorder
+) -> None:
+    """BNNR checkpoints load via the safe weights_only=True path, no warning."""
+    path = temp_dir / "ckpt.pt"
+    torch.save(_bnnr_like_payload(), path)
+    loaded = safe_torch_load(path, extra_safe_globals=numpy_rng_safe_globals())
+    assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning)]
+    assert torch.equal(loaded["model_state"]["w"], torch.zeros(3))
+    assert isinstance(loaded["rng_state"]["numpy"], tuple)
+
+
+def test_arbitrary_pickle_falls_back_with_warning(temp_dir: Path) -> None:
+    """A checkpoint pickling an arbitrary object falls back, warning loudly."""
+    path = temp_dir / "unsafe.pt"
+    torch.save({"obj": _ArbitraryObject()}, path)
+    with pytest.warns(RuntimeWarning, match=str(path.name)):
+        loaded = safe_torch_load(path)
+    assert loaded["obj"].payload == "arbitrary"
+
+
+def test_pure_tensor_checkpoint_no_warning(
+    temp_dir: Path, recwarn: pytest.WarningsRecorder
+) -> None:
+    """A plain state_dict loads via weights_only=True with no fallback warning."""
+    path = temp_dir / "weights.pt"
+    torch.save({"w": torch.ones(4), "b": torch.zeros(2)}, path)
+    loaded = safe_torch_load(path)
+    assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning)]
+    assert torch.equal(loaded["w"], torch.ones(4))


### PR DESCRIPTION
Closes #262 (PR-9, FINDING-21).

## Problem
Both `torch.load` call sites (`cli.py` analyze, `training/checkpoint.py`) passed `weights_only=False`, so `bnnr analyze --model untrusted.pt` could execute arbitrary pickled code.

## Change
New `safe_torch_load()` in `bnnr.utils`:
- Tries `weights_only=True` first.
- Falls back to `weights_only=False` **only** after emitting a `RuntimeWarning` that names the file and the risk.

BNNR's own checkpoints embed `np.random.get_state()` (a uint32 ndarray), which the restricted unpickler rejects by default. `numpy_rng_safe_globals()` allowlists the benign numpy globals, resolved at runtime so the set stays correct across numpy 1.x/2.x (`_reconstruct` moved to `numpy._core` in 2.0; the concrete dtype class differs). The checkpoint loader passes those globals, so BNNR checkpoints round-trip on the safe path with no fallback.

## Acceptance
- [x] BNNR checkpoints round-trip with `weights_only=True` (no warning)
- [x] Fallback warning tested with a pickled-object checkpoint
- [x] bandit B614 skip comment updated to reflect the new posture

## Tests
New `tests/test_safe_torch_load.py`: round-trip-no-warning, arbitrary-pickle-falls-back-with-warning, pure-tensor-no-warning. Full suite: 977 passed, 15 skipped. ruff + mypy clean.