### PR TITLE
ci: cap numpy<2.5 in quality job so mypy passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,dashboard]"
+          # numpy 2.5.0 ships PEP 695 `type` statements in its stubs, which mypy
+          # rejects under our python_version = "3.10" target ("Type statement is
+          # only supported in Python 3.12 and greater"). Cap numpy here, in the
+          # type-check job only, so the test matrix still runs against numpy 2.5.
+          pip install -e ".[dev,dashboard]" "numpy<2.5"
 
       - name: Lint with ruff
         run: ruff check src/ tests/


### PR DESCRIPTION
## Problem

Every open PR (#351, #349) was failing CI on the `quality-linux` job, at the `mypy src/bnnr/` step, with an error in numpy's own stubs:

```
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
Process completed with exit code 2
```

The failure is dependency drift, not a code change: the quality job installs unpinned tooling and pulled in the freshly released numpy 2.5.0, whose stubs use PEP 695 `type X = ...` statements. mypy rejects that syntax under our `python_version = "3.10"` target.

## Root cause confirmed by local repro

| mypy | numpy | result |
|------|-------|--------|
| 2.1.0 | 2.5.0 | **fails** (stub syntax error) |
| 2.0.0 | 2.5.0 | **fails** (so capping mypy does not help) |
| 2.1.0 | 2.4.6 | passes |

The culprit is numpy 2.5.0, not mypy.

## Fix

Cap `numpy<2.5` in the `quality-linux` install step only. mypy type-checks against numpy 2.4 stubs; the test matrix keeps installing the latest numpy and exercises it at runtime, so we lose no runtime coverage.