### PR TITLE
fix(augmentations): stop silently destroying normalised batches

### DIFF
--- a/benchmarks/spurious_repair.py
+++ b/benchmarks/spurious_repair.py
@@ -551,10 +551,9 @@ def _apply_batch_aug(aug: Any, x: Any, y: Any, idx: Any) -> Any:
     re-implementation. Consumes ``src/bnnr`` but modifies no public API.
 
     Contract: the runner round-trips tensor -> uint8 HWC -> tensor and returns a
-    tensor in the same [0, 1] range it was given (``_uint8_to_tensor`` divides by
-    255 when ``ref_batch.max() <= 1.05``). Feeding it a *normalized* batch would
-    trip ``_tensor_to_uint8``'s negative-clip and silently zero the image; hence
-    this is called BEFORE ``normalize_batch`` in the training loop.
+    tensor in the same [0, 1] range it was given. Feeding it a *normalized* batch
+    raises ``NormalisedInputError`` instead of augmenting it; hence this is called
+    BEFORE ``normalize_batch`` in the training loop.
     """
     from bnnr.augmentation_runner import AugmentationRunner
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,23 @@ The XAI cache is precomputed **after** the baseline phase, so masks from `ICD`/`
 - `denormalization_mean` (default: `null`)
 - `denormalization_std` (default: `null`)
 
+BNNR augmentations operate on unnormalised images, so a batch that has already
+been through `transforms.Normalize()` has to be converted back before it can be
+augmented. Set both fields to the statistics your DataLoader used and BNNR
+undoes the normalisation before each augmentation and reapplies it afterwards.
+The values are also used for report previews and XAI overlays.
+
+If a batch arrives outside both `[0, 1]` and `[0, 255]` and these fields are not
+set, BNNR raises `NormalisedInputError` rather than clipping the batch into
+`[0, 1]`, which would destroy the image without any visible error. The two ways
+out are to remove `Normalize()` from the DataLoader transforms and rely on
+BatchNorm in the model, which is what the built-in pipelines do, or to set these
+two fields.
+
+Batches that are already in `[0, 1]` or `[0, 255]` are never denormalised, so
+setting these fields for reporting alone does not change how such a batch is
+augmented.
+
 ## Task-specific fields
 
 ### `task: classification` (default)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -298,3 +298,24 @@ Fix:
 New-Item -ItemType Directory -Force -Path data
 curl.exe -k -L -o data\cifar-10-python.tar.gz https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
 ```
+## 21) `NormalisedInputError: BNNR received a batch with values in [...]`
+
+Symptom:
+
+- Training stops immediately with `NormalisedInputError` naming a value range such as `[-2.118, 2.640]`.
+
+Cause:
+
+- The DataLoader applies `transforms.Normalize(mean, std)` before BNNR sees the batch. BNNR augmentations operate on unnormalised images, so a normalised batch has to be converted back first. Earlier versions clipped such a batch into `[0, 1]`, which silently destroyed the image and produced a plausible but meaningless run.
+
+Fix, pick one:
+
+- Remove `Normalize()` from the DataLoader transforms and rely on BatchNorm in the model. This is what every built-in BNNR pipeline does.
+- Or tell BNNR what the statistics were, so it can undo and redo the normalisation around each augmentation:
+
+```yaml
+denormalization_mean: [0.485, 0.456, 0.406]
+denormalization_std: [0.229, 0.224, 0.225]
+```
+
+The same error appears for any batch that is neither `[0, 1]` nor `[0, 255]`, including a `[0, 255]` batch whose brightest pixel is below 32, which cannot be told apart from a normalised one by range alone.

--- a/src/bnnr/augmentation_runner.py
+++ b/src/bnnr/augmentation_runner.py
@@ -13,11 +13,14 @@ from collections.abc import Iterable, Iterator
 from queue import Empty, Queue
 from typing import Any
 
-import numpy as np
-import torch
 from torch import Tensor
 
 from bnnr.augmentations import BaseAugmentation
+from bnnr.image_scale import BatchScale, detect_batch_scale, from_unit, to_unit
+from bnnr.training.image_utils import tensor_to_uint8, uint8_to_tensor
+
+# The convention every tensor-path augmentation implementation expects.
+_UNIT_SCALE = BatchScale("unit")
 
 logger = logging.getLogger("bnnr.augmentation_runner")
 
@@ -45,6 +48,11 @@ class AugmentationRunner:
         If True, CPU-bound augmentations are applied in a background thread.
     prefetch_queue_size : int
         Max number of prefetched batches to keep in memory.
+    denorm_mean, denorm_std : list[float] | None
+        Per-channel normalisation statistics of the incoming batches. Supply
+        them when the DataLoader applies ``transforms.Normalize()``: the runner
+        undoes the normalisation before augmenting and redoes it afterwards.
+        Without them a normalised batch raises instead of being corrupted.
     """
 
     def __init__(
@@ -52,10 +60,14 @@ class AugmentationRunner:
         augmentations: list[BaseAugmentation],
         async_prefetch: bool = True,
         prefetch_queue_size: int = 2,
+        denorm_mean: list[float] | None = None,
+        denorm_std: list[float] | None = None,
     ) -> None:
         self.augmentations = augmentations
         self.async_prefetch = async_prefetch
         self.prefetch_queue_size = prefetch_queue_size
+        self.denorm_mean = denorm_mean
+        self.denorm_std = denorm_std
 
         # Split augmentations into GPU-native and CPU-bound
         self.gpu_augmentations = [a for a in augmentations if a.device_compatible]
