### PR TITLE
docs: describe what ICD and AICD actually mask, and when each applies

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Advanced: pass `--config path.yaml` to override defaults.
 
 ## XAI-driven augmentations (ICD & AICD)
 
-BNNR uses saliency maps to guide augmentation, not random flips and crops. One Grad-CAM map yields two targeted augmentations: **ICD** hides the most salient region (so the model cannot lean on a shortcut), **AICD** hides the background (so it focuses on the object).
+BNNR uses saliency maps to guide augmentation, not random flips and crops. One Grad-CAM map yields two opposite augmentations: **ICD** hides the most salient tiles, so the model cannot lean on whatever it currently relies on; **AICD** hides the least salient tiles, which suppresses the surrounding context once attention is already on the object.
 
 <p align="center">
   <img src="docs/assets/icd-aicd-comparison.png" alt="One saliency map, two augmentations (ICD and AICD) on dog, cat, espresso, and car" width="760">

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -58,11 +58,15 @@ python benchmarks/run.py --list-conditions
 
 ## BNNR augmentations in this benchmark
 
-| Name | Role |
-|------|------|
-| **ICD** | Masks *high-saliency* regions — forces the model to look beyond the easiest cue |
-| **AICD** | Masks *low-saliency* background — reduces shortcut learning on context |
-| **ChurchNoise** | Lightweight noise aug — non-XAI candidate in the branch pool |
+| Name | What it masks | Right when |
+|------|---------------|------------|
+| **ICD** | The *most* salient tiles, above the threshold percentile | The model leans on a cue you want broken. ICD destroys what it currently relies on |
+| **AICD** | The *least* salient tiles | Attention is already on the object and the surrounding context needs suppressing |
+| **ChurchNoise** | Nothing saliency-guided; regional noise | Non-XAI candidate in the branch pool |
+
+**The least salient tiles are the background only when the model already attends the object.** On a model attending the background, which is the case ICD and AICD exist to help with, AICD masks the object instead. The two are opposite operations on attention, so which one is appropriate depends on where attention already is.
+
+BNNR does not currently diagnose that. It trains both candidates and keeps whichever scored higher on selection-validation accuracy, a criterion the T20 findings showed is close to orthogonal to the objective. Diagnosing the attention regime is bnnr-team/bnnr#403 and acting on it is bnnr-team/bnnr#413.
 
 The branch search keeps augmentations that improve validation accuracy; the winning path is recorded in `results.json` → `best_path`.
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -175,7 +175,7 @@ For raw `ultralytics.nn.tasks` modules without this adapter, detection XAI stays
 XAI-driven augmentations:
 
 - `DetectionICD(threshold_percentile=70.0, tile_size=8, fill_strategy="gaussian_blur")` — masks high-saliency (object) tiles
-- `DetectionAICD(threshold_percentile=70.0, tile_size=8, fill_strategy="gaussian_blur")` — masks low-saliency (background) tiles
+- `DetectionAICD(threshold_percentile=70.0, tile_size=8, fill_strategy="gaussian_blur")` — masks the least salient tiles, which are the background only when the model already attends the object
 
 Presets: `from bnnr.detection_augmentations import get_detection_preset` — `name` ∈ `{"light", "standard", "aggressive"}`.
 

--- a/docs/augmentations.md
+++ b/docs/augmentations.md
@@ -102,7 +102,7 @@ Detection augmentations are bbox-aware — they transform both images and boundi
 ### Detection ICD / AICD
 
 - `DetectionICD` — masks high-saliency tiles (forces context learning)
-- `DetectionAICD` — masks low-saliency tiles (sharpens object focus)
+- `DetectionAICD` — masks the least salient tiles (sharpens object focus, once attention is already on the object)
 
 Both accept `threshold_percentile`, `tile_size`, `fill_strategy`, and `probability`.
 

--- a/src/bnnr/detection_icd.py
+++ b/src/bnnr/detection_icd.py
@@ -274,10 +274,14 @@ class DetectionICD(_DetectionBaseICD):
 
 
 class DetectionAICD(_DetectionBaseICD):
