### PR TITLE
perf: lazy-import cv2 so import bnnr no longer pays the OpenCV cost

### DIFF
--- a/src/bnnr/augmentations.py
+++ b/src/bnnr/augmentations.py
@@ -9,10 +9,11 @@ import warnings
 from collections.abc import Callable
 from typing import Any, TypeVar
 
-import cv2
 import numpy as np
 import torch
 from torch import Tensor
+
+from bnnr.utils import lazy_cv2 as cv2
 
 AugT = TypeVar("AugT", bound="BaseAugmentation")
 

--- a/src/bnnr/data_quality.py
+++ b/src/bnnr/data_quality.py
@@ -18,10 +18,11 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import cv2
 import numpy as np
 import torch
 import torch.nn.functional as F  # noqa: N812
+
+from bnnr.utils import lazy_cv2 as cv2
 
 logger = logging.getLogger(__name__)
 

--- a/src/bnnr/detection_augmentations.py
+++ b/src/bnnr/detection_augmentations.py
@@ -24,12 +24,12 @@ from __future__ import annotations
 import abc
 from typing import Any
 
-import cv2
 import numpy as np
 import torch
 from torch import Tensor
 
 from bnnr.augmentations import BaseAugmentation
+from bnnr.utils import lazy_cv2 as cv2
 
 # ---------------------------------------------------------------------------
 #  BboxAwareAugmentation base

--- a/src/bnnr/detection_icd.py
+++ b/src/bnnr/detection_icd.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import cv2
 import numpy as np
 from torch import Tensor
 
@@ -32,6 +31,7 @@ from bnnr.detection_augmentations import (
     _ensure_numpy_labels,
     _restore_target_types,
 )
