### PR TITLE
fix(deps): floor msgpack>=1.2.1 to patch GHSA-6v7p-g79w-8964

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ constraint-dependencies = [
   "pygments>=2.20.0",
   "pillow>=12.2.0",
   "starlette>=1.3.1",  # CVE-2026-48817/48818/54282/54283 via fastapi[dashboard]
+  "msgpack>=1.2.1",  # GHSA-6v7p-g79w-8964 OOB read; dev-only transitive via pip-audit -> cachecontrol
 ]
 
 # Default sdist respects .gitignore; UI build output must still land in the tarball.


### PR DESCRIPTION
## Alert

Dependabot alert #30 (high, GHSA-6v7p-g79w-8964): `msgpack <= 1.2.0` has an out-of-bounds read / crash on `Unpacker` reuse after a caught error. Patched in 1.2.1.

## Exposure

msgpack reaches the project **only as a dev-only transitive**: `pip-audit` -> `cachecontrol` -> `msgpack`. It is in the `dev` extra, never in runtime deps, and never ships in the bnnr wheel. Real-world impact on installed users is nil; the alert surfaces via the gitignored `uv.lock`.

## Fix

Add `msgpack>=1.2.1` to the existing `[tool.uv] constraint-dependencies` security floors (next to filelock / pillow / starlette). `uv lock --dry-run` confirms the resolution moves 1.2.0 -> 1.2.1.

Because `uv.lock` is gitignored, the alert is keyed to an untracked file and will not auto-close from a lockfile bump, so it is dismissed manually once this floor lands.