### PR TITLE
fix(xai): honor explicit device on GPU hosts, enforce CPU-only tests

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -261,7 +261,12 @@ Fix:
 
 - Explicitly pass your current Python version to override the default configuration target: `mypy src --python-version 3.14`
 
-## 19) PyTorch / CUDA device mismatch during pytest on WSL
+## 19) (Historical) PyTorch / CUDA device mismatch during pytest on WSL
+
+This is fixed as of issue #356: `tests/conftest.py` now hides the GPU for the
+test session automatically, and the OptiCAM explainer no longer promotes an
+explicit `device="cpu"` run to CUDA. A plain `pytest` works on a GPU-visible
+host with no manual env var. The notes below are kept as background.
 
 Symptom:
 
@@ -273,4 +278,4 @@ Cause:
 
 Fix:
 
-- Force PyTorch to execute the entire test suite on the CPU by hiding the GPU devices using the `CUDA_VISIBLE_DEVICES` environment variable: `CUDA_VISIBLE_DEVICES="" pytest`
+- Update to a release that includes the issue #356 fix. If you are on an older checkout, force PyTorch to execute the entire test suite on the CPU by hiding the GPU devices using the `CUDA_VISIBLE_DEVICES` environment variable: `CUDA_VISIBLE_DEVICES="" pytest`

--- a/src/bnnr/xai.py
+++ b/src/bnnr/xai.py
@@ -154,11 +154,15 @@ class OptiCAMExplainer(BaseExplainer):
         if not target_layers:
             raise ValueError("OptiCAMExplainer requires at least one target layer")
 
+        # Honor the device the caller already placed the model/inputs on. We
+        # must not promote an explicit device="cpu" run to CUDA just because a
+        # GPU is visible: model.to() is in-place, so that would silently move
+        # the caller's shared model to CUDA and break subsequent CPU steps with
+        # a FloatTensor/cuda.FloatTensor mismatch (see issue #356). The
+        # use_cuda flag is retained for backward-compatible construction but no
+        # longer overrides the caller's device choice.
         device = images.device
-        if self.use_cuda and torch.cuda.is_available():
-            device = torch.device("cuda")
         model = model.to(device)
-        images = images.to(device)
         batch, _, height, width = images.shape
 
         targets = torch.as_tensor(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+import os
+
+# Force CPU-only test runs regardless of host GPU visibility (e.g. WSL2 with
+# CUDA passthrough or a GPU CI runner). This must run before torch initializes
+# its CUDA context so torch.cuda.is_available() reports False and the suite is
+# deterministic without any manual env var (see issue #356). setdefault keeps
+# an explicit CUDA_VISIBLE_DEVICES override intact for anyone who wants it.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_device_handling.py
+++ b/tests/test_device_handling.py
@@ -1,0 +1,62 @@
+"""Device-handling regression tests (issue #356).
+
+These pin the contract that an explicit ``device="cpu"`` run is never
+auto-promoted to CUDA, even on a host where a GPU is visible. The failure this
+guards against is a saliency explainer moving the shared model to CUDA in place,
+which later breaks CPU training with a FloatTensor/cuda.FloatTensor mismatch.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from bnnr.xai import OptiCAMExplainer, generate_saliency_maps
+
+
+class _TinyNet(nn.Module):
+    def __init__(self, n_classes: int = 3) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, 3, padding=1)
+        self.pool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(8, n_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.relu(self.conv(x))
+        return self.fc(self.pool(x).flatten(1))
+
+
+# n_iters=0 skips the optimization loop. That keeps the test runnable on a
+# CPU-only build (a patched-available CUDA otherwise trips torch's Adam graph
+# capture health check) while still exercising the device selection at the top
+# of explain(), which is where the promotion bug lived.
+
+
+def test_opticam_does_not_promote_cpu_model_when_cuda_visible(monkeypatch):
+    """OptiCAM must keep a CPU model on CPU even if a GPU appears available."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    model = _TinyNet()
+    images = torch.rand(2, 3, 32, 32)
+    labels = torch.randint(0, 3, (2,))
+
+    maps = OptiCAMExplainer(n_iters=0).explain(model, images, labels, [model.conv])
+
+    assert next(model.parameters()).device.type == "cpu"
+    assert maps.shape[0] == 2
+
+
+def test_generate_saliency_maps_keeps_cpu_when_cuda_visible(monkeypatch):
+    """The public entrypoint must not create CUDA tensors for a CPU run."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    model = _TinyNet()
+    images = torch.rand(2, 3, 32, 32)
+    labels = torch.randint(0, 3, (2,))
+
+    maps = generate_saliency_maps(
+        model, images, labels, [model.conv], method="opticam", n_iters=0
+    )
+
+    assert next(model.parameters()).device.type == "cpu"
+    assert maps.shape[0] == 2


### PR DESCRIPTION
Closes #356.

## Root cause

`OptiCAMExplainer.explain` (`src/bnnr/xai.py`) moved the shared model to CUDA in place whenever a GPU was visible (`use_cuda=True` default and `torch.cuda.is_available()`), ignoring the device the caller placed the model and inputs on. Since `Module.to()` mutates in place, an explicit `device="cpu"` run was silently promoted to CUDA, and the next CPU training step failed with:

```
RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same
```

This is what produced the WSL/GPU-host pytest failures documented as a workaround in #354. `get_device("cpu")` was already correct; this explainer was the leak. `GradCAMExplainer` already honors `images.device`.

## Changes

1. `OptiCAMExplainer.explain` now computes on `images.device` and never promotes an explicit device to CUDA. `use_cuda` is retained for backward-compatible construction but no longer overrides the caller's device.
2. `tests/conftest.py` sets `CUDA_VISIBLE_DEVICES=""` before torch initializes CUDA, so a plain `pytest` is deterministically CPU-only on a GPU-visible host. Uses `setdefault`, so an explicit override is still honored.
3. `tests/test_device_handling.py` adds a regression test that patches `torch.cuda.is_available()` to `True` and asserts a CPU run is not promoted to CUDA. It uses `n_iters=0` so it stays runnable on CPU-only builds (a patched-available CUDA otherwise trips torch's Adam graph-capture health check) while still exercising the device selection where the bug lived.
4. `docs/troubleshooting.md` section 19 is marked historical; the env-var trick is no longer required to run the suite.

## Verification

- Full suite: 1025 passed, 4 skipped locally.
- Regression test fails on the pre-fix code and passes after the fix.

## Acceptance criteria

- [x] `pytest` passes on a GPU-visible host with no manual env var.
- [x] A regression test pins device behavior with a simulated-available GPU.
- [x] Library code never auto-promotes an explicit `device="cpu"` run to CUDA.
- [x] The #354 troubleshooting entry stays as background context but is no longer required.