@@ -106,9 +118,11 @@ class AugmentationRunner:
         2. ``apply_tensor`` (GPU-native tensor path)
         3. ``apply_batch`` (numpy uint8 fallback)
         """
+        scale: BatchScale | None = None
         for aug in augmentations:
             if hasattr(aug, "apply_batch_with_labels"):
-                np_images = _tensor_to_uint8(images)
+                scale = scale or self._batch_scale(images)
+                np_images = tensor_to_uint8(images, scale=scale)
                 np_labels = labels.detach().cpu().numpy()
                 np_indices = (
                     sample_indices.detach().cpu().numpy()
@@ -118,15 +132,30 @@ class AugmentationRunner:
                 aug_images = aug.apply_batch_with_labels(
                     np_images, np_labels, sample_indices=np_indices
                 )
-                images = _uint8_to_tensor(aug_images, ref_batch=images)
+                images = uint8_to_tensor(aug_images, ref_batch=images, scale=scale)
             else:
+                # Every tensor-path implementation, including third-party ones,
+                # assumes [0, 1]. Hand it that and convert back, so a normalised
+                # or [0, 255] batch is not truncated inside the augmentation.
+                scale = scale or self._batch_scale(images)
+                unit = to_unit(images, scale)
                 try:
-                    images = aug.apply_tensor(images)
+                    # No scale argument: the batch is already in the convention
+                    # apply_tensor would detect, and third-party overrides that
+                    # predate the keyword keep working unchanged.
+                    unit = aug.apply_tensor(unit)
                 except NotImplementedError:
-                    np_images = _tensor_to_uint8(images)
+                    np_images = tensor_to_uint8(unit, scale=_UNIT_SCALE)
                     aug_images = aug.apply_batch(np_images)
-                    images = _uint8_to_tensor(aug_images, ref_batch=images)
+                    unit = uint8_to_tensor(aug_images, ref_batch=unit, scale=_UNIT_SCALE)
+                images = from_unit(unit, scale)
         return images
+
+    def _batch_scale(self, images: Tensor) -> BatchScale:
+        """Detect the batch convention once, before any augmentation changes it."""
+        return detect_batch_scale(
+            images, denorm_mean=self.denorm_mean, denorm_std=self.denorm_std
+        )
 
     def _apply_gpu_augmentations(
         self,
@@ -257,26 +286,12 @@ def _unpack_batch(
     raise ValueError(f"Unexpected batch format: {type(raw_batch)}")
 
 
-def _tensor_to_uint8(images: Tensor) -> np.ndarray:
-    """Convert a (B, C, H, W) float tensor to a (B, H, W, C) uint8 array."""
-    np_images = images.detach().cpu().permute(0, 2, 3, 1).numpy()
-    lo, hi = float(np_images.min()), float(np_images.max())
-
-    if lo < -0.01 or (hi > 1.05 and hi < 200):
-        np_images = np.clip(np_images, 0.0, 1.0)
-
-    if hi <= 1.05:
-        return (np_images * 255.0).astype("uint8")  # type: ignore[no-any-return]
-    return np_images.astype("uint8")  # type: ignore[no-any-return]
-
-
-def _uint8_to_tensor(np_images: np.ndarray, *, ref_batch: Tensor) -> Tensor:
-    """Convert (B, H, W, C) uint8 back to (B, C, H, W) float tensor."""
-    t = torch.as_tensor(np_images, dtype=ref_batch.dtype, device=ref_batch.device)
-    t = t.permute(0, 3, 1, 2)
-    if ref_batch.max() <= 1.05:
-        t = t / 255.0
-    return t
+# Kept as module-private aliases of the shared implementation in
+# bnnr.training.image_utils. The runner used to carry its own copy, which was
+# the copy without the out-of-range check, so a normalised batch was destroyed
+# here with no warning at all.
+_tensor_to_uint8 = tensor_to_uint8
+_uint8_to_tensor = uint8_to_tensor
 
 
 __all__ = ["AugmentationRunner"]

--- a/src/bnnr/augmentation_runner.py
+++ b/src/bnnr/augmentation_runner.py
@@ -286,12 +286,4 @@ def _unpack_batch(
     raise ValueError(f"Unexpected batch format: {type(raw_batch)}")
 
 
-# Kept as module-private aliases of the shared implementation in
-# bnnr.training.image_utils. The runner used to carry its own copy, which was
-# the copy without the out-of-range check, so a normalised batch was destroyed
-# here with no warning at all.
-_tensor_to_uint8 = tensor_to_uint8
-_uint8_to_tensor = uint8_to_tensor
-
-
 __all__ = ["AugmentationRunner"]

--- a/src/bnnr/augmentations.py
+++ b/src/bnnr/augmentations.py
@@ -13,6 +13,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
+from bnnr.image_scale import BatchScale, detect_batch_scale, from_unit, to_unit
 from bnnr.utils import lazy_cv2 as cv2
 
 AugT = TypeVar("AugT", bound="BaseAugmentation")
@@ -94,21 +95,33 @@ class BaseAugmentation(abc.ABC):
     def apply_tensor_native(self, images: Tensor) -> Tensor:
         raise NotImplementedError("Tensor-native augmentation is not implemented")
 
-    def apply_tensor(self, images: Tensor) -> Tensor:
+    def apply_tensor(self, images: Tensor, *, scale: BatchScale | None = None) -> Tensor:
+        """Apply this augmentation to a BCHW float batch, whatever its convention.
+
+        Implementations only ever see [0, 1] tensors (``apply_tensor_native``)
+        or unnormalised uint8 arrays (``apply_batch``). This method adapts the
+        incoming batch to that and converts the result back, so a normalised or
+        [0, 255] batch is no longer silently truncated on the way in.
+
+        Pass *scale* when the caller already detected the convention, which is
+        also the only way to augment a normalised batch: detecting it here has
+        no access to the denormalisation statistics and raises instead.
+        """
+        if scale is None:
+            scale = detect_batch_scale(images)
+
+        unit = to_unit(images, scale)
+
         if self.device_compatible:
-            return self.apply_tensor_native(images)
+            return from_unit(self.apply_tensor_native(unit), scale)
 
         # Default fallback path for augmentations that do not implement GPU-native variant.
-        np_images = images.detach().cpu().permute(0, 2, 3, 1).numpy()
-        if np_images.max() <= 1.0:
-            np_images = (np_images * 255.0).astype(np.uint8)
-        else:
-            np_images = np_images.astype(np.uint8)
+        np_images = np.clip(
+            unit.detach().cpu().permute(0, 2, 3, 1).numpy() * 255.0, 0.0, 255.0
+        ).astype(np.uint8)
         aug = self.apply_batch(np_images)
         tensor = torch.as_tensor(aug, device=images.device, dtype=images.dtype).permute(0, 3, 1, 2)
-        if images.max() <= 1.0:
-            tensor = tensor / 255.0
-        return tensor
+        return from_unit(tensor / 255.0, scale)
 
     def __repr__(self) -> str:
         parts = f"name={self.name}, probability={self.probability}"

--- a/src/bnnr/image_scale.py
+++ b/src/bnnr/image_scale.py
@@ -1,0 +1,152 @@
+"""Batch value-range conventions shared by every image conversion in BNNR.
+
+Batches reach BNNR in one of three conventions, and the augmentations only
+understand the first two:
+
+``unit``
+    float in [0, 1]
+``byte``
+    float carrying [0, 255] values
+``normalised``
+    float after ``transforms.Normalize()``, which BNNR must undo before
+    augmenting and redo afterwards
+
+This module is deliberately free of BNNR imports so that both
+``bnnr.augmentations`` and ``bnnr.training.image_utils`` can depend on it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import torch
+from torch import Tensor
+
+# Tolerances are expressed as a fraction of the convention's own scale, so the
+# same 1 % undershoot allowance covers interpolation ringing in both.
+_UNIT_MAX = 1.05
+_BYTE_MAX = 260.0
+_UNDERSHOOT = 0.01
+
+# A "byte" batch whose brightest pixel sits below this is indistinguishable
+# from a normalised batch by range alone: 32/255 is a 12 %-grey image, while a
+# normalised batch reaching 32 would need a std near 0.03, which no standard
+# normalisation uses. Inside that band we refuse rather than guess, because
+# guessing wrong destroys the image silently.
+_BYTE_MIN_PEAK = 32.0
+
+
+class NormalisedInputError(ValueError):
+    """Raised when a batch cannot be converted to uint8 without destroying it."""
+
+
+@dataclass(frozen=True)
+class BatchScale:
+    """The convention a batch of images is expressed in.
+
+    ``mean`` and ``std`` are populated only for ``kind="normalised"`` and are
+    the values needed to undo the normalisation.
+    """
+
+    kind: Literal["unit", "byte", "normalised"]
+    mean: tuple[float, ...] | None = None
+    std: tuple[float, ...] | None = None
+
+
+def detect_batch_scale(
+    images: Tensor | np.ndarray,
+    *,
+    denorm_mean: list[float] | tuple[float, ...] | None = None,
+    denorm_std: list[float] | tuple[float, ...] | None = None,
+) -> BatchScale:
+    """Classify *images* into one of the three conventions.
+
+    An in-range batch is classified from its range alone, so configuring
+    ``denormalization_mean`` / ``denormalization_std`` for reporting never
+    changes how a plain [0, 1] or [0, 255] batch is treated. The stats are
+    consulted only once the range rules out both, which is exactly the case
+    that used to be silently clipped.
+
+    Raises
+    ------
+    NormalisedInputError
+        When the range fits neither convention and no denormalisation stats
+        were configured.
+    """
+    lo = float(images.min())
+    hi = float(images.max())
+
+    if lo >= -_UNDERSHOOT and hi <= _UNIT_MAX:
+        return BatchScale("unit")
+    if lo >= -_UNDERSHOOT * 255.0 and _BYTE_MIN_PEAK <= hi <= _BYTE_MAX:
+        return BatchScale("byte")
+
+    if denorm_mean is not None and denorm_std is not None:
+        return BatchScale(
+            "normalised",
+            tuple(float(m) for m in denorm_mean),
+            tuple(float(s) for s in denorm_std),
+        )
+
+    raise NormalisedInputError(
+        f"BNNR received a batch with values in [{lo:.3f}, {hi:.3f}], which is "
+        "neither [0, 1] nor [0, 255]. This usually means transforms.Normalize() "
+        "was applied before BNNR augmentations, which operate on unnormalised "
+        "uint8 images. Either remove Normalize() from your DataLoader "
+        "transforms and rely on BatchNorm in the model, or set "
+        "denormalization_mean and denormalization_std in the BNNR config so "
+        "BNNR can undo and redo the normalisation around each augmentation."
+    )
+
+
+def denorm_arrays(scale: BatchScale, channels: int) -> tuple[np.ndarray, np.ndarray]:
+    """Validate and materialise the per-channel mean/std of a normalised scale."""
+    mean = np.asarray(scale.mean, dtype=np.float32)
+    std = np.asarray(scale.std, dtype=np.float32)
+    if mean.shape != (channels,) or std.shape != (channels,):
+        raise NormalisedInputError(
+            f"denormalization_mean/std have {mean.size}/{std.size} entries but the "
+            f"batch has {channels} channels."
+        )
+    if not np.all(std > 0):
+        raise NormalisedInputError("denormalization_std entries must all be positive.")
+    return mean, std
+
+
+def _channel_stats(scale: BatchScale, images: Tensor) -> tuple[Tensor, Tensor]:
+    mean_np, std_np = denorm_arrays(scale, int(images.shape[1]))
+    mean = torch.as_tensor(mean_np, dtype=images.dtype, device=images.device).view(1, -1, 1, 1)
+    std = torch.as_tensor(std_np, dtype=images.dtype, device=images.device).view(1, -1, 1, 1)
+    return mean, std
+
+
+def to_unit(images: Tensor, scale: BatchScale) -> Tensor:
+    """Convert a BCHW batch from *scale* into the [0, 1] convention."""
+    if scale.kind == "unit":
+        return images
+    if scale.kind == "byte":
+        return images / 255.0
+    mean, std = _channel_stats(scale, images)
+    return (images * std + mean).clamp(0.0, 1.0)
+
+
+def from_unit(images: Tensor, scale: BatchScale) -> Tensor:
+    """Convert a BCHW batch in [0, 1] back into *scale*."""
+    if scale.kind == "unit":
+        return images
+    if scale.kind == "byte":
+        return images * 255.0
+    mean, std = _channel_stats(scale, images)
+    return (images - mean) / std
+
+
+__all__ = [
+    "BatchScale",
+    "NormalisedInputError",
+    "denorm_arrays",
+    "detect_batch_scale",
+    "from_unit",
+    "to_unit",
+]

