### PR TITLE
feat(benchmarks): expose --fill-strategy sweep and fill-ranking in grand benchmark - T13

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -170,6 +170,7 @@ benchmarks/
 - **Unequal compute by design.** `bnnr_branch_search` runs a baseline phase plus branch search (more epochs of compute than the fixed-epoch baselines). Compare as *"full BNNR product vs fixed-epoch baselines"*, not equal-budget ablation.
 - **Not an ImageNet-SOTA claim.** This is a low-data fine-grained transfer setup for comparing augmentation *strategies*, not a leaderboard entry.
 - **Low-data, from-scratch by design.** A small balanced train subset trained from random init is what surfaces augmentation effects; `--train-per-class`, `--pretrained`, `--epochs`, and `--img-size` tune the regime.
+- **Fill sweeps share baselines and need enough seeds.** Fill-independent conditions run once and are reused across every fill, so a sweep only multiplies the ICD/AICD-using conditions. Ranking many fills is Holm-corrected: with 5 fills the "meaningful" verdict needs **≥ 8 seeds**, and `summarize_grand.py` prints an explicit *underpowered* note when that gate can't fire.
 
 ### Results
 
@@ -191,6 +192,7 @@ The Imagewoof benchmark above compares the **full BNNR product** against fixed-e
 | BNNR beats strong external baselines | vs RandAugment, TrivialAugment, AutoAugment |
 | ICD reduces shortcut learning | XAI metrics: edge ratio, gini, coverage |
 | Results generalize across domains | 6 datasets |
+| Which ICD/AICD fill strategy is best | `icd_only` across `--fill-strategies` |
 
 ### Conditions (10)
 
@@ -206,6 +208,16 @@ The Imagewoof benchmark above compares the **full BNNR product** against fixed-e
 | DTD | 47 | 120 | 224px | Textures |
 | FGVC-Aircraft | 100 | 33 | 224px | Aircraft |
 | EuroSAT | 10 | 100 | 64px | Satellite |
+
+### Fill strategy
+
+| Value | Fill |
+|-------|------|
+| `gaussian_blur` | Blurred copy of the region (**default**) |
+| `local_mean` | Per-region mean color |
+| `global_mean` | Whole-image mean color |
+| `noise` | Random noise (seed-controlled) |
+| `solid` | Constant fill |
 
 ### Protocol caveats (read before quoting numbers)
 
@@ -228,6 +240,11 @@ python benchmarks/run_grand_benchmark.py --dataset pets --device cuda
 
 # Summarize: Wilcoxon signed-rank + bootstrap CI + Holm-Bonferroni
 python benchmarks/summarize_grand.py --results-dir benchmarks/ --markdown
