### PR TITLE
fix(augmentations): make ChurchNoise the same transform on both paths

### DIFF
--- a/docs/augmentations.md
+++ b/docs/augmentations.md
@@ -52,7 +52,12 @@ Main classes used by presets:
 - **Sync path** (`async_prefetch=False`, no CPU augs, or a mixed/interleaved list): augs run inline in list order.
 - **Async prefetch** (`async_prefetch=True`): only engaged when every CPU aug precedes every GPU aug in your list. CPU augs run in a background thread for the next batch while the current batch trains; GPU augs run on the main thread (with `sample_indices` threaded through, so index-aware augs key on the sample index rather than an image hash). If the list interleaves CPU and GPU augs, the runner falls back to the sync path so order is never changed by the split.
 
-**CPU/GPU divergence:** `ChurchNoise`, `DifPresets`, and `ProCAM` are `device_compatible=True` but their GPU and CPU implementations are **different transforms**, not just different precision (e.g. `ChurchNoise` is regional line noise on CPU but uniform Gaussian noise on GPU). On a machine with a GPU tensor path the GPU variant runs; on CPU-only the numpy variant runs. See each class docstring for the specifics.
+**CPU/GPU divergence:** `DifPresets` and `ProCAM` are `device_compatible=True` but their GPU and CPU implementations are **different transforms**, not just different precision. On a machine with a GPU tensor path the GPU variant runs; on CPU-only the numpy variant runs, so the device silently decides which transform you get and results from the two are not comparable. See each class docstring for the specifics.
+
+`ChurchNoise` no longer diverges. Both paths implement both transforms and `noise_mode` selects one:
+
+- `noise_mode="regional"` (default) — `num_lines` random lines split the image into regions, each with its own noise kind (white, gaussian, pink) and standard deviation. This is what the numpy path always did.
+- `noise_mode="uniform"` — one Gaussian field over the whole image with a single standard deviation. Cheaper, and what the tensor path used to do unconditionally; pass it to reproduce runs made before the change. `num_lines` has no effect in this mode.
 
 ## Multi-label note
 

