### PR TITLE
fix(deps): require starlette>=1.3.1 to patch four CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ ultralytics = [
 ]
 dashboard = [
   "fastapi>=0.115.0",
+  "starlette>=1.3.1",  # security floor: CVE-2026-48817/48818/54282/54283 (transitive via fastapi)
   "uvicorn>=0.30.0",
   "websockets>=12.0",
   "qrcode>=7.0",
@@ -107,6 +108,7 @@ constraint-dependencies = [
   "filelock>=3.20.3",
   "pygments>=2.20.0",
   "pillow>=12.2.0",
+  "starlette>=1.3.1",  # CVE-2026-48817/48818/54282/54283 via fastapi[dashboard]
 ]
 
 # Default sdist respects .gitignore; UI build output must still land in the tarball.

--- a/security/pip-audit-allowlist.txt
+++ b/security/pip-audit-allowlist.txt
@@ -10,5 +10,3 @@ PYSEC-2026-139  # torch; fixed in torch 2.9+
 # aka GHSA-rrmf-rvhw-rf47. IDs kept comment-free so the CI ignore loop matches them.
 CVE-2025-3000
 PYSEC-2025-194
-# starlette via fastapi[dashboard] — bump when upstream pins fixed release
-PYSEC-2026-161


### PR DESCRIPTION
## What

Pin `starlette>=1.3.1` to resolve the four Dependabot alerts on the default branch. Starlette is a transitive dependency via `fastapi[dashboard]`.

| Alert | CVE | Severity | Fixed in |
|---|---|---|---|
| #27 SSRF/NTLM via UNC in StaticFiles | CVE-2026-48818 | High | 1.1.0 |
| #29 `request.form()` limits ignored (DoS) | CVE-2026-54283 | High | 1.3.1 |
| #26 arbitrary HTTP method via `getattr` | CVE-2026-48817 | Moderate | 1.1.0 |
| #28 path poisons `request.url.hostname` | CVE-2026-54282 | Low | 1.3.0 |

`starlette>=1.3.1` clears all four. `fastapi==0.135.1` requires only `starlette>=0.46.0`, so the bump resolves cleanly (verified with `uv lock`).

## Changes

- `pyproject.toml`: add `starlette>=1.3.1` to the `dashboard` extra (manifest-level floor that the dependency graph reads directly).
- `pyproject.toml`: add the same floor to `[tool.uv].constraint-dependencies`, matching the existing filelock/pygments/pillow pattern, so any in-repo resolve is guaranteed safe.
- `security/pip-audit-allowlist.txt`: drop the obsolete `PYSEC-2026-161` entry (a separate starlette CVE already fixed below the new floor).

## Note on the alerts

The alerts read "detected in `uv.lock`", but `uv.lock` is intentionally untracked (removed in #244, gitignored). The alerts trace to the last committed lockfile snapshot. This PR floors starlette at the manifest level so the dependency graph refreshes safely; any residual stale alerts will be dismissed separately.