+from bnnr.utils import lazy_cv2 as cv2
 
 _VALID_FILL_STRATEGIES = frozenset(
     {"gaussian_blur", "local_mean", "global_mean", "noise", "solid"}

--- a/src/bnnr/detection_xai.py
+++ b/src/bnnr/detection_xai.py
@@ -17,10 +17,11 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
-import cv2
 import numpy as np
 import torch
 from torch import Tensor, nn
+
+from bnnr.utils import lazy_cv2 as cv2
 
 logger = logging.getLogger(__name__)
 

--- a/src/bnnr/icd.py
+++ b/src/bnnr/icd.py
@@ -6,12 +6,12 @@ import logging
 import warnings
 from typing import Any
 
-import cv2
 import numpy as np
 import torch
 from torch import nn
 
 from bnnr.augmentations import BaseAugmentation
+from bnnr.utils import lazy_cv2 as cv2
 from bnnr.xai import generate_saliency_maps
 from bnnr.xai_cache import XAICache
 

--- a/src/bnnr/training/augmentation_batch.py
+++ b/src/bnnr/training/augmentation_batch.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import cv2
 import numpy as np
 import torch
 from torch import Tensor
 
 from bnnr.augmentations import BaseAugmentation
+from bnnr.utils import lazy_cv2 as cv2
 
 if TYPE_CHECKING:
     from bnnr.trainer import BNNRTrainer

--- a/src/bnnr/training/image_utils.py
+++ b/src/bnnr/training/image_utils.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-import cv2
 import numpy as np
 import torch
 from torch import Tensor
+
+from bnnr.utils import lazy_cv2 as cv2
 
 
 def tensor_to_uint8(

--- a/src/bnnr/training/probe.py
+++ b/src/bnnr/training/probe.py
@@ -6,13 +6,13 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import cv2
 import numpy as np
 import torch
 from torch import Tensor
 
 from bnnr.adapter import XAICapableModel
 from bnnr.training.checkpoint import _is_ultralytics_tasks_backbone
+from bnnr.utils import lazy_cv2 as cv2
 
 if TYPE_CHECKING:
     from bnnr.trainer import BNNRTrainer

--- a/src/bnnr/training/xai_runner.py
+++ b/src/bnnr/training/xai_runner.py
@@ -8,7 +8,6 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
-import cv2
 import numpy as np
 import torch
 from torch import Tensor
@@ -20,6 +19,7 @@ from bnnr.training import callbacks as _callbacks
 from bnnr.training import image_utils as _img
 from bnnr.training import probe as _probe
 from bnnr.training.checkpoint import _is_ultralytics_tasks_backbone
+from bnnr.utils import lazy_cv2 as cv2
 from bnnr.xai import generate_saliency_maps, save_xai_visualization
 from bnnr.xai_analysis import analyze_xai_batch_rich
 from bnnr.xai_cache import XAICache

--- a/src/bnnr/utils.py
+++ b/src/bnnr/utils.py
@@ -16,6 +16,33 @@ import torch
 from torch import Tensor
 
 
+class _LazyModule:
+    """Defer importing a heavy module until its first attribute access.
+
+    Lets modules on the ``import bnnr`` path reference e.g. ``cv2`` at the top
+    level without paying its (slow, wheel-fragile) import cost on startup. The
+    real import happens on the first ``<proxy>.<attr>`` use. Usage::
+
+        from bnnr.utils import lazy_cv2 as cv2
+        ...
+        cv2.cvtColor(...)  # cv2 is imported here, not at module load
+    """
+
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: Any = None
+
+    def __getattr__(self, attr: str) -> Any:
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = importlib.import_module(self._module_name)
+            object.__setattr__(self, "_module", module)
+        return getattr(module, attr)
+
+
+lazy_cv2 = _LazyModule("cv2")
+
+
 class JsonFormatter(logging.Formatter):
     """Simple JSON formatter for production-friendly structured logs."""
 

--- a/src/bnnr/xai.py
+++ b/src/bnnr/xai.py
@@ -7,7 +7,6 @@ import inspect
 from pathlib import Path
 from typing import Any
 
-import cv2
 import numpy as np
 import torch
 from torch import Tensor, nn
@@ -18,6 +17,7 @@ from bnnr.craft import (
     RealCRAFTExplainer,
     RecursiveCRAFTExplainer,
 )
+from bnnr.utils import lazy_cv2 as cv2
 
 
 class BaseExplainer(abc.ABC):

--- a/src/bnnr/xai_analysis.py
+++ b/src/bnnr/xai_analysis.py
@@ -27,8 +27,9 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
-import cv2
 import numpy as np
+
+from bnnr.utils import lazy_cv2 as cv2
 
 __all__ = [
     "analyze_saliency_map",

--- a/tests/test_lazy_cv2_import.py
+++ b/tests/test_lazy_cv2_import.py
@@ -1,0 +1,32 @@
+"""``import bnnr`` should not eagerly import ``cv2`` (slow, wheel-fragile in Colab)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_import_bnnr_in_fresh_process_does_not_load_cv2() -> None:
+    """Other tests may already import cv2 in-session; use a clean interpreter."""
+    code = (
+        "import sys\n"
+        "import bnnr  # noqa: F401\n"
+        "assert 'cv2' not in sys.modules, 'cv2 imported eagerly by import bnnr'\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_lazy_cv2_proxy_resolves_real_cv2() -> None:
+    """The proxy must transparently delegate to the real cv2 on attribute use."""
+    import cv2 as real_cv2
+
+    from bnnr.utils import lazy_cv2
+
+    assert lazy_cv2.cvtColor is real_cv2.cvtColor
+    assert lazy_cv2.COLOR_BGR2RGB == real_cv2.COLOR_BGR2RGB


### PR DESCRIPTION
Addresses audit **F-23** (cv2 imported at module top across the always-imported core chain), the optional slice that was left out of the hygiene PR.

## Problem
`import bnnr` pulled `cv2` via xai, icd, augmentations, data_quality, xai_analysis and several training/* modules, so every `bnnr --help` paid the OpenCV import (~100-200 ms cold start) and inherited cv2's fragile-wheel failure modes at startup even for commands that never touch it.

## Change
- `utils.py`: small `_LazyModule` proxy; `lazy_cv2 = _LazyModule("cv2")`. First `cv2.<attr>` access triggers the real import.
- Swapped `import cv2` for `from bnnr.utils import lazy_cv2 as cv2` in the 12 modules that imported it (call sites unchanged — the proxy delegates).
- A fresh `import bnnr` no longer loads cv2: `python -X importtime -c "import bnnr"` shows no cv2 entry; `'cv2' not in sys.modules`.

## Tests
- `test_lazy_cv2_import.py`: fresh-process `import bnnr` does not load cv2; proxy delegates to the real cv2.
- Existing cv2-heavy suites (icd, augmentations, xai, detection, data_quality, training image/probe) all pass unchanged.

`perf:`, no API or behaviour change.