### PR TITLE
chore: gitignore benchmark run directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ docs/ecosystem-outreach.md
 # YOLO XAI manual script outputs (regenerate with tests/integration/smoke_yolo_xai_overlay.py)
 tests/integration/xai_yolov8n_activation_overlay.png
 tests/integration/_smoke_input_cat.jpg
+
+# Benchmark run artifacts (per-run logs, XAI overlays)
+benchmarks/runs_grand/
+benchmarks/runs_imagewoof/


### PR DESCRIPTION
benchmarks/README.md documents runs_grand/ and runs_imagewoof/ as gitignored, but .gitignore does not list them. A local grand-benchmark run leaves 3.3 GB of logs and XAI overlays untracked and exposed to an accidental 'git add -A'.

## Summary

<!-- What does this PR change and why? -->

## Related issue

<!-- Link: Fixes #123 -->

## Checklist

- [ ] `pytest` passes locally
- [ ] `ruff check src tests` passes
- [ ] Docs updated if CLI or user-facing behavior changed (`README.md`, `docs/`)
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed (`cd dashboard_web && npm ci && npm run build`)

See [CONTRIBUTING.md](../CONTRIBUTING.md) for full setup and style guidelines.