--- a/src/bnnr/kornia_aug.py
+++ b/src/bnnr/kornia_aug.py
@@ -98,9 +98,10 @@ class KorniaAugmentation(BaseAugmentation):
             augmented = images * (1.0 - self.intensity) + augmented * self.intensity
         return augmented
 
-    def apply_tensor(self, images: Tensor) -> Tensor:
-        """Override to use GPU-native path directly."""
-        return self.apply_tensor_native(images)
+    # No apply_tensor override: BaseAugmentation already routes a
+    # device_compatible augmentation straight to apply_tensor_native, and doing
+    # it here as well would bypass the batch-convention handling, so a
+    # normalised batch would reach the Kornia transform unconverted.
 
 
 def create_kornia_pipeline(

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -182,12 +182,30 @@ class BNNRTrainer:
     _clone_state_dict = staticmethod(clone_state_dict)
     _copy_state_dict_inplace = staticmethod(copy_state_dict_inplace)
 
-    def _tensor_to_uint8(self, images: Tensor) -> np.ndarray:
-        return _img.tensor_to_uint8(images, warn_context=self)
+    def _batch_scale(self, images: Tensor) -> _img.BatchScale:
+        """Detect the batch convention using the configured denormalisation stats."""
+        return _img.detect_batch_scale(
+            images,
+            denorm_mean=self.config.denormalization_mean,
+            denorm_std=self.config.denormalization_std,
+        )
+
+    def _tensor_to_uint8(self, images: Tensor, *, scale: _img.BatchScale | None = None) -> np.ndarray:
+        return _img.tensor_to_uint8(
+            images,
+            scale=scale,
+            denorm_mean=self.config.denormalization_mean,
+            denorm_std=self.config.denormalization_std,
+        )
 
     @staticmethod
-    def _uint8_to_tensor(np_images: np.ndarray, *, ref_batch: Tensor) -> Tensor:
-        return _img.uint8_to_tensor(np_images, ref_batch=ref_batch)
+    def _uint8_to_tensor(
+        np_images: np.ndarray,
+        *,
+        ref_batch: Tensor,
+        scale: _img.BatchScale | None = None,
+    ) -> Tensor:
+        return _img.uint8_to_tensor(np_images, ref_batch=ref_batch, scale=scale)
 
     @staticmethod
     def _det_uint8_batch_to_float01(np_images: np.ndarray, *, ref_batch: Tensor) -> Tensor:

--- a/src/bnnr/training/__init__.py
+++ b/src/bnnr/training/__init__.py
@@ -19,7 +19,10 @@ from bnnr.training.checkpoint import (
 )
 from bnnr.training.dataset_profile import compute_dataset_profile, count_labels
 from bnnr.training.image_utils import (
+    BatchScale,
+    NormalisedInputError,
     det_uint8_batch_to_float01,
+    detect_batch_scale,
     resize_saliency_batch,
     tensor_batch_to_preview_uint8,
     tensor_to_uint8,
@@ -36,6 +39,8 @@ from bnnr.training.xai_runner import (
 )
 
 __all__ = [
+    "BatchScale",
+    "NormalisedInputError",
     "adapt_icd_thresholds",
     "average_metrics",
     "build_xai_insights",
@@ -45,6 +50,7 @@ __all__ = [
     "copy_state_dict_inplace",
     "count_labels",
     "det_uint8_batch_to_float01",
+    "detect_batch_scale",
     "evaluate",
     "generate_augmentation_previews",
     "generate_xai",

--- a/src/bnnr/training/augmentation_batch.py
+++ b/src/bnnr/training/augmentation_batch.py
@@ -80,18 +80,22 @@ def apply_augmentation_to_batch(
 
     images, labels = batch
     if hasattr(augmentation, "apply_batch_with_labels"):
-        np_images = trainer._tensor_to_uint8(images)
+        # Detect the convention before the augmentation touches the pixels, so
+        # the way back is the exact inverse of the way in.
+        scale = trainer._batch_scale(images)
+        np_images = trainer._tensor_to_uint8(images, scale=scale)
         np_labels = labels.detach().cpu().numpy()
         np_indices = sample_indices.detach().cpu().numpy() if sample_indices is not None else None
         aug_images = augmentation.apply_batch_with_labels(
             np_images, np_labels, sample_indices=np_indices,
         )
-        return trainer._uint8_to_tensor(aug_images, ref_batch=images), labels
+        return trainer._uint8_to_tensor(aug_images, ref_batch=images, scale=scale), labels
 
+    scale = trainer._batch_scale(images)
     try:
-        images = augmentation.apply_tensor(images)
+        images = augmentation.apply_tensor(images, scale=scale)
         return images, labels
     except (NotImplementedError, RuntimeError, TypeError):
-        np_images = trainer._tensor_to_uint8(images)
+        np_images = trainer._tensor_to_uint8(images, scale=scale)
         aug_images = augmentation.apply_batch(np_images)
-        return trainer._uint8_to_tensor(aug_images, ref_batch=images), labels
+        return trainer._uint8_to_tensor(aug_images, ref_batch=images, scale=scale), labels

--- a/src/bnnr/training/image_utils.py
+++ b/src/bnnr/training/image_utils.py
@@ -8,52 +8,92 @@ import numpy as np
 import torch
 from torch import Tensor
 
+from bnnr.image_scale import (
+    _UNIT_MAX,
+    BatchScale,
+    NormalisedInputError,
+    detect_batch_scale,
+)
+from bnnr.image_scale import (
+    denorm_arrays as _denorm_arrays,
+)
 from bnnr.utils import lazy_cv2 as cv2
+
+__all__ = [
+    "BatchScale",
+    "NormalisedInputError",
+    "det_uint8_batch_to_float01",
+    "detect_batch_scale",
+    "resize_saliency_batch",
+    "tensor_batch_to_preview_uint8",
+    "tensor_to_uint8",
+    "uint8_to_tensor",
+]
 
 
 def tensor_to_uint8(
     images: Tensor,
     *,
+    scale: BatchScale | None = None,
+    denorm_mean: list[float] | tuple[float, ...] | None = None,
+    denorm_std: list[float] | tuple[float, ...] | None = None,
     warn_context: Any | None = None,
 ) -> np.ndarray:
     """Convert a (B, C, H, W) float tensor to a (B, H, W, C) uint8 array.
 
-    *warn_context* is an object on which ``_norm_warning_emitted`` is
-    tracked to emit the normalisation warning at most once.
+    Pass *scale* when the caller also has to invert the conversion, so both
+    directions agree on the convention instead of re-deriving it from data
+    that the augmentation has since changed. When omitted it is detected via
+    :func:`detect_batch_scale`, which raises rather than clipping a batch it
+    cannot represent.
+
+    *warn_context* is accepted for backward compatibility and is unused: the
+    case it used to warn about now raises :class:`NormalisedInputError`.
     """
     np_images = images.detach().cpu().permute(0, 2, 3, 1).numpy()
-    lo, hi = float(np_images.min()), float(np_images.max())
+    if scale is None:
+        scale = detect_batch_scale(np_images, denorm_mean=denorm_mean, denorm_std=denorm_std)
 
-    if lo < -0.01 or (hi > 1.05 and hi < 200):
-        if warn_context is not None and not getattr(warn_context, "_norm_warning_emitted", False):
-            import warnings
+    if scale.kind == "unit":
+        return np.clip(np_images * 255.0, 0.0, 255.0).astype("uint8")  # type: ignore[no-any-return]
+    if scale.kind == "byte":
+        return np.clip(np_images, 0.0, 255.0).astype("uint8")  # type: ignore[no-any-return]
 
-            warnings.warn(
-                "BNNR detected input tensors with values outside [0, 1] "
-                f"(range [{lo:.2f}, {hi:.2f}]). This usually means "
-                "transforms.Normalize() was applied BEFORE BNNR augmentations. "
-                "BNNR augmentations convert images to uint8 internally — "
-                "pre-normalised data will be corrupted. Remove Normalize() "
-                "from your DataLoader transforms and rely on BatchNorm in "
-                "the model instead.",
-                RuntimeWarning,
-                stacklevel=4,
-            )
-            warn_context._norm_warning_emitted = True
-        np_images = np.clip(np_images, 0.0, 1.0)
-
-    if hi <= 1.05:
-        return (np_images * 255.0).astype("uint8")  # type: ignore[no-any-return]
-    return np_images.astype("uint8")  # type: ignore[no-any-return]
+    mean, std = _denorm_arrays(scale, np_images.shape[-1])
+    denormalised = np.clip(np_images * std + mean, 0.0, 1.0)
+    return (denormalised * 255.0).astype("uint8")  # type: ignore[no-any-return]
 
 
-def uint8_to_tensor(np_images: np.ndarray, *, ref_batch: Tensor) -> Tensor:
-    """Convert (B, H, W, C) uint8 back to (B, C, H, W) float tensor."""
+def uint8_to_tensor(
+    np_images: np.ndarray,
+    *,
+    ref_batch: Tensor,
+    scale: BatchScale | None = None,
+) -> Tensor:
+    """Convert (B, H, W, C) uint8 back to (B, C, H, W) float tensor.
+
+    With *scale* the conversion is the exact inverse of :func:`tensor_to_uint8`,
+    including re-applying the normalisation. Without it the legacy heuristic on
+    ``ref_batch`` is used, which cannot express the normalised convention.
+    """
     t = torch.as_tensor(np_images, dtype=ref_batch.dtype, device=ref_batch.device)
     t = t.permute(0, 3, 1, 2)
-    if ref_batch.max() <= 1.05:
-        t = t / 255.0
-    return t
+
+    if scale is None:
+        if ref_batch.max() <= _UNIT_MAX:
+            t = t / 255.0
+        return t
+
+    if scale.kind == "byte":
+        return t
+    t = t / 255.0
+    if scale.kind == "unit":
+        return t
+
+    mean_np, std_np = _denorm_arrays(scale, t.shape[1])
+    mean = torch.as_tensor(mean_np, dtype=t.dtype, device=t.device).view(1, -1, 1, 1)
+    std = torch.as_tensor(std_np, dtype=t.dtype, device=t.device).view(1, -1, 1, 1)
+    return (t - mean) / std
 
 
 def det_uint8_batch_to_float01(np_images: np.ndarray, *, ref_batch: Tensor) -> Tensor:

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -55,7 +55,12 @@ def train_epoch(
         return average_metrics(epoch_metrics)
 
     if augmentations:
-        runner = AugmentationRunner(augmentations, async_prefetch=False)
+        runner = AugmentationRunner(
+            augmentations,
+            async_prefetch=False,
+            denorm_mean=trainer.config.denormalization_mean,
+            denorm_std=trainer.config.denormalization_std,
+        )
         for raw_batch in loader:
             if len(raw_batch) == 3:
                 images, labels, sample_indices = raw_batch

--- a/tests/test_gpu_augmentations.py
+++ b/tests/test_gpu_augmentations.py
@@ -13,6 +13,7 @@ from bnnr.augmentations import (
     DifPresets,
     ProCAM,
 )
+from bnnr.training.image_utils import NormalisedInputError
 
 
 def _make_batch(b: int = 4, c: int = 3, h: int = 32, w: int = 32) -> torch.Tensor:
@@ -239,3 +240,41 @@ class TestApplyTensorFallback:
         result = aug.apply_tensor(images)
         assert result.shape == images.shape
         assert result.dtype == images.dtype
+
+
+class TestRunnerNormalisedBatches:
+    """The runner used to carry the copy of the converter without any check."""
+
+    MEAN = [0.485, 0.456, 0.406]
+    STD = [0.229, 0.224, 0.225]
+
+    def _normalise(self, images: torch.Tensor) -> torch.Tensor:
+        mean = torch.tensor(self.MEAN).view(1, 3, 1, 1)
+        std = torch.tensor(self.STD).view(1, 3, 1, 1)
+        return (images - mean) / std
+
+    def test_normalised_batch_raises_without_stats(self) -> None:
+        aug = BasicAugmentation(probability=1.0, random_state=0)
+        aug.device_compatible = False  # type: ignore[attr-defined]
+        runner = AugmentationRunner([aug], async_prefetch=False)
+        images = self._normalise(_make_batch())
+
+        with pytest.raises(NormalisedInputError):
+            runner.apply_batch(images, torch.zeros(4, dtype=torch.long))
+
+    def test_normalised_batch_survives_with_stats(self) -> None:
+        """With stats the batch stays in its own convention and keeps its spread."""
+        aug = BasicAugmentation(probability=1.0, random_state=0)
+        aug.device_compatible = False  # type: ignore[attr-defined]
+        runner = AugmentationRunner(
+            [aug], async_prefetch=False, denorm_mean=self.MEAN, denorm_std=self.STD
+        )
+        images = self._normalise(_make_batch())
+
+        out, _ = runner.apply_batch(images, torch.zeros(4, dtype=torch.long))
+
+        assert out.shape == images.shape
+        # Clipping to [0, 1] would have collapsed the normalised range.
+        assert float(out.min()) < -0.5
+        assert float(out.max()) > 0.5
+        assert torch.isfinite(out).all()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -14,7 +14,6 @@ Tests verify:
 from __future__ import annotations
 
 import copy
-import warnings
 
 import numpy as np
 import pytest
@@ -27,6 +26,7 @@ from bnnr.augmentation_runner import AugmentationRunner
 from bnnr.augmentations import AugmentationRegistry, BaseAugmentation, BasicAugmentation
 from bnnr.config import validate_config
 from bnnr.core import BNNRConfig, BNNRTrainer
+from bnnr.training.image_utils import NormalisedInputError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -270,14 +270,18 @@ class TestAugmentationRunnerRefactor:
 
 
 # ---------------------------------------------------------------------------
-# 5. _tensor_to_uint8 warning is per-instance
+# 5. _tensor_to_uint8 refuses normalized input instead of destroying it
 # ---------------------------------------------------------------------------
 
 
-class TestTensorToUint8Warning:
-    """Warning about normalized inputs should be per-instance, not class-level."""
+class TestTensorToUint8Normalized:
+    """Normalized input used to be clipped into [0, 1], which destroys the image.
 
-    def test_warning_emitted_per_instance(self, tmp_path) -> None:
+    It now raises unless the config carries the denormalization statistics, in
+    which case the normalization is undone and redone around the augmentation.
+    """
+
+    def _trainer(self, tmp_path, **cfg_overrides):
         loader = _fixed_loader(seed=0)
         adapter = _make_adapter(seed=42)
         cfg = BNNRConfig(
@@ -285,26 +289,35 @@ class TestTensorToUint8Warning:
             checkpoint_dir=tmp_path / "ckpt",
             report_dir=tmp_path / "report",
             save_checkpoints=False,
+            **cfg_overrides,
         )
+        return BNNRTrainer(adapter, loader, loader, [], cfg)
 
-        # Create two independent trainer instances
-        trainer1 = BNNRTrainer(adapter, loader, loader, [], cfg)
-        trainer2 = BNNRTrainer(adapter, loader, loader, [], cfg)
-
-        # Simulate normalized data (values outside [0,1])
+    def test_raises_on_every_instance(self, tmp_path) -> None:
+        trainer1 = self._trainer(tmp_path)
+        trainer2 = self._trainer(tmp_path)
         normalized = torch.randn(2, 3, 8, 8)  # mean ~0, std ~1 -> has negatives
 
-        with warnings.catch_warnings(record=True) as w1:
-            warnings.simplefilter("always")
-            trainer1._tensor_to_uint8(normalized)
+        for trainer in (trainer1, trainer2):
+            with pytest.raises(NormalisedInputError, match="Normalize"):
+                trainer._tensor_to_uint8(normalized)
 
-        with warnings.catch_warnings(record=True) as w2:
-            warnings.simplefilter("always")
-            trainer2._tensor_to_uint8(normalized)
+    def test_denormalization_stats_make_it_work(self, tmp_path) -> None:
+        trainer = self._trainer(
+            tmp_path,
+            denormalization_mean=[0.485, 0.456, 0.406],
+            denormalization_std=[0.229, 0.224, 0.225],
+        )
+        mean = torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1)
+        std = torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1)
+        original = torch.rand(2, 3, 8, 8)
+        normalized = (original - mean) / std
 
-        # Both instances should emit the warning (not just the first)
-        assert any("outside [0, 1]" in str(w.message) for w in w1), "First instance should warn"
-        assert any("outside [0, 1]" in str(w.message) for w in w2), "Second instance should also warn"
+        scale = trainer._batch_scale(normalized)
+        as_uint8 = trainer._tensor_to_uint8(normalized, scale=scale)
+        back = trainer._uint8_to_tensor(as_uint8, ref_batch=normalized, scale=scale)
+
+        assert torch.allclose(back * std + mean, original, atol=1.0 / 255.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_training_image_utils.py
+++ b/tests/test_training_image_utils.py
@@ -3,15 +3,34 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 import torch
 
 from bnnr.training.image_utils import (
+    BatchScale,
+    NormalisedInputError,
     det_uint8_batch_to_float01,
+    detect_batch_scale,
     resize_saliency_batch,
     tensor_batch_to_preview_uint8,
     tensor_to_uint8,
     uint8_to_tensor,
 )
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+
+def _normalise(images: torch.Tensor) -> torch.Tensor:
+    mean = torch.tensor(IMAGENET_MEAN).view(1, 3, 1, 1)
+    std = torch.tensor(IMAGENET_STD).view(1, 3, 1, 1)
+    return (images - mean) / std
+
+
+def _denormalise(images: torch.Tensor) -> torch.Tensor:
+    mean = torch.tensor(IMAGENET_MEAN).view(1, 3, 1, 1)
+    std = torch.tensor(IMAGENET_STD).view(1, 3, 1, 1)
+    return images * std + mean
 
 
 def test_tensor_to_uint8_from_01() -> None:
@@ -48,3 +67,94 @@ def test_tensor_batch_to_preview_uint8() -> None:
     out = tensor_batch_to_preview_uint8(images)
     assert out.dtype == np.uint8
     assert out.shape == (1, 16, 16, 3)
+
+
+# ---------------------------------------------------------------------------
+# Batch-convention detection (FIX-0-1)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_unit_batch() -> None:
+    assert detect_batch_scale(torch.rand(2, 3, 8, 8)).kind == "unit"
+
+
+def test_detect_byte_batch() -> None:
+    images = torch.rand(2, 3, 8, 8) * 255.0
+    assert detect_batch_scale(images).kind == "byte"
+
+
+def test_normalised_batch_raises_without_stats() -> None:
+    normalised = _normalise(torch.rand(2, 3, 8, 8))
+    with pytest.raises(NormalisedInputError) as excinfo:
+        detect_batch_scale(normalised)
+    message = str(excinfo.value)
+    # The error has to name both ways out, not just one.
+    assert "Normalize()" in message
+    assert "denormalization_mean" in message
+
+
+def test_normalised_batch_detected_with_stats() -> None:
+    normalised = _normalise(torch.rand(2, 3, 8, 8))
+    scale = detect_batch_scale(
+        normalised, denorm_mean=IMAGENET_MEAN, denorm_std=IMAGENET_STD
+    )
+    assert scale.kind == "normalised"
+    assert scale.mean == tuple(IMAGENET_MEAN)
+
+
+def test_configured_stats_do_not_hijack_a_unit_batch() -> None:
+    """Stats set for reporting must not change how an in-range batch is treated."""
+    scale = detect_batch_scale(
+        torch.rand(2, 3, 8, 8), denorm_mean=IMAGENET_MEAN, denorm_std=IMAGENET_STD
+    )
+    assert scale.kind == "unit"
+
+
+def test_normalised_roundtrip_is_lossless_to_one_step() -> None:
+    original = torch.rand(2, 3, 8, 8)
+    normalised = _normalise(original)
+    scale = detect_batch_scale(
+        normalised, denorm_mean=IMAGENET_MEAN, denorm_std=IMAGENET_STD
+    )
+
+    as_uint8 = tensor_to_uint8(normalised, scale=scale)
+    assert as_uint8.dtype == np.uint8
+    # A destroyed batch collapses onto 0/255; a denormalised one keeps its spread.
+    assert 10 < int(as_uint8.mean()) < 245
+
+    back = uint8_to_tensor(as_uint8, ref_batch=normalised, scale=scale)
+    assert back.shape == normalised.shape
+    assert torch.allclose(_denormalise(back), original, atol=1.0 / 255.0)
+
+
+def test_dark_byte_batch_is_not_destroyed() -> None:
+    """A [0, 255] batch whose peak is below 200 used to be clipped into [0, 1]."""
+    images = torch.rand(1, 3, 8, 8) * 150.0
+    out = tensor_to_uint8(images)
+    assert int(out.max()) > 100
+
+
+def test_unit_batch_overshoot_does_not_wrap_around() -> None:
+    """1.04 * 255 overflows uint8; it must clamp to white, not wrap to black."""
+    images = torch.full((1, 3, 4, 4), 1.04)
+    out = tensor_to_uint8(images)
+    assert int(out.min()) == 255
+
+
+def test_unit_batch_undershoot_does_not_wrap_around() -> None:
+    images = torch.full((1, 3, 4, 4), -0.005)
+    out = tensor_to_uint8(images)
+    assert int(out.max()) == 0
+
+
+def test_uint8_to_tensor_without_scale_keeps_legacy_heuristic() -> None:
+    ref = torch.full((1, 3, 4, 4), 200.0)
+    u8 = np.full((1, 4, 4, 3), 255, dtype=np.uint8)
+    assert float(uint8_to_tensor(u8, ref_batch=ref).max()) > 1.5
+
+
+def test_denorm_stats_channel_mismatch_raises() -> None:
+    images = _normalise(torch.rand(1, 3, 4, 4))
+    scale = BatchScale("normalised", (0.5, 0.5), (0.5, 0.5))
+    with pytest.raises(NormalisedInputError):
+        tensor_to_uint8(images, scale=scale)


### PR DESCRIPTION
## Summary

BNNR augmentations operate on unnormalised images. A batch that had been through `transforms.Normalize()` was clipped into `[0, 1]` on the way in, which destroys the image, and on the path the classification trainer actually uses nothing raised or warned. The run finished and produced a plausible number. Reported in the T20 findings appendix (#389).

**The conversion existed in three copies with three different behaviours:**

| copy | on normalised input |
|---|---|
| `training/image_utils.py:tensor_to_uint8` | `RuntimeWarning` once per trainer, then clip to `[0, 1]` |
| `augmentation_runner.py:_tensor_to_uint8` | clip to `[0, 1]`, no warning at all |
| `augmentations.py:BaseAugmentation.apply_tensor` | straight `astype(uint8)`, no clip, negatives wrap around |

The third is the one every CPU-bound augmentation goes through, because `apply_tensor` is implemented on the base class and so never raises `NotImplementedError`. Fixing only the runner would have left the live path broken, which is why the diff is wider than the issue text.

**Now there is one implementation.** New `src/bnnr/image_scale.py` classifies a batch as `unit` ([0, 1]), `byte` ([0, 255]) or `normalised`, and every converter takes that classification instead of re-deriving it from data the augmentation has since changed. The runner, the trainer and `apply_tensor` all resolve the convention once per batch and invert it exactly.

With `denormalization_mean` / `denormalization_std` set, the normalisation is undone before augmenting and reapplied afterwards. Without them, a batch fitting neither convention raises `NormalisedInputError` naming both ways out.

**Two more silent-corruption paths in the same four lines go with it**, both found while writing the tests:

- `hi > 1.05 and hi < 200` clipped any `[0, 255]` batch whose brightest pixel was below 200 into `[0, 1]` and then cast it, zeroing every dark image.
- `hi <= 1.05` allowed up to `1.05 * 255 = 267`, which overflows uint8 and wraps white to black. Same for a small negative undershoot wrapping to 255.

## Compatibility

- `tensor_to_uint8` and `uint8_to_tensor` keep their signatures; the new arguments are keyword-only with defaults. `uint8_to_tensor` without `scale` keeps the legacy `ref_batch` heuristic, covered by the existing test.
- `augmentation_runner._tensor_to_uint8` / `_uint8_to_tensor` are gone. They were module-private names that nothing imported; the `BNNRTrainer` methods of the same name are unchanged.
- `BaseAugmentation.apply_tensor` gains a keyword-only `scale`. The runner does not pass it, so third-party overrides with the old signature keep working and now receive a `[0, 1]` batch, which is what they already assumed.
- Nothing added to `bnnr.__all__`. `BatchScale`, `NormalisedInputError` and `detect_batch_scale` are exported from `bnnr.training` only.
- Behaviour change: normalised input raises where it used to warn or pass. `tests/test_regression.py::TestTensorToUint8Warning` asserted the old warning and is rewritten to assert the error, plus a case proving the denormalisation roundtrip works. This is the point of the issue, and per the plan it ships as a 0.x minor.

## Test plan

- `pytest -q` -> **1061 passed, 4 skipped** (was 1061 before the change, with 2 rewritten and 14 added).
- `ruff check src tests` clean.
- `mypy src/bnnr/image_scale.py src/bnnr/training/image_utils.py src/bnnr/augmentation_runner.py src/bnnr/augmentations.py` -> no issues.
- New coverage: convention detection for all three cases, the "stats configured but batch is already in range" case, a lossless normalised roundtrip to within 1/255, the dark `[0, 255]` regression, both uint8 wraparound cases, channel-count mismatch, and two runner-level tests that go through the real dispatch.

## Docs

`docs/configuration.md` explains what the two denormalization fields now do, and `docs/troubleshooting.md` gets an entry for the new error with both fixes.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #394