+# Same as above but "does any fill beat gaussian_blur?"
+python benchmarks/summarize_grand.py --results-dir benchmarks/ --markdown --reference-fill gaussian_blur
+
+# Fill-strategy ablation: sweep all five fills for icd_only
+python benchmarks/run_grand_benchmark.py --dataset imagewoof --device cuda --conditions icd_only --fill-strategies gaussian_blur,local_mean,global_mean,noise,solid
 ```
 
 Resume-safe: `results_{dataset}_{regime}.json` is checkpointed after every `(condition, seed)` run. Use `--drive-base-dir` to land results, run logs, and dataset cache under one directory (Colab/Drive).

--- a/benchmarks/run_grand_benchmark.py
+++ b/benchmarks/run_grand_benchmark.py
@@ -85,6 +85,8 @@ _IMAGENET_STD = (0.229, 0.224, 0.225)
 N_CANDIDATES = 3
 _CANDIDATE_NAMES = ["ICD", "AICD", "ChurchNoise"]
 
+VALID_FILL_STRATEGIES = ["gaussian_blur", "local_mean", "global_mean", "noise", "solid"]
+
 # Indices into held_out_test loader for XAI overlay export
 _XAI_SAMPLE_INDICES = [0, 50, 100, 150, 200, 250]
 
@@ -247,6 +249,9 @@ CONDITIONS: dict[str, ConditionSpec] = {
         max_iterations=N_CANDIDATES,
     ),
 }
+
+FILL_USING_CONDITIONS = {"icd_only", "aicd_only", "icd_aicd_fixed", "bnnr_random", "bnnr_xai"}
+
 
 _POLICY_BY_CONDITION = {
     "no_aug": "base",
@@ -415,6 +420,7 @@ def _stamp(
     img_size: int,
     pretrained: bool,
     regime: str,
+    fill_strategy: str,
 ) -> dict[str, Any]:
     """Override CIFAR-10 defaults baked into lib._result_entry."""
     entry["dataset"] = dataset
@@ -422,6 +428,7 @@ def _stamp(
     entry["img_size"] = img_size
     entry["pretrained"] = pretrained
     entry["regime"] = regime
+    entry["fill_strategy"] = fill_strategy
     return entry
 
 
@@ -643,6 +650,7 @@ def _run_plain_condition(
         img_size=args.img_size,
         pretrained=args.pretrained,
         regime=args.regime,
+        fill_strategy=args.fill_strategy,
     )
 
 
@@ -777,19 +785,23 @@ def _run_xai_aug_warmup_condition(
     if aug_type == "icd":
         augmentations = [ICD(model=_model, target_layers=_layers,
                              threshold_percentile=75.0, probability=0.5,
-                             random_state=seed, cache=_cache)]
+                             random_state=seed, cache=_cache,
+                             fill_strategy=args.fill_strategy)]
     elif aug_type == "aicd":
         augmentations = [AICD(model=_model, target_layers=_layers,
                               threshold_percentile=75.0, probability=0.5,
-                              random_state=seed + 1, cache=_cache)]
+                              random_state=seed + 1, cache=_cache,
+                              fill_strategy=args.fill_strategy)]
     elif aug_type == "icd_aicd":
         augmentations = [
             ICD(model=_model, target_layers=_layers,
                 threshold_percentile=75.0, probability=0.5,
-                random_state=seed, cache=_cache),
+                random_state=seed, cache=_cache,
+                fill_strategy=args.fill_strategy),
             AICD(model=_model, target_layers=_layers,
                  threshold_percentile=75.0, probability=0.5,
-                 random_state=seed + 1, cache=_cache),
+                 random_state=seed + 1, cache=_cache,
+                 fill_strategy=args.fill_strategy),
         ]
     else:
         raise ValueError(f"Unknown aug_type {aug_type!r}")
@@ -889,6 +901,7 @@ def _run_xai_aug_warmup_condition(
         img_size=args.img_size,
         pretrained=args.pretrained,
         regime=args.regime,
+        fill_strategy=args.fill_strategy,
     )
 
 
@@ -1061,10 +1074,12 @@ def _run_bnnr_equal_compute(
         phase_candidates = [
             ICD(model=_cand_model, target_layers=_cand_layers,
                 threshold_percentile=75.0, probability=0.5,
-                random_state=seed, cache=xai_cache),
+                random_state=seed, cache=xai_cache,
+                fill_strategy=args.fill_strategy),
             AICD(model=_cand_model, target_layers=_cand_layers,
                  threshold_percentile=75.0, probability=0.5,
-                 random_state=seed + 1, cache=xai_cache),
+                 random_state=seed + 1, cache=xai_cache,
+                 fill_strategy=args.fill_strategy),
             ChurchNoise(probability=0.5, intensity=0.5,
                         noise_strength_range=(3.0, 8.0), random_state=seed + 2),
         ]
@@ -1203,6 +1218,7 @@ def _run_bnnr_equal_compute(
         img_size=args.img_size,
         pretrained=args.pretrained,
         regime=args.regime,
+        fill_strategy=args.fill_strategy
     )
 
 
@@ -1221,15 +1237,20 @@ def run_condition(
 ) -> dict[str, Any]:
     spec = CONDITIONS[condition_id]
 
+    if condition_id in FILL_USING_CONDITIONS:
+        run_output_root = output_root / f"fill_{args.fill_strategy}"
+    else:
+        run_output_root = output_root
+
     if condition_id == "bnnr_xai":
         return _run_bnnr_equal_compute(
             condition=spec, seed=seed, args=args,
-            output_root=output_root, selection_mode="xai", num_classes=num_classes,
+            output_root=run_output_root, selection_mode="xai", num_classes=num_classes,
         )
     if condition_id == "bnnr_random":
         return _run_bnnr_equal_compute(
             condition=spec, seed=seed, args=args,
-            output_root=output_root, selection_mode="random", num_classes=num_classes,
+            output_root=run_output_root, selection_mode="random", num_classes=num_classes,
         )
 
     # ICD/AICD conditions use warmup+aug design so saliency comes from a
@@ -1238,17 +1259,17 @@ def run_condition(
     if condition_id == "icd_only":
         return _run_xai_aug_warmup_condition(
             condition=spec, aug_type="icd", seed=seed, args=args,
-            output_root=output_root, num_classes=num_classes,
+            output_root=run_output_root, num_classes=num_classes,
         )
     if condition_id == "aicd_only":
         return _run_xai_aug_warmup_condition(
             condition=spec, aug_type="aicd", seed=seed, args=args,
-            output_root=output_root, num_classes=num_classes,
+            output_root=run_output_root, num_classes=num_classes,
         )
     if condition_id == "icd_aicd_fixed":
         return _run_xai_aug_warmup_condition(
             condition=spec, aug_type="icd_aicd", seed=seed, args=args,
-            output_root=output_root, num_classes=num_classes,
+            output_root=run_output_root, num_classes=num_classes,
         )
 
     policy = _POLICY_BY_CONDITION[condition_id]
@@ -1330,20 +1351,23 @@ def _benchmark_document(args: argparse.Namespace, num_classes: int) -> dict[str,
 # ---------------------------------------------------------------------------
 
 
-def _estimate(args: argparse.Namespace, n_seeds: int, conds: list[str]) -> str:
-    bnnr_conds = {"bnnr_xai", "bnnr_random"}
-    bnnr_count = sum(1 for c in conds if c in bnnr_conds)
-    plain_count = len(conds) - bnnr_count
-    plain_epochs_total = plain_count * args.budget * n_seeds
-    bnnr_epochs_total = bnnr_count * args.budget * n_seeds
-    total_epoch_minutes = (plain_epochs_total + bnnr_epochs_total) * 1.0
+def _estimate(args: argparse.Namespace, n_seeds: int, conds: list[str], n_strategies: int = 1) -> str:
+    # Fill-using conditions run once per strategy; fill-independent run once total.
+    fill_using_count = sum(1 for c in conds if c in FILL_USING_CONDITIONS)
+    fill_indep_count = len(conds) - fill_using_count
+    fill_using_runs = fill_using_count * n_seeds * n_strategies
+    fill_indep_runs = fill_indep_count * n_seeds
+    total_runs = fill_using_runs + fill_indep_runs
+    total_epoch_minutes = total_runs * args.budget * 1.0
     if args.device != "cpu":
         total_epoch_minutes *= 0.15
+    sweep = f" x {n_strategies} strategies" if n_strategies > 1 else ""
     return (
         f"~{total_epoch_minutes/60:.1f}h wall-clock estimate "
-        f"({len(conds)} conditions x {n_seeds} seeds, {args.device}, "
+        f"({len(conds)} conditions x {n_seeds} seeds{sweep}, {args.device}, "
         f"budget={args.budget})"
     )
+
 
 
 # ---------------------------------------------------------------------------
@@ -1389,6 +1413,12 @@ def main() -> None:
         help="Comma-separated seeds (default: dataset-specific)",
     )
     parser.add_argument("--arch", default="resnet18", choices=["resnet18", "resnet50"])
+    parser.add_argument(
+        "--fill-strategy", "--fill-strategies",
+        dest="fill_strategy",
+        default="gaussian_blur",
+        help="Single fill strategy or comma-separated strategies for ICD/AICD masked regions (default: gaussian_blur)"
+    )
     parser.add_argument(
         "--img-size",
         type=int,
@@ -1502,6 +1532,22 @@ def main() -> None:
         if c not in CONDITIONS:
             parser.error(f"Unknown condition {c!r}. Available: {', '.join(CONDITIONS)}")
 
+    # ---- Fill strategies ----
+    requested = [s.strip() for s in args.fill_strategy.split(",") if s.strip()]
+    if not requested:
+        parser.error("--fill-strategy must name at least one strategy")
+    for s in requested:
+        if s not in VALID_FILL_STRATEGIES:
+            parser.error(
+                f"Unknown fill strategy {s!r}. "
+                f"Available: {', '.join(VALID_FILL_STRATEGIES)}"
+            )
+    fill_strategies: list[str] = []
+    for s in requested:
+        if s not in fill_strategies:
+            fill_strategies.append(s)
+    args.fill_strategies = fill_strategies
+
     # ---- Device ----
     if not hasattr(args, "device"):
         args.device = "auto"
@@ -1520,11 +1566,15 @@ def main() -> None:
     print(f"  pretrained={args.pretrained}  img_size={args.img_size}")
     print(f"  num_classes={num_classes}  train_per_class={args.train_per_class}")
     print(f"  seeds={seeds}  conditions={conds}")
+    if len(fill_strategies) == 1:
+        print(f"  fill_strategy={fill_strategies[0]}")
+    else:
+        print(f"  fill_strategies (sweep of {len(fill_strategies)})={fill_strategies}")
     print(
         f"  budget={args.budget} epochs  epochs_per_phase={epochs_per_phase}  "
         f"N_candidates={N_CANDIDATES}  device={args.device}"
     )
-    print(f"  {_estimate(args, len(seeds), conds)}")
+    print(f"  {_estimate(args, len(seeds), conds, len(fill_strategies))}")
     print(f"  results -> {args.results}")
 
     if args.dry_run:
@@ -1542,46 +1592,65 @@ def main() -> None:
 
     # Resume safety
     done = {
-        (r["condition"], r["seed"], r.get("regime", "scratch"))
+        (r["condition"], r["seed"], r.get("regime", "scratch"), r.get("fill_strategy", "none"))
         for r in data["runs"]
         if "val_metric" in r and "error" not in r
     }
+    # Partition conditions: fill-using vary per strategy; fill-independent run once.
+    fill_using = [c for c in conds if c in FILL_USING_CONDITIONS]
+    fill_indep = [c for c in conds if c not in FILL_USING_CONDITIONS]
 
+    def _execute(cid: str, seed: int) -> None:
+        strategy = args.fill_strategy  # set per block by the caller ("none" or a real strategy)
+        key = (cid, seed, args.regime, strategy)
+        if key in done:
+            print(f"SKIP {cid} seed={seed} regime={args.regime} fill={strategy} (already done)")
+            return
+        print(f"\n>>> dataset={args.dataset}  condition={cid}  seed={seed}  regime={args.regime}  fill={strategy}")
+        try:
+            entry = run_condition(
+                condition_id=cid,
+                seed=seed,
+                args=args,
+                output_root=args.output_root,
+                num_classes=num_classes,
+            )
+        except Exception as exc:  # noqa: BLE001
+            import traceback
+            print(f"    FAILED ({cid}, seed={seed}, fill={strategy}): {exc}", file=sys.stderr)
+            traceback.print_exc()
+            entry = {
+                "condition": cid,
+                "seed": seed,
+                "regime": args.regime,
+                "dataset": args.dataset,
+                "model": args.arch,
+                "fill_strategy": args.fill_strategy,
+                "error": str(exc),
+            }
+        data["runs"].append(entry)
+        save_results(args.results, data)  # checkpoint after every run
+        if "error" not in entry:
+            done.add(key)  # in-invocation guard: never redo a completed cell
+        val = entry.get("val_metric")
+        held = entry.get("held_out_test_metric")
+        if val is not None:
+            print(f"    {cid} seed={seed} fill={strategy}: val_metric(held_out)={val:.4f}")
+        elif held is not None:
+            print(f"    {cid} seed={seed} fill={strategy}: held_out_test_accuracy={held:.4f}")
+
+    # ---- Block A: fill-independent methods — evaluated once, tagged "none", reused across strategies ----
+    args.fill_strategy = "none"
     for seed in seeds:
-        for cid in conds:
-            key = (cid, seed, args.regime)
-            if key in done:
-                print(f"SKIP {cid} seed={seed} regime={args.regime} (already done)")
-                continue
-            print(f"\n>>> dataset={args.dataset}  condition={cid}  seed={seed}  regime={args.regime}")
-            try:
-                entry = run_condition(
-                    condition_id=cid,
-                    seed=seed,
-                    args=args,
-                    output_root=args.output_root,
-                    num_classes=num_classes,
-                )
-            except Exception as exc:  # noqa: BLE001
-                import traceback
-                print(f"    FAILED ({cid}, seed={seed}): {exc}", file=sys.stderr)
-                traceback.print_exc()
-                entry = {
-                    "condition": cid,
-                    "seed": seed,
-                    "regime": args.regime,
-                    "dataset": args.dataset,
-                    "model": args.arch,
-                    "error": str(exc),
-                }
-            data["runs"].append(entry)
-            save_results(args.results, data)  # checkpoint after every run
-            val = entry.get("val_metric")
-            held = entry.get("held_out_test_metric")
-            if val is not None:
-                print(f"    {cid} seed={seed}: val_metric(held_out)={val:.4f}")
-            elif held is not None:
-                print(f"    {cid} seed={seed}: held_out_test_accuracy={held:.4f}")
+        for cid in fill_indep:
+            _execute(cid, seed)
+
+    # ---- Block B: fill-using methods — evaluated once per strategy ----
+    for strategy in fill_strategies:
+        args.fill_strategy = strategy  # downstream ICD/AICD constructors read args.fill_strategy
+        for seed in seeds:
+            for cid in fill_using:
+                _execute(cid, seed)
 
     n_valid = sum(1 for r in data["runs"] if "val_metric" in r and "error" not in r)
     print(f"\nDone. {n_valid} valid run records in {args.results}")

--- a/benchmarks/summarize_grand.py
+++ b/benchmarks/summarize_grand.py
@@ -7,6 +7,7 @@ Loads all ``results_*.json`` files from a directory and produces:
   3. XAI correlation section (Spearman ρ between edge_ratio and accuracy)
   4. Key comparison section (bnnr_xai vs bnnr_random, per dataset, with p-values)
   5. Compute transparency (total_gpu_epochs per condition)
+  6. Which fill is best (fill-using methods ranked across strategies)
 
 Examples
 --------
@@ -63,6 +64,12 @@ COMPARISON_CONDITIONS = [
     "no_aug", "randaugment", "trivialaugment", "autoaugment",
     "churchnoise_only", "icd_only", "aicd_only", "icd_aicd_fixed", "bnnr_random",
 ]
+
+FILL_STRATEGY_ORDER = ["gaussian_blur", "local_mean", "global_mean", "noise", "solid"]
+FILL_USING_CONDITIONS = [
+    "icd_only", "aicd_only", "icd_aicd_fixed", "bnnr_random", "bnnr_xai",
+]
+
 
 
 # ---------------------------------------------------------------------------
@@ -276,6 +283,7 @@ def _load_all_runs(results_dir: Path, regime_filter: str) -> list[dict[str, Any]
             run_regime = r.get("regime", "scratch")
             if regime_filter != "all" and run_regime != regime_filter:
                 continue
+            r.setdefault("fill_strategy", "none")
             runs.append(r)
     return runs
 
@@ -292,6 +300,7 @@ def _analyze_dataset(
     no_bootstrap: bool,
     n_boot: int,
     markdown: bool,
+    strategy: str = "none",
 ) -> None:
     """Print per-dataset condition table with statistics."""
     ds_runs = [r for r in runs if r.get("dataset") == dataset]
@@ -312,7 +321,7 @@ def _analyze_dataset(
             gpu_epochs_by_cond[cid].append(int(ep))
 
     print(f"\n{'='*70}")
-    print(f"  DATASET: {dataset.upper()}")
+    print(f"  DATASET: {dataset.upper()}  |  fill={strategy}")
     print(f"  Conditions found: {', '.join(sorted(by_cond))}")
     print(f"{'='*70}")
 
@@ -504,10 +513,11 @@ def _cross_dataset_table(
     datasets: list[str],
     *,
     markdown: bool,
+    strategy: str = "none",
 ) -> None:
     """Print a condition × dataset accuracy matrix with mean Δ."""
     print("\n" + "=" * 80)
-    print("  CROSS-DATASET SUMMARY  (median held_out_test accuracy per dataset)")
+    print(f"  CROSS-DATASET SUMMARY  (median held_out_test accuracy)  |  fill={strategy}")
     print("=" * 80)
 
     # Collect medians: by_cond_ds[cond][dataset] = median accuracy
@@ -597,10 +607,11 @@ def _xai_correlation_section(
     datasets: list[str],
     *,
     markdown: bool,
+    strategy: str = "none",
 ) -> None:
     """Print Spearman ρ between xai_edge_ratio and test_accuracy per dataset."""
     print("\n" + "=" * 70)
-    print("  XAI ANALYSIS: edge_ratio vs accuracy correlations")
+    print(f"  XAI ANALYSIS: edge_ratio vs accuracy correlations  |  fill={strategy}")
     print("=" * 70)
 
     for ds in datasets:
@@ -651,10 +662,11 @@ def _key_comparison_section(
     no_bootstrap: bool,
     n_boot: int,
     markdown: bool,
+    strategy: str = "none",
 ) -> None:
     """bnnr_xai vs bnnr_random, per dataset, with Wilcoxon p-values."""
     print("\n" + "=" * 70)
-    print("  KEY COMPARISON: bnnr_xai vs bnnr_random (per dataset)")
+    print(f"  KEY COMPARISON: bnnr_xai vs bnnr_random (per dataset)  |  fill={strategy}")
     print("  (Isolates the contribution of XAI-guided selection)")
     print("=" * 70)
 
@@ -760,10 +772,12 @@ def _key_comparison_section(
 def _compute_transparency_section(
     all_runs: list[dict[str, Any]],
     datasets: list[str],
+    *,
+    strategy: str = "none",
 ) -> None:
     """Print median total_gpu_epochs per condition."""
     print("\n" + "=" * 70)
-    print("  COMPUTE TRANSPARENCY: median total_gpu_epochs per condition")
+    print(f"  COMPUTE TRANSPARENCY: median total_gpu_epochs per condition  |  fill={strategy}")
     print("=" * 70)
     for ds in datasets:
         ds_runs = [r for r in all_runs if r.get("dataset") == ds]
@@ -782,6 +796,284 @@ def _compute_transparency_section(
         if parts:
             print(f"  {ds}: {', '.join(parts)}")
     print()
+
+# ---------------------------------------------------------------------------
+# Which fill is best
+# ---------------------------------------------------------------------------
+
+def _meaningful_gate_reachable(n_present: int, n_shared: int) -> tuple[bool, float]:
+    """Can the 'meaningful' verdict fire at all, given #strategies and #seeds?
+
+    (n_present - 1) tests are run against the reference, so Holm multiplies the
+    smallest raw p by (n_present - 1). The smallest a two-sided signed-rank p can
+    be at n_shared paired seeds (all diffs same sign, no ties) is 2 / 2**n_shared.
+    If even that best case times the Holm factor can't clear 0.05, no data can
+    make the gate fire. Returns (reachable, holm_floor); floor is a lower bound,
+    so an "unreachable" result here is definitive.
+    """
+    if n_shared < 2:
+        return False, 1.0
+    m = max(1, n_present - 1)
+    min_raw_p = 2.0 ** (1 - n_shared)  # = 2 / 2**n_shared
+    floor = min(1.0, min_raw_p * m)
+    return floor < 0.05, floor
+
+def _rank_strategies_for_method(
+    by_strat: dict[str, dict[int, float]],
+    strategies: list[str],
+    *,
+    no_bootstrap: bool,
+    n_boot: int,
+    reference: str | None = None,
+) -> dict[str, Any] | None:
+    """Rank fill strategies for one (dataset, method) cell on shared seeds.
+
+    reference=None  -> empirical-best mode: the top strategy by median is the
+                       reference; the verdict asks whether it is separated from
+                       the runner-up (original behaviour).
+    reference=<s>   -> fixed-reference mode: <s> (e.g. the library default) is the
+                       reference; the verdict asks whether any strategy *beats* it
+                       ("should we change the default?"). Falls back to empirical
+                       best, with a flag, if <s> has no data in this cell.
+    """
+    present = [s for s in strategies if by_strat.get(s)]
+    if len(present) < 2:
+        return None
+
+    shared = sorted(set.intersection(*(set(by_strat[s]) for s in present)))
+    if len(shared) < 2:
+        return {"insufficient": True, "present": present, "shared": shared}
+
+    vecs = {s: [by_strat[s][seed] for seed in shared] for s in present}
+    medians = {s: statistics.median(vecs[s]) for s in present}
+
+    order_index = {s: i for i, s in enumerate(FILL_STRATEGY_ORDER)}
+    ranked = sorted(present, key=lambda s: (-medians[s], order_index.get(s, len(order_index))))
+    top = ranked[0]
+
+    reference_missing = bool(reference) and reference not in present
+    if reference and reference in present:
+        ref, mode = reference, "reference"
+    else:
+        ref, mode = top, "best"
+    ref_vec = vecs[ref]
+
+    entries = []
+    for s in ranked:
+        if s == ref:
+            entries.append({"strategy": s, "median": medians[s], "is_ref": True,
+                            "delta": None, "p": None, "p_holm": None, "r": None,
+                            "stars": "—", "ci_lo": float("nan"), "ci_hi": float("nan")})
+            continue
+        wres = _wilcoxon_signed_rank(vecs[s], ref_vec)
+        W, p, r = wres if wres is not None else (None, None, None)
+        ci_lo, ci_hi = float("nan"), float("nan")
+        if wres is not None and not no_bootstrap:
+            # Δ orientation: strategy - ref (positive => strategy is higher).
+            ci_lo, ci_hi = _bootstrap_median_diff_ci(vecs[s], ref_vec, n_boot=n_boot, rng_seed=42)
+        entries.append({"strategy": s, "median": medians[s], "is_ref": False,
+                        "delta": (medians[s] - medians[ref]) * 100,
+                        "p": p, "p_holm": None, "r": r, "stars": _sig_stars(p),
+                        "ci_lo": ci_lo, "ci_hi": ci_hi})
+
+    testable = [e for e in entries if not e["is_ref"] and e["p"] is not None]
+    if testable:
+        for e, p_adj in zip(testable, _holm_bonferroni([e["p"] for e in testable])):
+            e["p_holm"] = p_adj
+            e["stars"] = _sig_stars(p_adj)
+
+    non_ref = [e for e in entries if not e["is_ref"]]
+    challenger = non_ref[0] if non_ref else None  # highest-median non-reference strategy
+
+    def _sig_and_ci(e):
+        if e is None or e["p_holm"] is None:
+            return False
+        ci_excl = (not math.isnan(e["ci_lo"]) and not math.isnan(e["ci_hi"])
+                   and not (e["ci_lo"] <= 0.0 <= e["ci_hi"]))
+        return e["p_holm"] < 0.05 and (no_bootstrap or ci_excl)
+
+    if mode == "reference":
+        meaningful = (challenger is not None and challenger["median"] > medians[ref]
+                      and _sig_and_ci(challenger))
+    else:
+        meaningful = _sig_and_ci(challenger)  # challenger == runner-up in best mode
+
+    gate_reachable, holm_floor = _meaningful_gate_reachable(len(present), len(shared))
+
+    return {"insufficient": False, "mode": mode, "reference": ref,
+            "reference_requested": reference, "reference_missing": reference_missing,
+            "reference_is_top": ref == top, "shared": shared, "best": top,
+            "challenger": challenger["strategy"] if challenger else None,
+            "runner_up": challenger["strategy"] if challenger else None,
+            "entries": entries, "meaningful": meaningful,
+            "gate_reachable": gate_reachable, "holm_floor": holm_floor}
+
+def _which_fill_is_best_section(
+    all_runs: list[dict[str, Any]],
+    datasets: list[str],
+    strategies: list[str],
+    *,
+    no_bootstrap: bool,
+    n_boot: int,
+    markdown: bool,
+    reference: str | None = None,
+) -> None:
+    """Rank fill strategies head-to-head for each fill-using method (Phase 4).
+
+    Runs once over the whole result set (not per-strategy view). For every
+    dataset and fill-using method it compares strategies on shared seeds using
+    the held-out split metric, ranks them, tests best-vs-each with Wilcoxon +
+    bootstrap CI, and states whether the top gap is meaningful. Fill-independent
+    methods are excluded — there is nothing to compare across fills.
+    """
+    print("\n" + "#" * 80)
+    print("#  WHICH FILL IS BEST  (fill-using methods, held-out split)")
+    print("#  Strategies compared on shared seeds, ranked by median held-out accuracy.")
+    if reference:
+        print(f"#  Reference-anchored mode: testing whether any fill beats '{reference}' (the default).")
+    print("#" * 80)
+
+    if len(strategies) < 2:
+        print(
+            "\n  Only one fill strategy present "
+            f"({strategies[0] if strategies else 'none'}); nothing to rank.\n"
+        )
+        return
+
+    any_output = False
+    for ds in datasets:
+        ds_runs = [r for r in all_runs if r.get("dataset") == ds]
+        if not ds_runs:
+            continue
+
+        # method -> strategy -> {seed: held_out_metric}
+        by_method: dict[str, dict[str, dict[int, float]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+        for r in ds_runs:
+            cid = r["condition"]
+            if cid not in FILL_USING_CONDITIONS:
+                continue
+            strat = r.get("fill_strategy", "none")
+            if strat == "none":
+                continue  # a fill-using method must carry a real strategy tag
+            metric = float(r.get("held_out_test_metric") or r.get("val_metric") or 0.0)
+            by_method[cid][strat][int(r["seed"])] = metric
+
+        methods_present = [c for c in FILL_USING_CONDITIONS if c in by_method]
+        if not methods_present:
+            continue
+
+        print(f"\n{'='*70}")
+        print(f"  DATASET: {ds.upper()}")
+        print(f"{'='*70}")
+        any_output = True
+
+        for cid in methods_present:
+            result = _rank_strategies_for_method(
+                by_method[cid], strategies,
+                no_bootstrap=no_bootstrap, n_boot=n_boot,
+                reference=reference,
+            )
+            label = DISPLAY_NAMES.get(cid, cid)
+            if result is None:
+                print(f"\n  {label} ({cid}): only one strategy has data — nothing to rank.")
+                continue
+            if result.get("insufficient"):
+                n_sh = len(result["shared"])
+                print(
+                    f"\n  {label} ({cid}): insufficient shared-seed data "
+                    f"(n={n_sh}); need >= 2 seeds common to all strategies."
+                )
+                continue
+
+            if markdown:
+                _print_fill_ranking_markdown(cid, label, result)
+            else:
+                _print_fill_ranking_text(cid, label, result)
+
+    if not any_output:
+        print("\n  No fill-using method has multi-strategy data to rank.\n")
+
+
+def _verdict_line(result: dict[str, Any]) -> str:
+    ref = result["reference"]
+    challenger = result.get("challenger")
+    if result.get("mode") == "reference":
+        if result["meaningful"]:
+            return f"{challenger} beats the reference ({ref}) significantly — candidate to replace the default."
+        if result.get("reference_is_top"):
+            return f"reference ({ref}) has the highest median; no strategy beats it — keep the default."
+        return f"{challenger} leads the reference ({ref}) but not significantly — keep the default (change unjustified)."
+    if result["meaningful"]:
+        return f"best: {ref} — gap to runner-up ({challenger}) is significant (meaningful)."
+    return (f"best: {ref} — but not clearly separated from runner-up ({challenger}); "
+            "treat the ranking as tentative.")
+
+
+def _print_fill_ranking_text(cid: str, label: str, result: dict[str, Any]) -> None:
+    shared = result["shared"]
+    seed_s = ",".join(str(s) for s in shared)
+    ref = result["reference"]
+    tag = "reference" if result.get("mode") == "reference" else "best"
+    print(f"\n  {label} ({cid})  — shared seeds n={len(shared)}: {seed_s}")
+    if result.get("reference_missing"):
+        print(f"    note: requested reference {result.get('reference_requested')!r} "
+              f"has no data here; using empirical best ({ref}).")
+    for i, e in enumerate(result["entries"], start=1):
+        med_s = f"{e['median']*100:.2f}%"
+        if e["is_ref"]:
+            print(f"    {i}. {e['strategy']:<14} {med_s:>8}   ({tag})")
+            continue
+        ci_s = ""
+        if not (math.isnan(e["ci_lo"]) or math.isnan(e["ci_hi"])):
+            ci_s = f"  CI=[{e['ci_lo']*100:+.2f},{e['ci_hi']*100:+.2f}]pp"
+        r_s = f"{e['r']:.2f}" if e["r"] is not None else "—"
+        print(
+            f"    {i}. {e['strategy']:<14} {med_s:>8}   "
+            f"Δ={e['delta']:+.2f}pp vs {ref}  "
+            f"{_p_label(e['p_holm'])} {e['stars']}  r={r_s}{ci_s}"
+        )
+    print(f"    -> {_verdict_line(result)}")
+    if not result.get("gate_reachable", True):
+        n_strat = len(result["entries"])
+        print(
+            f"    note: underpowered — with {n_strat} strategies and n={len(shared)} shared "
+            f"seeds the 'meaningful' gate cannot fire (best-case Holm p>={result['holm_floor']:.4f}); "
+            f"any verdict reads 'tentative'. Increase seeds (>=8 for 5 strategies)."
+        )
+
+
+def _print_fill_ranking_markdown(cid: str, label: str, result: dict[str, Any]) -> None:
+    shared = result["shared"]
+    ref = result["reference"]
+    tag = "reference" if result.get("mode") == "reference" else "best"
+    print(f"\n**{label} (`{cid}`)** — shared seeds n={len(shared)}")
+    if result.get("reference_missing"):
+        print(f"\n> requested reference `{result.get('reference_requested')}` has no data here; "
+              f"using empirical best (`{ref}`).")
+    print("| Rank | Strategy | Median | Δ vs ref | p (Holm) | stars | r | Bootstrap 95% CI |")
+    print("|------|----------|--------|---------|---|-------|---|------------------|")
+    for i, e in enumerate(result["entries"], start=1):
+        med_s = f"{e['median']*100:.2f}%"
+        if e["is_ref"]:
+            print(f"| {i} | {e['strategy']} | {med_s} | ({tag}) | — | — | — | — |")
+            continue
+        ci_s = (f"[{e['ci_lo']*100:+.2f}, {e['ci_hi']*100:+.2f}]pp"
+                if not (math.isnan(e["ci_lo"]) or math.isnan(e["ci_hi"])) else "—")
+        r_s = f"{e['r']:.2f}" if e["r"] is not None else "—"
+        print(
+            f"| {i} | {e['strategy']} | {med_s} | {e['delta']:+.2f}pp | "
+            f"{_p_label(e['p_holm'])} | {e['stars']} | {r_s} | {ci_s} |"
+        )
+    print(f"\n**{_verdict_line(result).capitalize()}**")
+    if not result.get("gate_reachable", True):
+        n_strat = len(result["entries"])
+        print(
+            f"\n> **Underpowered:** {n_strat} strategies, n={len(shared)} shared seeds — "
+            f"the 'meaningful' gate cannot fire (best-case Holm p>={result['holm_floor']:.4f}); "
+            f"any verdict reads 'tentative'. Increase seeds (>=8 for 5 strategies)."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -819,6 +1111,13 @@ def main() -> None:
         default=10_000,
         help="Bootstrap resampling iterations (default 10000)",
     )
+    parser.add_argument(
+        "--reference-fill",
+        default=None,
+        help="Anchor the 'which fill is best' comparison on this fixed strategy "
+             "(e.g. the current library default 'gaussian_blur') and ask whether any "
+             "fill beats it. Default: rank by empirical best and test best-vs-runner-up.",
+    )
     args = parser.parse_args()
 
     if not args.results_dir.exists():
@@ -841,36 +1140,64 @@ def main() -> None:
         if not datasets:
             datasets = found
 
+    real_strategies = {r.get("fill_strategy", "none") for r in all_runs} - {"none"}
+    strategies = [s for s in FILL_STRATEGY_ORDER if s in real_strategies]
+    strategies += sorted(real_strategies - set(FILL_STRATEGY_ORDER))
+    if not strategies:
+        strategies = ["none"]  # baseline-only file: a single unlabelled pass
+
     print(f"\nGrand Benchmark Summary  |  regime={args.regime}")
     print(f"Results dir: {args.results_dir}")
     print(f"Datasets: {', '.join(datasets)}")
+    print(f"Fill strategies: {', '.join(strategies)}")
     print(f"Total valid runs: {len(all_runs)}")
 
-    # 1. Per-dataset tables
-    for ds in datasets:
-        _analyze_dataset(
-            ds, all_runs,
+    for strategy in strategies:
+        # View = this strategy's fill-using results + the shared "none" baselines.
+        view = [
+            r for r in all_runs
+            if r.get("fill_strategy", "none") in (strategy, "none")
+        ]
+
+        print("\n" + "#" * 80)
+        print(f"#  FILL STRATEGY: {strategy}   ({len(view)} runs in view)")
+        print("#" * 80)
+
+        # 1. Per-dataset tables
+        for ds in datasets:
+            _analyze_dataset(
+                ds, view,
+                no_bootstrap=args.no_bootstrap,
+                n_boot=args.bootstrap_n,
+                markdown=args.markdown,
+                strategy=strategy,
+            )
+
+        # 2. Cross-dataset summary table
+        _cross_dataset_table(view, datasets, markdown=args.markdown, strategy=strategy)
+
+        # 3. XAI correlation section
+        _xai_correlation_section(view, datasets, markdown=args.markdown, strategy=strategy)
+
+        # 4. Key comparison: bnnr_xai vs bnnr_random
+        _key_comparison_section(
+            view, datasets,
             no_bootstrap=args.no_bootstrap,
             n_boot=args.bootstrap_n,
             markdown=args.markdown,
+            strategy=strategy,
         )
 
-    # 2. Cross-dataset summary table
-    _cross_dataset_table(all_runs, datasets, markdown=args.markdown)
+        # 5. Compute transparency
+        _compute_transparency_section(view, datasets, strategy=strategy)
 
-    # 3. XAI correlation section
-    _xai_correlation_section(all_runs, datasets, markdown=args.markdown)
-
-    # 4. Key comparison: bnnr_xai vs bnnr_random
-    _key_comparison_section(
-        all_runs, datasets,
+    _which_fill_is_best_section(
+        all_runs, datasets, strategies,
         no_bootstrap=args.no_bootstrap,
         n_boot=args.bootstrap_n,
         markdown=args.markdown,
+        reference=args.reference_fill,
     )
-
-    # 5. Compute transparency
-    _compute_transparency_section(all_runs, datasets)
 
     # Footer
     print(


### PR DESCRIPTION
## Summary

Adds a `--fill-strategy` / `--fill-strategies` flag to `run_grand_benchmark.py` so ICD/AICD
masked regions can be filled with any of the five strategies (gaussian_blur, local_mean,
global_mean, noise, solid) - singly, or as a comma-separated sweep like `--seeds`. The value is
threaded into every ICD/AICD construction, stamped onto every result row, and used to partition
run artifacts per fill. `summarize_grand.py` gains a "which fill is best" section that ranks fills
head-to-head per fill-using method (Wilcoxon + bootstrap CI + Holm), a `--reference-fill` mode
("does any fill beat the default?"), and a power-check that flags when too few seeds make a
"meaningful" verdict impossible. `benchmarks/README.md` documents the new flag.

Scope of the task was expanded after a talk with the mainteiner: accept multiple strategies at once,
wire all five fill-using conditions (icd_only, aicd_only, icd_aicd_fixed, bnnr_random, bnnr_xai),
fold the summarizer analysis into this task, and run fill-independent conditions once (tagged
`none`, reused across strategy views) instead of recomputing them per fill.

Smoke evidence (CPU, 2 seeds, 5 fills): 52 runs, 0 without a stamped `fill_strategy`; `no_aug`
ran once as `none` while the five fill-using conditions ran once per fill; accuracy varies by fill
(e.g. icd_only: local_mean 11.23% vs solid 9.49%), confirming the value reaches the ICD
constructor rather than only the config.

## Related issue

Closes #334

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed (`README.md`)
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed (n/a — no dashboard changes)