### PR TITLE
fix(cli): give actionable error when analyze --model is missing

### DIFF
--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -636,7 +636,7 @@ def analyze_command(
             f"Error: --model checkpoint not found: {model}\n"
             "Pass --model with the path to a trained checkpoint (.pt) file, e.g.:\n"
             "  bnnr analyze --model checkpoints/model.pt --data cifar10 --output analysis/\n"
-            "If you have not trained a model yet, run `bnnr train` first.",
+            "If you have not trained a model yet, run bnnr train first.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/src/bnnr/cli.py
+++ b/src/bnnr/cli.py
@@ -632,7 +632,13 @@ def analyze_command(
     from bnnr.analyze import analyze_model
 
     if not model.exists():
-        typer.echo(f"Error: Model path does not exist: {model}", err=True)
+        typer.echo(
+            f"Error: --model checkpoint not found: {model}\n"
+            "Pass --model with the path to a trained checkpoint (.pt) file, e.g.:\n"
+            "  bnnr analyze --model checkpoints/model.pt --data cifar10 --output analysis/\n"
+            "If you have not trained a model yet, run `bnnr train` first.",
+            err=True,
+        )
         raise typer.Exit(code=1)
 
     task = task.strip()

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -168,6 +168,28 @@ class TestReportCommand:
         assert result.exit_code == 1
 
 
+class TestAnalyzeMissingCheckpoint:
+    """`bnnr analyze` should give an actionable error when --model is missing."""
+
+    def test_nonexistent_model_gives_actionable_error(self, tmp_path):
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                "--model",
+                str(tmp_path / "does_not_exist.pt"),
+                "--data",
+                "cifar10",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "--model checkpoint not found" in result.output
+        assert ".pt" in result.output
+        assert "bnnr train" in result.output
+
+
 class TestXaiPresets:
     """Tests for XAI preset helpers in config.py."""
 

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -169,7 +169,7 @@ class TestReportCommand:
 
 
 class TestAnalyzeMissingCheckpoint:
-    """`bnnr analyze` should give an actionable error when --model is missing."""
+    """`bnnr analyze` should give an actionable error when --model points to a missing checkpoint."""
 
     def test_nonexistent_model_gives_actionable_error(self, tmp_path):
         result = runner.invoke(
@@ -185,9 +185,9 @@ class TestAnalyzeMissingCheckpoint:
             ],
         )
         assert result.exit_code == 1
-        assert "--model checkpoint not found" in result.output
-        assert ".pt" in result.output
-        assert "bnnr train" in result.output
+        assert "--model checkpoint not found" in result.stderr
+        assert ".pt" in result.stderr
+        assert "bnnr train" in result.stderr
 
 
 class TestXaiPresets:


### PR DESCRIPTION
## Summary

`bnnr analyze` previously failed with a bare
`Error: Model path does not exist: <path>` when `--model` pointed at a
missing checkpoint — a newcomer had no idea what to do next.

This rewrites the message to name the problem, the expected value
(a `.pt` checkpoint), and the exact fix: pass a real checkpoint, or run
`bnnr train` first if there is no model yet. Adds a CLI test
(`TestAnalyzeMissingCheckpoint`) asserting the new message text.

## Related issue

Closes #327

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [ ] Docs updated if CLI or user-facing behavior changed (`README.md`, `docs/`)
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed (`cd dashboard_web && npm ci && npm run build`)

See [CONTRIBUTING.md](../CONTRIBUTING.md) for full setup and style guidelines.
