### PR TITLE
fix: invalidate XAI cache when a different model shares the cache dir

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,7 @@ trainer = BNNRTrainer(
 - `xai_cache_force_recompute` (default: `false`)
 - `xai_cache_progress` (default: `true`)
 
-The XAI cache is precomputed **after** the baseline phase, so masks from `ICD`/`AICD` are guided by the trained baseline model rather than random initial weights, and is computed once for all branch-search iterations. A `manifest.json` records the XAI method, dataset size, and image shape; if any of these differs from the cached maps (for example a different `xai_method` against an explicit `xai_cache_dir`), the stale maps are dropped and recomputed.
+The XAI cache is precomputed **after** the baseline phase, so masks from `ICD`/`AICD` are guided by the trained baseline model rather than random initial weights, and is computed once for all branch-search iterations. A `manifest.json` records the XAI method, dataset size, image shape, and a fingerprint of the baseline model's weights; if any of these differs from the cached maps (for example a different `xai_method`, or a **different model** sharing an explicit `xai_cache_dir`), the stale maps are dropped and recomputed.
 - `xai_selection_weight` (default: `0.0`, validated to `[0,1]`)
 - `xai_pruning_threshold` (default: `0.0`, validated to `[0,1]`)
 - `adaptive_icd_threshold` (default: `false`)

--- a/src/bnnr/xai_cache.py
+++ b/src/bnnr/xai_cache.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # method, dataset size, or image shape) invalidates the cache so stale saliency
 # maps are never reused, e.g. across runs that share an explicit cache dir.
 _MANIFEST_FILENAME = "manifest.json"
-_MANIFEST_SCHEMA = 1
+_MANIFEST_SCHEMA = 2
 
 
 def _safe_dataset_size(loader: DataLoader) -> int | None:
@@ -61,6 +61,33 @@ except ImportError:
         return hashlib.sha256(data).hexdigest()
 
 
+def _model_state_hash(model: nn.Module) -> str:
+    """Cheap, deterministic fingerprint of a model's weights.
+
+    Each parameter is sampled (up to 64 evenly spaced values plus a global sum)
+    so the cost stays low for large models while still changing whenever the
+    weights change. Used so the XAI cache invalidates when a *different* model
+    writes into the same cache dir, not only on a different method/dataset/shape.
+    """
+    parts: list[bytes] = []
+    state = model.state_dict()
+    for name in sorted(state):
+        tensor = state[name]
+        parts.append(name.encode())
+        if not hasattr(tensor, "detach"):
+            parts.append(repr(tensor).encode())
+            continue
+        flat = tensor.detach().to(torch.float64).reshape(-1).cpu()
+        n = int(flat.numel())
+        parts.append(str(tuple(tensor.shape)).encode())
+        if n == 0:
+            continue
+        idx = torch.linspace(0, n - 1, steps=min(n, 64)).long()
+        parts.append(flat[idx].numpy().tobytes())
+        parts.append(repr(float(flat.sum())).encode())
+    return _fast_hash(b"".join(parts))
+
+
 class XAICache:
     def __init__(self, cache_dir: Path | str) -> None:
         self.cache_dir = Path(cache_dir)
@@ -98,19 +125,23 @@ class XAICache:
         dataset_size: int | None,
         image_shape: list[int] | None,
         force_recompute: bool,
+        model_hash: str | None = None,
     ) -> None:
         """Drop cached maps whose provenance differs from the current request.
 
-        Writes a manifest of ``{method, dataset_size, image_shape}``. When an
-        existing manifest does not match (or ``force_recompute`` is set), all
-        ``*.npy`` maps are removed so they are recomputed from the current
-        model/method/dataset instead of silently reused.
+        Writes a manifest of ``{method, dataset_size, image_shape, model_hash}``.
+        When an existing manifest does not match (or ``force_recompute`` is set),
+        all ``*.npy`` maps are removed so they are recomputed from the current
+        model/method/dataset instead of silently reused. ``model_hash`` lets a
+        different model sharing the same cache dir invalidate stale saliency even
+        when method, dataset size and image shape are identical.
         """
         desired = {
             "schema": _MANIFEST_SCHEMA,
             "method": method,
             "dataset_size": dataset_size,
             "image_shape": image_shape,
+            "model_hash": model_hash,
         }
         if not force_recompute and self._load_manifest() == desired:
             return
@@ -229,6 +260,7 @@ class XAICache:
             dataset_size=_safe_dataset_size(train_loader),
             image_shape=_safe_image_shape(train_loader),
             force_recompute=force_recompute,
+            model_hash=_model_state_hash(model),
         )
 
         written = 0

--- a/tests/test_xai_cache.py
+++ b/tests/test_xai_cache.py
@@ -11,18 +11,22 @@ from torch.utils.data import DataLoader, TensorDataset
 from bnnr.xai_cache import (
     _MANIFEST_SCHEMA,
     XAICache,
+    _model_state_hash,
     _safe_dataset_size,
     _safe_image_shape,
 )
 
 
