### PR TITLE
docs: clarify demo shutdown and report dir, linkify next pages

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -104,6 +104,8 @@ python -m bnnr demo
 
 This downloads CIFAR-10 if needed, trains a small demo CNN with the **`demo`** augmentation preset (ICD + ChurchNoise), opens the live dashboard, and prints paths to your report and XAI heatmaps when finished.
 
+The demo keeps the dashboard running after training finishes. Press `Ctrl+C` to exit once you've seen the report paths.
+
 ## 5) Python quickstart (`quick_run`)
 
 If you already have a PyTorch model and dataloaders:
@@ -226,6 +228,8 @@ python -m bnnr dashboard serve --run-dir reports_quickstart --port 8080 --token 
 
 ## 10) Read the generated report
 
+Steps 10-12 assume you trained with the sample config from step 6, which writes to `reports_quickstart/`. If you used a default command instead (`python -m bnnr demo`, or `train` without `--config`), your runs are under `reports/`, so substitute that directory below.
+
 ```bash
 RUN_DIR=$(ls -1dt reports_quickstart/run_* | head -n 1)
 python -m bnnr report "$RUN_DIR/report.json" --format summary
@@ -289,12 +293,12 @@ See [troubleshooting.md](troubleshooting.md) section 13 for details on checkpoin
 
 ## 15) Next pages
 
-- `analyze.md` — full `bnnr analyze` guide (Python API, custom datasets, torchvision models, multi-label)
-- `dashboard.md`
-- `detection.md`
-- `examples.md`
-- `notebooks.md`
-- `configuration.md`
-- `cli.md`
-- `api_reference.md`
-- `troubleshooting.md`
+- [analyze.md](analyze.md) — full `bnnr analyze` guide (Python API, custom datasets, torchvision models, multi-label)
+- [dashboard.md](dashboard.md)
+- [detection.md](detection.md)
+- [examples.md](examples.md)
+- [notebooks.md](notebooks.md)
+- [configuration.md](configuration.md)
+- [cli.md](cli.md)
+- [api_reference.md](api_reference.md)
+- [troubleshooting.md](troubleshooting.md)


### PR DESCRIPTION
## Summary

Verifies `docs/getting_started.md` (the "pip install to report.html in under
5 minutes" path) by following it end to end on a fresh from-PyPI venv
(`bnnr[dashboard]` 0.6.5).

**Verified**
- All internal and external links resolve; no dead links.
- Every runnable step (§1-§14) executes.
- Happy path: `python -m bnnr demo` finishes well under the 5-minute target once
  CIFAR-10 is already downloaded.

**Changes**
- §4: note that `python -m bnnr demo` keeps the dashboard alive after training
  and needs `Ctrl+C`.
- §10: clarify that steps 10-12 read `reports_quickstart/` only when trained
  with the step 6 config; default runs are under `reports/`.
- §15: make the "Next pages" list clickable links.

**Noticed**
- CIFAR download: ~90 kB/s (~28 min) single-connection vs ~700 KiB/s (~4 min)
  with a 16-connection `aria2c`; the mirror throttles per-connection. A parallel
  download or faster mirror would remove the biggest first-run stall.
- §14 checkpoint name `iter_1_augname.pt` is a placeholder; real files are
  `iter_<N>_progress_<augname>.pt`.
- The rendered docs website is out of date and needs updating to match this file.

## Related issue

Closes #331

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed (`README.md`, `docs/`)
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed (`cd dashboard_web && npm ci && npm run build`)
