### PR TITLE
feat: warn once when branch search projects a very long runtime

### DIFF
--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -274,6 +274,30 @@ def run_single_iteration(
     return best_metrics, best_model_state, best_epoch, pruned
 
 
+# Projected branch-search time above which a one-time long-run warning is printed.
+_LONG_RUN_WARN_SECONDS = 3600.0
+
+
+def _estimate_remaining_seconds(
+    avg_candidate_seconds: float,
+    candidates_per_iteration: int,
+    completed_in_iteration: int,
+    current_iteration: int,
+    max_iterations: int,
+) -> float:
+    """Project wall-clock seconds left in the branch search.
+
+    Uses the running average candidate duration and counts the unfinished
+    candidates in the current iteration plus a full candidate sweep for each
+    iteration still to come. Best-effort (ignores pruning/early-stop), so it is
+    an upper-ish bound used only to warn about very long runs.
+    """
+    remaining_this_iter = max(candidates_per_iteration - completed_in_iteration, 0)
+    remaining_iterations = max(max_iterations - current_iteration, 0)
+    total_candidates_left = remaining_this_iter + candidates_per_iteration * remaining_iterations
+    return max(avg_candidate_seconds, 0.0) * total_candidates_left
+
+
 def run(trainer: BNNRTrainer) -> BNNRRunResult:
     from bnnr.reporting import BNNRRunResult
 
@@ -459,6 +483,7 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
     else:
         trainer._emit_pipeline_phase("xai_cache", "completed")
 
+    long_run_warned = False
     for iteration in tqdm(
         range(start_iteration, trainer.config.max_iterations + 1),
         desc="BNNR iterations",
@@ -635,6 +660,24 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
                 remaining = max(len(candidates) - idx, 0)
                 eta = avg_time * remaining
                 candidate_bar.set_postfix_str(f"avg={avg_time:.2f}s eta={eta:.1f}s")
+
+                if not long_run_warned:
+                    projected = _estimate_remaining_seconds(
+                        avg_time,
+                        len(candidates),
+                        idx,
+                        iteration,
+                        trainer.config.max_iterations,
+                    )
+                    if projected >= _LONG_RUN_WARN_SECONDS:
+                        long_run_warned = True
+                        print(
+                            f"\n  WARNING: branch search may take ~{projected / 3600:.1f}h more "
+                            f"(~{avg_time:.0f}s/candidate over the remaining iterations). "
+                            "Lower --max-iterations or pick a lighter preset to shorten it; "
+                            "training is checkpointed, so Ctrl+C and resume is safe.\n",
+                            flush=True,
+                        )
 
                 if trainer.config.save_checkpoints:
                     _ = _ckpt.save_checkpoint(trainer,

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -6,7 +6,26 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from bnnr.training.loop import run_single_iteration
+from bnnr.training.loop import (
+    _LONG_RUN_WARN_SECONDS,
+    _estimate_remaining_seconds,
+    run_single_iteration,
+)
+
+
+def test_estimate_remaining_seconds_counts_this_and_future_iterations() -> None:
+    # 4 candidates/iter, 1 done in iter 2 of max 5: 3 left now + 4*3 future = 15.
+    assert _estimate_remaining_seconds(10.0, 4, 1, 2, 5) == 150.0
+
+
+def test_estimate_remaining_seconds_last_candidate_last_iteration_is_zero() -> None:
+    assert _estimate_remaining_seconds(10.0, 4, 4, 5, 5) == 0.0
+
+
+def test_estimate_remaining_seconds_crosses_long_run_threshold() -> None:
+    # ~6 min/candidate over many candidates trips the 1h warning threshold.
+    projected = _estimate_remaining_seconds(360.0, 8, 1, 1, 5)
+    assert projected >= _LONG_RUN_WARN_SECONDS
 
 
 @pytest.fixture()


### PR DESCRIPTION
Addresses audit **F-28** (no wall-clock guard on branch search), which was not assigned to any of the original PR cards. Per the agreed scope: **no hard time limit**, just a louder signal.

## Problem
Branch search is bounded only by `epochs x iterations x candidates`. The progress bar showed a per-iteration ETA, but nothing warned that a slow box + aggressive preset could run for many hours.

## Change
- `training/loop.py`: `_estimate_remaining_seconds(...)` projects wall-clock time over the candidates left this iteration plus a full sweep for each remaining iteration, from the running average candidate duration.
- Print a single prominent warning when the projection exceeds `_LONG_RUN_WARN_SECONDS` (1h), pointing at `--max-iterations`, lighter presets, and checkpoint resume. Warned at most once per run.

## Tests
- `_estimate_remaining_seconds`: counts this + future iterations; zero at the last candidate of the last iteration; trips the 1h threshold for slow candidates.

No new config, no behaviour change to the search itself.