### PR TITLE
Add test for apply_tensor CPU-fallback roundtrip

### DIFF
--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -172,3 +172,14 @@ def test_torchvision_augmentation() -> None:
     assert out.shape == image.shape
     assert out.dtype == np.uint8
     assert aug.name == "pil_blur"
+
+def test_apply_tensor_cpu_fallback_roundtrip_preserves_image() -> None:
+    """apply_tensor's CPU-fallback path must round-trip
+    a tensor through numpy/uint8 and back without corrupting pixel values."""
+    aug = _DummyAug(probability=1.0, random_state=1)
+    images = torch.full((2, 3, 4, 4), 0.5)
+
+    out = aug.apply_tensor(images)
+
+    assert out.shape == images.shape
+    assert torch.allclose(out, images, atol=1 / 255)


### PR DESCRIPTION
## Summary

Added a test covering the CPU-fallback path of `BaseAugmentation.apply_tensor`
(the non `device_compatible` branch) - previously only the
`device_compatible=True` path was tested.

The test round-trips a known tensor through the numpy/uint8 conversion and
back using a no-op augmentation, asserting the image is
preserved.

## Related issue

Closes #326

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [ ] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed