### PR TITLE
docs: point Colab badges at bnnr-team/bnnr

### DIFF
--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -97,7 +97,7 @@ python3 scripts/validate_user_notebooks.py
 
 ## Quality notes from notebook audit
 During B11 notebook hardening, the following were normalized:
-- valid Colab links to `mateuszwalo/BNNR`,
+- valid Colab links to `bnnr-team/bnnr`,
 - modern CLI examples (`python3 -m bnnr ...`, no legacy `bnnr.cli`),
 - kernelspec metadata set to `python3`,
 - dashboard cells aligned for local + Colab + optional mobile flow,

--- a/examples/bnnr_augmentations_guide.ipynb
+++ b/examples/bnnr_augmentations_guide.ipynb
@@ -19,7 +19,7 @@
         "\n",
         "⏱ **Runtime:** ~5 min (visualization only, no training).\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mateuszwalo/BNNR/blob/main/examples/bnnr_augmentations_guide.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/bnnr_augmentations_guide.ipynb)"
       ]
     },
     {

--- a/examples/bnnr_custom_data.ipynb
+++ b/examples/bnnr_custom_data.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "⏱ **Runtime:** Depends on your data size. The examples below use small synthetic data for demonstration.\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mateuszwalo/BNNR/blob/main/examples/bnnr_custom_data.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/bnnr_custom_data.ipynb)"
       ]
     },
     {

--- a/examples/classification/bnnr_classification_demo.ipynb
+++ b/examples/classification/bnnr_classification_demo.ipynb
@@ -19,7 +19,7 @@
         "\n",
         "⏱ **Runtime:** ~15 min on Colab GPU (T4), ~40 min on CPU.\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mateuszwalo/BNNR/blob/main/examples/classification/bnnr_classification_demo.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/classification/bnnr_classification_demo.ipynb)"
       ]
     },
     {

--- a/examples/multilabel/bnnr_multilabel_demo.ipynb
+++ b/examples/multilabel/bnnr_multilabel_demo.ipynb
@@ -30,7 +30,7 @@
         "\n",
         "⏱ **Runtime:** ~3 min on CPU, ~1 min on GPU.\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mateuszwalo/BNNR/blob/main/examples/multilabel/bnnr_multilabel_demo.ipynb)\n"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/bnnr-team/bnnr/blob/main/examples/multilabel/bnnr_multilabel_demo.ipynb)\n"
       ]
     },
     {


### PR DESCRIPTION
Four notebook badges still linked to `mateuszwalo/BNNR`, which returns 404 since the project moved to the organisation. GitHub serves no redirect for the old name, so "Open In Colab" failed with "Notebook not found" while the same file opened normally on GitHub.

## Summary

Replaces `mateuszwalo/BNNR` with `bnnr-team/bnnr` in:

- `examples/bnnr_augmentations_guide.ipynb`
- `examples/bnnr_custom_data.ipynb`
- `examples/classification/bnnr_classification_demo.ipynb`
- `examples/multilabel/bnnr_multilabel_demo.ipynb`
- `docs/notebooks.md` (stale repo name in the audit notes)

The other five badges (detection, cooking, gradcam, analyze_colab_quickstart, colab_imagewoof) already pointed at the organisation and are untouched. No notebook content changes, only the badge URL.

## Verification

- All nine Colab badge targets in the repo resolve to files present on `main`, checked against the contents API.
- `python3 scripts/validate_user_notebooks.py` passes, 7 notebooks validated.
- All notebooks still parse as nbformat v4 JSON.

## Follow-up worth considering

`scripts/validate_user_notebooks.py` checks existence, nbformat, kernelspec and cell compilation, but not badge URLs. A check that every Colab badge points at this repo and at a path that exists would have caught this. Happy to open a separate issue if wanted, keeping it out of this PR.

## Related issue

None, reported directly.

## Checklist

- [X] `pytest` passes locally
- [X] `ruff check src tests` passes
- [X] Docs updated if CLI or user-facing behavior changed (`README.md`, `docs/`)
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed (no `dashboard_web/` changes)