--- a/src/bnnr/augmentations.py
+++ b/src/bnnr/augmentations.py
@@ -196,6 +196,10 @@ def _line_partitions(height: int, width: int, num_lines: int, rnd: random.Random
     return region_id
 
 
+_NOISE_KINDS = ("white", "gaussian", "pink")
+_NOISE_MODES = frozenset({"regional", "uniform"})
+
+
 def _np_rng(rnd: random.Random) -> np.random.Generator:
     return np.random.default_rng(rnd.randrange(0, 2**32 - 1))  # type: ignore[return-value]
 
@@ -203,60 +207,169 @@ def _np_rng(rnd: random.Random) -> np.random.Generator:
 @AugmentationRegistry.register("augmentation_1")
 @AugmentationRegistry.register("church_noise")
 class ChurchNoise(BaseAugmentation):
-    """Noise augmentation. CPU/GPU paths diverge by design.
+    """Line-partitioned regional noise, identical on the numpy and tensor paths.
 
-    The CPU path (``apply``) adds line-partitioned *regional* noise; the
-    GPU path (``apply_tensor_native``) adds *uniform* full-image Gaussian
-    noise. ``device_compatible=True``, so the runner uses the GPU path
-    whenever a tensor is available, which is a different transform than the
-    numpy fallback. ``num_lines`` only affects the CPU path.
+    ``num_lines`` random straight lines split the image into regions, and each
+    region gets its own noise kind (white, gaussian or pink) and its own
+    standard deviation drawn from ``noise_strength_range``.
+
+    ``noise_mode`` selects the transform, and both paths implement both modes,
+    so the device no longer decides which transform runs:
+
+    ``"regional"`` (default)
+        The transform described above. This is what the numpy path has always
+        done and what the tensor path now does too.
+    ``"uniform"``
+        One Gaussian noise field over the whole image with a single standard
+        deviation. Cheaper, and what the tensor path used to do
+        unconditionally. ``num_lines`` has no effect in this mode.
+
+    Regional noise on the tensor path costs one noise field per region rather
+    than one per image. Pass ``noise_mode="uniform"`` to trade the regional
+    structure back for that, or to reproduce runs made before this change.
     """
 
     device_compatible: bool = True
 
-    def __init__(self, num_lines: int = 3, noise_strength_range: tuple[float, float] = (5.0, 14.0), **kwargs: Any) -> None:
+    def __init__(
+        self,
+        num_lines: int = 3,
+        noise_strength_range: tuple[float, float] = (5.0, 14.0),
+        noise_mode: str = "regional",
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
+        if noise_mode not in _NOISE_MODES:
+            raise ValueError(
+                f"noise_mode must be one of {sorted(_NOISE_MODES)}, got {noise_mode!r}"
+            )
         self.num_lines = num_lines
         self.noise_strength_range = noise_strength_range
+        self.noise_mode = noise_mode
+
+    def __repr__(self) -> str:
+        # Extend, do not replace: the base repr carries probability and intensity.
+        return f"{super().__repr__()[:-1]}, noise_mode={self.noise_mode})"
+
+    # ------------------------------------------------------------------
+    # Shared plan: both paths draw the same regions and the same per-region
+    # parameters from the same RNG, so they are the same transform.
+    # ------------------------------------------------------------------
+
+    def _regional_plan(self, h: int, w: int) -> tuple[np.ndarray, list[tuple[int, float, str]]]:
+        """Draw the region map and the (region, std, kind) triples for one image."""
+        regions = _line_partitions(h, w, max(1, int(self.num_lines)), self._rnd)
+        plan = [
+            (int(region), self._rnd.uniform(*self.noise_strength_range), self._rnd.choice(_NOISE_KINDS))
+            for region in np.unique(regions)
+        ]
+        return regions, plan
+
+    # ------------------------------------------------------------------
+    # Tensor path
+    # ------------------------------------------------------------------
+
+    def _torch_noise(
+        self,
+        kind: str,
+        std: float,
+        h: int,
+        w: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        generator: torch.Generator,
+    ) -> Tensor:
+        """One (H, W) noise field of the given kind, scaled to *std*."""
+        if kind == "white":
+            span = std * math.sqrt(3.0)
+            uniform = torch.rand(h, w, device=device, dtype=torch.float32, generator=generator)
+            return ((uniform * 2.0 - 1.0) * span).to(dtype)
+        if kind == "gaussian":
+            normal = torch.randn(h, w, device=device, dtype=torch.float32, generator=generator)
+            return (normal * std).to(dtype)
+
+        # Pink: 1/f spectrum, mirroring the numpy path.
+        real = torch.randn(h, w, device=device, dtype=torch.float32, generator=generator)
+        imag = torch.randn(h, w, device=device, dtype=torch.float32, generator=generator)
+        fy = torch.fft.fftfreq(h, device=device).reshape(-1, 1)
+        fx = torch.fft.fftfreq(w, device=device).reshape(1, -1)
+        radius = torch.sqrt(fx * fx + fy * fy)
+        radius[0, 0] = 1.0
+        pink = torch.fft.ifft2(torch.complex(real, imag) / radius).real
+        pink = (pink - pink.mean()) / (pink.std() + 1e-8)
+        return (pink * std).to(dtype)
 
     def apply_tensor_native(self, images: Tensor) -> Tensor:
-        """GPU-native noise augmentation on BCHW float32 tensors in [0,1]."""
+        """Tensor-native noise on BCHW float32 tensors in [0, 1]."""
         if self._rnd.random() > self.probability:
             return images
-        b, c, h, w = images.shape
-        std = self._rnd.uniform(*self.noise_strength_range) / 255.0  # scale to [0,1]
-        noise = torch.randn(b, 1, h, w, device=images.device, dtype=images.dtype) * std
+        b, _, h, w = images.shape
+        generator = torch.Generator(device=images.device)
+        generator.manual_seed(self._rnd.randrange(0, 2**63 - 1))
+
+        if self.noise_mode == "uniform":
+            std = self._rnd.uniform(*self.noise_strength_range) / 255.0
+            noise = torch.randn(
+                b, 1, h, w, device=images.device, dtype=images.dtype, generator=generator
+            ) * std
+        else:
+            noise = torch.zeros(b, 1, h, w, device=images.device, dtype=images.dtype)
+            for idx in range(b):
+                regions, plan = self._regional_plan(h, w)
+                region_map = torch.as_tensor(regions, device=images.device)
+                for region, std, kind in plan:
+                    sample = self._torch_noise(
+                        kind,
+                        std / 255.0,  # plan is in pixel units, tensors are in [0, 1]
+                        h,
+                        w,
+                        device=images.device,
+                        dtype=images.dtype,
+                        generator=generator,
+                    )
+                    noise[idx, 0] = torch.where(region_map == region, sample, noise[idx, 0])
+
         result = (images + noise).clamp(0.0, 1.0)
         if self.intensity < 1.0:
             result = images * (1.0 - self.intensity) + result * self.intensity
         return result
 
+    # ------------------------------------------------------------------
+    # Numpy path
+    # ------------------------------------------------------------------
+
+    def _np_noise(self, kind: str, std: float, h: int, w: int, np_rng: np.random.Generator) -> np.ndarray:
+        """One (H, W) noise field of the given kind, scaled to *std*."""
+        if kind == "white":
+            return np_rng.uniform(-std * math.sqrt(3), std * math.sqrt(3), size=(h, w)).astype(np.float32)
+        if kind == "gaussian":
+            return np_rng.normal(0.0, std, size=(h, w)).astype(np.float32)
+
+        spectrum = np_rng.normal(size=(h, w)) + 1j * np_rng.normal(size=(h, w))
+        fy = np.fft.fftfreq(h).reshape(-1, 1)
+        fx = np.fft.fftfreq(w).reshape(1, -1)
+        radius = np.sqrt(fx * fx + fy * fy)
+        radius[0, 0] = 1.0
+        pink = np.fft.ifft2(spectrum / radius).real
+        pink = (pink - pink.mean()) / (pink.std() + 1e-8)
+        return (pink * std).astype(np.float32)
+
     def apply(self, image: np.ndarray) -> np.ndarray:
         image = self.validate_input(image)
         h, w, _ = image.shape
-        rnd = self._rnd
-        regions = _line_partitions(h, w, max(1, int(self.num_lines)), rnd)
         out: np.ndarray = image.astype(np.float32).copy()
 
-        for region in np.unique(regions):
-            mask = regions == region
-            std = rnd.uniform(*self.noise_strength_range)
-            noise_kind = rnd.choice(["white", "gaussian", "pink"])
-            np_rng = _np_rng(rnd)
-            if noise_kind == "white":
-                noise = np_rng.uniform(-std * math.sqrt(3), std * math.sqrt(3), size=(h, w)).astype(np.float32)
-            elif noise_kind == "gaussian":
-                noise = np_rng.normal(0.0, std, size=(h, w)).astype(np.float32)
-            else:
-                spectrum = np_rng.normal(size=(h, w)) + 1j * np_rng.normal(size=(h, w))
-                fy = np.fft.fftfreq(h).reshape(-1, 1)
-                fx = np.fft.fftfreq(w).reshape(1, -1)
-                radius = np.sqrt(fx * fx + fy * fy)
-                radius[0, 0] = 1.0
-                pink = np.fft.ifft2(spectrum / radius).real
-                pink = (pink - pink.mean()) / (pink.std() + 1e-8)
-                noise = (pink * std).astype(np.float32)
+        if self.noise_mode == "uniform":
+            std = self._rnd.uniform(*self.noise_strength_range)
+            noise = self._np_noise("gaussian", std, h, w, _np_rng(self._rnd))
+            out = np.clip(out + noise[:, :, None], 0, 255)
+            return out.astype(np.uint8)
 
+        regions, plan = self._regional_plan(h, w)
+        for region, std, kind in plan:
+            mask = regions == region
+            noise = self._np_noise(kind, std, h, w, _np_rng(self._rnd))
             noise3 = np.repeat(noise[:, :, None], 3, axis=2)
             out[mask] = np.clip(out[mask] + noise3[mask], 0, 255)
         return out.astype(np.uint8)

--- a/tests/test_gpu_augmentations.py
+++ b/tests/test_gpu_augmentations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 import torch
 
@@ -278,3 +279,102 @@ class TestRunnerNormalisedBatches:
         assert float(out.min()) < -0.5
         assert float(out.max()) > 0.5
         assert torch.isfinite(out).all()
+
+
+class TestChurchNoiseModes:
+    """CPU and tensor paths must run the same transform (FIX-0-3)."""
+
+    @staticmethod
+    def _plan_for(**kwargs):
+        """Redraw the plan a tensor-path call would use for the first image.
+
+        ``apply_tensor_native`` consumes one draw for the probability check and
+        one to seed the torch generator before it asks for a plan, so mirror
+        that here.
+        """
+        aug = ChurchNoise(probability=1.0, **kwargs)
+        aug._rnd.random()
+        aug._rnd.randrange(0, 2**63 - 1)
+        return aug._regional_plan(64, 64)
+
+    def test_regional_is_the_default_on_both_paths(self) -> None:
+        assert ChurchNoise().noise_mode == "regional"
+
+    def test_invalid_mode_rejected(self) -> None:
+        with pytest.raises(ValueError, match="noise_mode"):
+            ChurchNoise(noise_mode="sometimes")
+
+    def test_num_lines_affects_the_tensor_path(self) -> None:
+        """num_lines used to be ignored once a tensor path was available."""
+        _, few = self._plan_for(random_state=7, num_lines=1)
+        _, many = self._plan_for(random_state=7, num_lines=3)
+        assert len(few) == 2
+        assert len(many) > len(few)
+
+    def test_tensor_regional_noise_follows_the_per_region_plan(self) -> None:
+        """Each region gets its own standard deviation, as on the numpy path."""
+        aug = ChurchNoise(probability=1.0, random_state=11, num_lines=1)
+        regions, plan = self._plan_for(random_state=11, num_lines=1)
+
+        images = torch.full((1, 3, 64, 64), 0.5)
+        out = aug.apply_tensor_native(images)
+        diff = (out - images)[0, 0].numpy()
+
+        for region, std, _kind in plan:
+            observed = float(diff[regions == region].std())
+            assert observed == pytest.approx(std / 255.0, rel=0.15)
+
+    def test_numpy_regional_noise_follows_the_per_region_plan(self) -> None:
+        aug = ChurchNoise(probability=1.0, random_state=11, num_lines=1)
+        plan_aug = ChurchNoise(probability=1.0, random_state=11, num_lines=1)
+        regions, plan = plan_aug._regional_plan(64, 64)
+
+        image = np.full((64, 64, 3), 128, dtype=np.uint8)
+        out = aug.apply(image)
+        diff = out.astype(np.float32)[:, :, 0] - 128.0
+
+        for region, std, _kind in plan:
+            observed = float(diff[regions == region].std())
+            assert observed == pytest.approx(std, rel=0.15)
+
+    def test_uniform_mode_has_one_std_everywhere(self) -> None:
+        aug = ChurchNoise(probability=1.0, random_state=3, noise_mode="uniform")
+        images = torch.full((1, 3, 64, 64), 0.5)
+        diff = (aug.apply_tensor_native(images) - images)[0, 0].numpy()
+
+        halves = [float(diff[:32].std()), float(diff[32:].std())]
+        assert halves[0] == pytest.approx(halves[1], rel=0.12)
+
+    def test_regional_mode_varies_across_the_image(self) -> None:
+        """The property uniform mode cannot have, on the path that used to lack it."""
+        aug = ChurchNoise(probability=1.0, random_state=11, num_lines=1)
+        regions, plan = self._plan_for(random_state=11, num_lines=1)
+        stds = sorted(std for _region, std, _kind in plan)
+        planned_ratio = stds[-1] / stds[0]
+        assert planned_ratio > 1.05  # this seed does draw different stds per region
+
+        images = torch.full((1, 3, 64, 64), 0.5)
+        diff = (aug.apply_tensor_native(images) - images)[0, 0].numpy()
+        observed = sorted(float(diff[regions == region].std()) for region, _s, _k in plan)
+        assert observed[-1] / observed[0] == pytest.approx(planned_ratio, rel=0.2)
+
+    def test_tensor_path_is_deterministic_for_a_seed(self) -> None:
+        images = torch.full((2, 3, 32, 32), 0.5)
+        first = ChurchNoise(probability=1.0, random_state=5).apply_tensor_native(images)
+        second = ChurchNoise(probability=1.0, random_state=5).apply_tensor_native(images)
+        assert torch.equal(first, second)
+
+    def test_both_paths_produce_comparable_noise_magnitude(self) -> None:
+        """The two paths are the same transform, so their noise scale matches."""
+        cpu_out = ChurchNoise(probability=1.0, random_state=2, num_lines=3).apply(
+            np.full((96, 96, 3), 128, dtype=np.uint8)
+        )
+        cpu_std = float((cpu_out.astype(np.float32)[:, :, 0] - 128.0).std()) / 255.0
+
+        images = torch.full((1, 3, 96, 96), 0.5)
+        tensor_out = ChurchNoise(
+            probability=1.0, random_state=2, num_lines=3
+        ).apply_tensor_native(images)
+        tensor_std = float((tensor_out - images)[0, 0].numpy().std())
+
+        assert tensor_std == pytest.approx(cpu_std, rel=0.35)


### PR DESCRIPTION
## Summary

`ChurchNoise` added line-partitioned **regional** noise on the numpy path and **uniform** full-image Gaussian noise on the tensor path. With `device_compatible=True` the runner takes the tensor path whenever a tensor is available, so:

- the device decided which transform ran,
- `num_lines` did nothing on the tensor path,
- a CPU result and a GPU result were not the same condition, which quietly breaks any comparison that mixes machines.

The class docstring called this "by design", which is what kept it out of review. Reported in the T20 findings appendix (#389).

## What changed

**Both transforms now exist on both paths**, selected by `noise_mode`:

| mode | transform | notes |
|---|---|---|
| `"regional"` (default) | `num_lines` random lines split the image into regions; each gets its own noise kind (white / gaussian / pink) and its own std | what the numpy path always did |
| `"uniform"` | one Gaussian field over the whole image, single std | what the tensor path used to do unconditionally; kept for reproducing earlier runs, and cheaper. `num_lines` has no effect |

**The two paths are the same transform by construction, not by inspection.** Both draw the region map and the per-region `(std, kind)` from one shared `_regional_plan`, off the same RNG. The tensor path generates the noise with torch, pink noise included, via `torch.fft`, and is deterministic per seed through an explicit `torch.Generator`.

## Cost

Regional noise on the tensor path costs one noise field per region rather than one per image, so up to eight fields at `num_lines=3`. That is the price of the two paths agreeing, and it is the same cost the numpy path already paid. `noise_mode="uniform"` buys it back for anyone who wants the cheap variant.

## Test plan

- `pytest -q` -> **1056 passed, 4 skipped**.
- `ruff check src tests` clean, `mypy src/bnnr/` clean.
- New tests, all on a CPU device so CI covers them: regional is the default; an invalid mode is rejected; `num_lines` now affects the tensor path; per-region empirical std matches the planned std on **both** paths; uniform mode has one std across the image while regional mode's per-region ratio tracks the planned ratio; the tensor path is deterministic for a seed; both paths produce comparable noise magnitude.

The noise realisation for a given seed changes, because the draw order moved into the shared plan. No test asserted exact pixel values for a seed.

## Follow-ups

- `noise_mode` belongs in the run record. That lands with the record fields in #410.
- `DifPresets` and `ProCAM` have the same divergence and are untouched here. Filed as #421.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #396