-def _write_matching_manifest(cache: XAICache, loader: DataLoader, method: str) -> None:
-    """Mark the cache as produced by *method* on *loader* so it is reusable."""
+def _write_matching_manifest(
+    cache: XAICache, loader: DataLoader, method: str, model: torch.nn.Module
+) -> None:
+    """Mark the cache as produced by *method*/*model* on *loader* so it is reusable."""
     manifest = {
         "schema": _MANIFEST_SCHEMA,
         "method": method,
         "dataset_size": _safe_dataset_size(loader),
         "image_shape": _safe_image_shape(loader),
+        "model_hash": _model_state_hash(model),
     }
     cache._manifest_path().write_text(json.dumps(manifest), encoding="utf-8")
 
@@ -105,7 +109,7 @@ def test_precompute_cache_skips_when_existing_entries_cover_target(temp_dir, dum
 
     # A matching manifest marks the existing entries as same-provenance, so the
     # count-based fast-skip is allowed to reuse them.
-    _write_matching_manifest(cache, loader, "opticam")
+    _write_matching_manifest(cache, loader, "opticam", dummy_model)
     for idx in range(3):
         np.save(cache.cache_dir / f"existing_{idx}.npy", np.zeros((4, 4), dtype=np.float32))
 
@@ -153,6 +157,43 @@ def test_precompute_writes_manifest(temp_dir, dummy_model, monkeypatch) -> None:
     assert manifest["method"] == "opticam"
     assert manifest["dataset_size"] == 2
     assert manifest["image_shape"] == [3, 8, 8]
+    assert manifest["model_hash"] == _model_state_hash(dummy_model)
+
+
+def test_precompute_invalidates_on_model_change(temp_dir, dummy_model, monkeypatch) -> None:
+    """A different model sharing the cache dir must invalidate stale maps."""
+    cache = XAICache(temp_dir / "xai_cache")
+    x = torch.rand(3, 3, 8, 8)
+    y = torch.randint(0, 2, (3,))
+    loader = DataLoader(TensorDataset(x, y), batch_size=3)
+
+    # Matching manifest + maps left by the model at its current weights.
+    _write_matching_manifest(cache, loader, "opticam", dummy_model)
+    for idx in range(3):
+        np.save(cache.cache_dir / f"idx_{idx}_0.npy", np.zeros((4, 4), dtype=np.float32))
+
+    # Same method/dataset/shape, but the weights changed -> stale maps.
+    with torch.no_grad():
+        next(dummy_model.parameters()).add_(1.0)
+
+    called = {"value": False}
+
+    def _fake_generate(*_args, **_kwargs):
+        called["value"] = True
+        return np.zeros((3, 8, 8), dtype=np.float32)
+
+    monkeypatch.setattr("bnnr.xai_cache.generate_saliency_maps", _fake_generate)
+    cache.precompute_cache(
+        model=dummy_model,
+        train_loader=loader,
+        target_layers=[dummy_model.conv1],
+        n_samples=3,
+        method="opticam",
+    )
+
+    assert called["value"] is True  # recomputed instead of reusing stale maps
+    manifest = json.loads(cache._manifest_path().read_text(encoding="utf-8"))
+    assert manifest["model_hash"] == _model_state_hash(dummy_model)
 
 
 def test_precompute_invalidates_on_manifest_mismatch(temp_dir, dummy_model, monkeypatch) -> None:
@@ -162,7 +203,7 @@ def test_precompute_invalidates_on_manifest_mismatch(temp_dir, dummy_model, monk
     loader = DataLoader(TensorDataset(x, y), batch_size=3)
 
     # Stale maps left by a run that used a different XAI method.
-    _write_matching_manifest(cache, loader, "craft")
+    _write_matching_manifest(cache, loader, "craft", dummy_model)
     for idx in range(3):
         np.save(cache.cache_dir / f"idx_{idx}_0.npy", np.zeros((4, 4), dtype=np.float32))
 


### PR DESCRIPTION
Closes the residual gap on the XAI-cache provenance work (audit F-10 / PR-1 acceptance criterion: "re-running with a different model in the same checkpoint_dir does not reuse old maps").

## Problem
The cache `manifest.json` was keyed on `{method, dataset_size, image_shape}`. A second run with a **different model** but the same dataset and XAI method silently reused the first run's saliency maps whenever they shared an explicit `xai_cache_dir`. The post-baseline precompute fixed the "guided by random init" problem within a run, but not this cross-run case.

## Change
- `xai_cache.py`: add `_model_state_hash(model)` — a cheap, deterministic per-parameter fingerprint (up to 64 sampled values + a global sum per tensor, hashed via the existing `_fast_hash`). Include it in the manifest as `model_hash` and bump `_MANIFEST_SCHEMA` to 2 (old manifests mismatch and recompute cleanly).
- A weight mismatch now drops stale `*.npy` maps and recomputes.
- `docs/configuration.md`: manifest now documents the model-weight fingerprint.

## Tests
- `test_precompute_writes_manifest`: asserts `model_hash` is written.
- `test_precompute_invalidates_on_model_change` (new): same method/dataset/shape, mutated weights -> stale maps dropped and recomputed.
- Existing matching-manifest tests updated to include the model hash.

Patch-level, no public API change.