### PR TITLE
Potential fix for code scanning alert no. 108: Binding a socket to all network interfaces

### DIFF
--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -804,9 +804,8 @@ def dashboard_serve_command(
 ) -> None:
     """Serve the BNNR dashboard for live or replay viewing.
 
-    The server binds to 0.0.0.0 so it is reachable from other devices
-    on the same network (e.g. your phone).  A QR code is printed so you
-    can scan it and open the dashboard instantly.
+    The server binds to 127.0.0.1 for local-only access. A QR code is
+    printed so you can open the dashboard URL quickly.
     """
     try:
         import uvicorn  # noqa: I001
@@ -827,8 +826,7 @@ def dashboard_serve_command(
     typer.echo(f"Available runs: {len(available)}")
 
     bind_host = _pick_bind_host(port)
-    if bind_host != "0.0.0.0":
-        typer.echo(f"  Bind host      : {bind_host} (fallback from 0.0.0.0)")
+    typer.echo(f"  Bind host      : {bind_host}")
     chosen_port = _find_free_port(bind_host, port)
     if chosen_port is None:
         typer.echo(

--- a/src/bnnr/dashboard/serve.py
+++ b/src/bnnr/dashboard/serve.py
@@ -4,10 +4,8 @@ Every script — CLI, examples, and user-written — should call
 :func:`start_dashboard` instead of rolling its own ``uvicorn.run``
 wrapper.  This guarantees that:
 
-* The server binds to ``0.0.0.0`` so phones on the same LAN can connect
-  (intentional trade-off for local training dashboards; use
-  ``BNNR_DASHBOARD_TOKEN`` for mutating control endpoints).
-* A QR code with the LAN URL is always printed.
+* The server binds to ``127.0.0.1`` by default for safer local access.
+* A QR code with the URL is always printed.
 * Frontend discovery / auto-build logic is consistent.
 """
 
@@ -39,22 +37,19 @@ def _get_lan_ip() -> str:
 
 
 def _pick_bind_host(port: int) -> str:
-    """Pick the best bind host for the dashboard server.
+    """Pick a safe bind host for the dashboard server.
 
-    Prefer ``0.0.0.0`` for LAN access. If that bind is not permitted in the
-    environment, gracefully fall back to ``127.0.0.1`` so local access still
-    works.
+    Bind only to loopback (``127.0.0.1``) to avoid exposing the service on
+    all interfaces.
     """
-    for host in ("0.0.0.0", "127.0.0.1"):
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind((host, port))
-            return host
-        except OSError:
-            continue
-    # If both probes fail, keep historical behavior so uvicorn surfaces
-    # the concrete bind error to the user.
-    return "0.0.0.0"
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", port))
+        return "127.0.0.1"
+    except OSError:
+        # If the probe fails, keep loopback behavior so uvicorn surfaces
+        # the concrete bind error to the user.
+        return "127.0.0.1"
 
 
 def _find_free_port(host: str, start_port: int, max_tries: int = 10) -> int | None:


### PR DESCRIPTION
Potential fix for [https://github.com/bnnr-team/bnnr/security/code-scanning/108](https://github.com/bnnr-team/bnnr/security/code-scanning/108)

General fix: stop binding probe sockets and runtime server sockets to `0.0.0.0`; bind to a dedicated interface, typically loopback (`127.0.0.1`) by default.

Best minimal fix without broader functional refactors:
- In `src/bnnr/dashboard/serve.py`, change `_pick_bind_host` so it only selects `127.0.0.1` and never returns `0.0.0.0`.
- Update its docstring and module header comments to reflect localhost-only binding.
- Keep `_find_free_port` unchanged logically; once `host` is no longer `0.0.0.0`, its bind probe is safe.
- In `src/bnnr/cli.py`, update dashboard command docstring and bind-host status messaging so it no longer references fallback from `0.0.0.0`.

No new methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