-    """Detection Anti-ICD — masks low-saliency (background) tiles.
+    """Detection Anti-ICD: masks the tiles the model attends to least.
 
-    Focuses training on object regions by removing distracting
-    background context.
+    Focuses training on the regions the model already considers important by
+    perturbing everything else.
+
+    The least salient tiles are the background only when the detector already
+    attends the objects. When it does not, this masks the objects instead. See
+    :class:`bnnr.AICD` for the same caveat on the classification side.
     """
 
     name: str = "det_aicd"

--- a/src/bnnr/icd.py
+++ b/src/bnnr/icd.py
@@ -29,6 +29,10 @@ class _BaseICD(BaseAugmentation):
     or least (AICD) salient regions of the image.  The masked area is filled
     with a configurable strategy (blurred original, local mean, noise, etc.)
     instead of a hard black rectangle.
+
+    ICD and AICD are opposite operations on the model's attention, so which one
+    is appropriate depends on where that attention already is. See the
+    subclasses for the condition under which each is the right intervention.
     """
 
     invert_mask: bool = False
@@ -461,14 +465,35 @@ class _BaseICD(BaseAugmentation):
 
 
 class ICD(_BaseICD):
-    """Intelligent Coarse Dropout — masks the most salient tiles."""
+    """Intelligent Coarse Dropout: masks the tiles the model relies on most.
+
+    Masks saliency above ``threshold_percentile``, so it destroys whatever the
+    model is currently leaning on and forces it to find other evidence.
+
+    **Right when** the model leans on a cue you want broken, which includes the
+    shortcut-learning case where saliency sits on the background or the frame.
+    """
 
     name = "icd"
     invert_mask = False
 
 
 class AICD(_BaseICD):
-    """Anti-ICD — masks the least salient tiles (keeps important regions)."""
+    """Anti-ICD: masks the tiles the model attends to least.
+
+    Masks saliency below ``threshold_percentile``, keeping the region the model
+    already considers important and perturbing everything else.
+
+    **Right when** attention is already on the object and the surrounding
+    context needs suppressing.
+
+    The least salient tiles are the background *only when that holds*. On a
+    model attending the background, AICD masks the object instead, which is the
+    opposite of the intended effect. BNNR does not currently diagnose which case
+    a model is in; it trains both candidates and keeps whichever scored higher
+    on selection-validation accuracy. Diagnosing the attention regime is
+    bnnr-team/bnnr#403, and acting on the diagnosis is bnnr-team/bnnr#413.
+    """
 
     name = "aicd"
     invert_mask = True


### PR DESCRIPTION
## Summary

`benchmarks/README.md:64` described AICD as masking "low-saliency **background**". AICD masks the least salient tiles. That equals background only when the model already attends the object. On a model attending the background, which is the case ICD and AICD exist to help with, **AICD masks the object instead**.

The same claim had spread to four other places: `README.md`, `docs/api_reference.md`, `docs/augmentations.md`, and the `DetectionAICD` docstring. All five are corrected.

Each augmentation now also states the condition under which it is the right intervention:

- **ICD** masks the most salient tiles. Right when the model leans on a cue you want broken, including the shortcut case where saliency sits on the background or the frame.
- **AICD** masks the least salient tiles. Right when attention is already on the object and the surrounding context needs suppressing.

## This is not a fix for the underlying problem

The code still has no way to tell which case it is in. It trains both candidates and keeps whichever scored higher on selection-validation accuracy, a criterion the T20 findings showed is close to orthogonal to the objective. The docs now say that plainly rather than implying the choice is principled, and link to the two issues that address it: #403 for the diagnosis and #413 for acting on it.

Filing it this way was deliberate, per the issue: correcting the prose alone would have made the docs accurate and the library no better.

## Test plan

Documentation and docstrings only, no behaviour change. `ruff check src` clean; `pytest -q -k "icd or detection"` -> 189 passed.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #397
