### PR TITLE
feat(analysis): saliency shape statistics for the attention-regime diagnosis

### DIFF
--- a/src/bnnr/analysis/saliency_stats.py
+++ b/src/bnnr/analysis/saliency_stats.py
@@ -1,0 +1,295 @@
+"""Shape statistics for a saliency map, for the attention-regime diagnosis.
+
+BNNR already computes a saliency map for every image and then keeps only which
+pixels to mask. The choice between ICD and AICD depends on *where the model is
+already looking*, which is measurable from the same maps with no annotation.
+
+Two things have to be pinned down or the numbers do not transfer between runs:
+
+**Resolution.** Normalised entropy of a 7x7 OptiCAM map upsampled to 224x224 is
+not the entropy of the native 7x7 map: the upsampling interpolates mass into
+neighbouring pixels and raises the entropy. Every statistic here is therefore
+computed at one declared resolution, recorded on the result as ``resolution``.
+A threshold calibrated at one resolution means nothing at another.
+
+**Perturbation fill.** ``perturbation_shift`` has to overwrite pixels with
+something, and the choice is exactly the free parameter T21 is measuring. It is
+frozen at ``gaussian_blur`` here and recorded as ``perturbation_fill`` so the
+calibration is not confounded by it. The correlation is Spearman, which is
+rank-based, so an explainer that rescales its maps does not move the statistic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from bnnr.utils import lazy_cv2 as cv2
+from bnnr.xai_analysis import analyze_saliency_map
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from torch import Tensor, nn
+
+    from bnnr.xai import BaseExplainer
+
+__all__ = [
+    "DEFAULT_RESOLUTION",
+    "PERTURBATION_FILL",
+    "SaliencyStats",
+    "aggregate_saliency_stats",
+    "perturbation_shift",
+    "saliency_stats_from_map",
+]
+
+#: Resolution every statistic is computed at unless the caller declares another.
+#: Native CAM grids differ per backbone (7x7 for ResNet-50 at 224, 14x14 for a
+#: ViT/16); resampling to a common grid is what makes the numbers comparable.
+DEFAULT_RESOLUTION = (14, 14)
+
+#: Frozen fill for :func:`perturbation_shift`. Not configurable on purpose, see
+#: the module docstring.
+PERTURBATION_FILL = "gaussian_blur"
+
+_BLUR_KERNEL_RATIO = 0.1
+
+
+@dataclass(frozen=True)
+class SaliencyStats:
+    """Shape of one saliency map, or the aggregate over a batch of them.
+
+    Attributes
+    ----------
+    concentration
+        ``1 - entropy / log2(H*W)``, on the grid named by ``resolution``. 1 is
+        all mass in a single cell, 0 is uniform. This is the normalisation that
+        makes entropy comparable across grid sizes; it does not make it
+        comparable across *interpolations* of the same map, hence the recorded
+        resolution.
+    gini
+        Gini coefficient of the map values. 0 uniform, 1 all mass in one cell.
+        Concentration and gini both measure inequality but disagree on the
+        shape of the tail, which is why the diagnosis gets to see both.
+    border_mass
+        Fraction of total activation inside a 15%-wide border strip. High
+        values are the signature of a model attending to padding or framing
+        artefacts rather than to the object.
+    resolution
+        ``(H, W)`` the three statistics above were computed on.
+    perturbation_shift
+        ``1 - rho(map_before, map_after)`` with Spearman ``rho``, where the
+        perturbation blurs the complement of the top-k saliency. ``None`` on a
+        result from :func:`saliency_stats_from_map`, which never runs a model.
+    perturbation_fill
+        Fill used for that perturbation, or ``None`` when it was not run.
+    n_maps
+        Number of maps behind these numbers. 1 for a single map.
+    """
+
+    concentration: float
+    gini: float
+    border_mass: float
+    resolution: tuple[int, int]
+    perturbation_shift: float | None = None
+    perturbation_fill: str | None = None
+    n_maps: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flat dict for run records and report artifacts."""
+        return asdict(self)
+
+
+def _resample(map_2d: np.ndarray, resolution: tuple[int, int]) -> np.ndarray:
+    """Resample a 2-D map to ``resolution`` (H, W), preserving nothing but shape."""
+    h, w = resolution
+    if map_2d.shape == (h, w):
+        return map_2d.astype(np.float64, copy=False)
+    # INTER_AREA both downsamples without aliasing and, on upsampling, degrades
+    # to bilinear, which is what the CAM libraries themselves use.
+    resized = cv2.resize(
+        map_2d.astype(np.float32, copy=False), (w, h), interpolation=cv2.INTER_AREA
+    )
+    return np.asarray(resized, dtype=np.float64)
+
+
+def saliency_stats_from_map(
+    map_2d: np.ndarray,
+    *,
+    resolution: tuple[int, int] = DEFAULT_RESOLUTION,
+) -> SaliencyStats:
+    """Compute the three model-free statistics of one ``[H, W]`` saliency map.
+
+    The map is resampled to ``resolution`` first, so two backbones with
+    different native CAM grids produce comparable numbers.
+
+    Entropy, gini and the border strip come from
+    :func:`bnnr.xai_analysis.analyze_saliency_map`, which is the one
+    implementation of them in the library.
+
+    An all-zero map has no shape to speak of; it comes back as concentration 0,
+    gini 0, border_mass 0 rather than as a division by zero.
+    """
+    if map_2d.ndim != 2:
+        raise ValueError(f"saliency map must be 2-D, got shape {map_2d.shape}")
+
+    grid = _resample(map_2d, resolution)
+    h, w = grid.shape
+    raw = analyze_saliency_map(grid)
+
+    max_entropy = float(np.log2(h * w)) if h * w > 1 else 0.0
+    if max_entropy > 0.0 and float(grid.sum()) > 1e-8:
+        concentration = 1.0 - raw["entropy"] / max_entropy
+    else:
+        concentration = 0.0
+
+    return SaliencyStats(
+        concentration=float(np.clip(concentration, 0.0, 1.0)),
+        gini=float(raw["gini"]),
+        border_mass=float(raw["edge_ratio"]),
+        resolution=(h, w),
+        n_maps=1,
+    )
+
+
+def _rankdata(values: np.ndarray) -> np.ndarray:
+    """Average-tied ranks, the convention Spearman is defined against."""
+    flat = values.ravel()
+    order = np.argsort(flat, kind="stable")
+    ranks = np.empty(flat.size, dtype=np.float64)
+    ranks[order] = np.arange(1, flat.size + 1, dtype=np.float64)
+
+    # Average the ranks within each run of equal values. A constant map is all
+    # one tie group, which is what makes the correlation undefined below.
+    sorted_vals = flat[order]
+    start = 0
+    for i in range(1, flat.size + 1):
+        if i == flat.size or sorted_vals[i] != sorted_vals[start]:
+            if i - start > 1:
+                ranks[order[start:i]] = ranks[order[start:i]].mean()
+            start = i
+    return ranks
+
+
+def _spearman(a: np.ndarray, b: np.ndarray) -> float:
+    """Spearman rho between two maps, 0.0 when either is constant.
+
+    A constant map has zero rank variance, so rho is undefined. Returning 0.0
+    reports "no monotone relationship", which sends ``perturbation_shift`` to
+    1.0: a map that carries no ordering did not survive the perturbation in any
+    usable sense.
+    """
+    ra, rb = _rankdata(a), _rankdata(b)
+    ra = ra - ra.mean()
+    rb = rb - rb.mean()
+    denom = float(np.sqrt(float(ra @ ra) * float(rb @ rb)))
+    if denom <= 1e-12:
+        return 0.0
+    return float(np.clip(float(ra @ rb) / denom, -1.0, 1.0))
+
+
+def _blur_complement(images: Tensor, maps: np.ndarray, top_k: float) -> Tensor:
+    """Blur everything outside the top-k saliency of each image.
+
+    Keeping the top-k and destroying the rest is the deletion-style probe: if
+    the model was genuinely reading the highlighted region, its explanation
+    should barely move.
+    """
+    import torch
+    import torchvision.transforms.functional as tv_functional
+
+    b, _, h, w = images.shape
+    k_size = max(3, int(max(h, w) * _BLUR_KERNEL_RATIO))
+    if k_size % 2 == 0:
+        k_size += 1
+    blurred = tv_functional.gaussian_blur(images, [k_size, k_size])
+
+    keep = np.empty((b, h, w), dtype=bool)
+    for i in range(b):
+        grid = _resample(maps[i], (h, w))
+        flat = grid.ravel()
+        n_keep = max(1, int(round(top_k * flat.size)))
+        # argpartition on the negated map puts the n_keep largest first.
+        idx = np.argpartition(-flat, n_keep - 1)[:n_keep]
+        flat_keep = np.zeros(flat.size, dtype=bool)
+        flat_keep[idx] = True
+        keep[i] = flat_keep.reshape(h, w)
+
+    keep_t = torch.as_tensor(keep, device=images.device).unsqueeze(1)
+    return torch.where(keep_t, images, blurred)
+
+
+def perturbation_shift(
+    model: nn.Module,
+    explainer: BaseExplainer,
+    images: Tensor,
+    labels: Tensor,
+    target_layers: list[nn.Module],
+    *,
+    top_k: float = 0.2,
+    resolution: tuple[int, int] = DEFAULT_RESOLUTION,
+) -> tuple[list[float], np.ndarray]:
+    """How far each explanation moves when the unattended region is destroyed.
+
+    Returns ``(shifts, maps_before)``: one ``1 - rho`` per image in ``images``,
+    and the unperturbed maps, so a caller that also wants
+    :func:`saliency_stats_from_map` does not pay for a second explainer pass.
+
+    ``top_k`` is the fraction of pixels kept intact. The complement is filled
+    with ``gaussian_blur`` (:data:`PERTURBATION_FILL`); this is deliberately not
+    a parameter, see the module docstring.
+
+    A shift near 0 means the explanation is unchanged by removing everything it
+    did not point at, which is the signature of a model reading a genuine local
+    feature. A shift near 1 means the explanation was an artefact of the
+    context.
+    """
+    if not 0.0 < top_k <= 1.0:
+        raise ValueError(f"top_k must be in (0, 1], got {top_k}")
+
+    maps_before = np.asarray(explainer.explain(model, images, labels, target_layers))
+    perturbed = _blur_complement(images, maps_before, top_k)
+    maps_after = np.asarray(explainer.explain(model, perturbed, labels, target_layers))
+
+    shifts: list[float] = []
+    for before, after in zip(maps_before, maps_after):
+        rho = _spearman(_resample(before, resolution), _resample(after, resolution))
+        shifts.append(float(np.clip(1.0 - rho, 0.0, 2.0)))
+    return shifts, maps_before
+
+
+def aggregate_saliency_stats(
+    stats: list[SaliencyStats],
+    *,
+    shifts: list[float] | None = None,
+) -> SaliencyStats:
+    """Reduce per-image stats to one batch-level :class:`SaliencyStats`.
+
+    The reduction is the **median**, not the mean, and this is a decision worth
+    stating: saliency statistics on a real dataset are skewed by a handful of
+    images the explainer fails on (a flat map, a map dominated by one artefact).
+    A mean lets those images move a threshold; a median does not.
+
+    ``resolution`` must agree across all inputs, since mixing resolutions is the
+    exact failure the recorded field exists to catch. ``shifts`` is the optional
+    per-image output of :func:`perturbation_shift`, reduced the same way.
+    """
+    if not stats:
+        raise ValueError("aggregate_saliency_stats needs at least one SaliencyStats")
+
+    resolutions = {s.resolution for s in stats}
+    if len(resolutions) > 1:
+        raise ValueError(
+            f"cannot aggregate stats computed at different resolutions: {sorted(resolutions)}"
+        )
+
+    shift = float(np.median(shifts)) if shifts else None
+    return SaliencyStats(
+        concentration=float(np.median([s.concentration for s in stats])),
+        gini=float(np.median([s.gini for s in stats])),
+        border_mass=float(np.median([s.border_mass for s in stats])),
+        resolution=resolutions.pop(),
+        perturbation_shift=shift,
+        perturbation_fill=PERTURBATION_FILL if shifts else None,
+        n_maps=sum(s.n_maps for s in stats),
+    )

--- a/tests/test_saliency_stats.py
+++ b/tests/test_saliency_stats.py
@@ -1,0 +1,246 @@
+"""Tests for bnnr.analysis.saliency_stats (FIX-1-1)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from torch import Tensor, nn
+
+from bnnr.analysis.saliency_stats import (
+    DEFAULT_RESOLUTION,
+    PERTURBATION_FILL,
+    SaliencyStats,
+    aggregate_saliency_stats,
+    perturbation_shift,
+    saliency_stats_from_map,
+)
+
+
+def _delta_map(size: int = 14) -> np.ndarray:
+    m = np.zeros((size, size), dtype=np.float32)
+    m[size // 2, size // 2] = 1.0
+    return m
+
+
+def _uniform_map(size: int = 14) -> np.ndarray:
+    return np.full((size, size), 0.5, dtype=np.float32)
+
+
+def _border_map(size: int = 14) -> np.ndarray:
+    m = np.zeros((size, size), dtype=np.float32)
+    strip = max(1, int(size * 0.15))
+    m[:] = 0.0
+    m[:strip, :] = 1.0
+    m[-strip:, :] = 1.0
+    m[:, :strip] = 1.0
+    m[:, -strip:] = 1.0
+    return m
+
+
+class TestPureStatistics:
+    def test_delta_map_is_maximally_concentrated(self) -> None:
+        stats = saliency_stats_from_map(_delta_map())
+        assert stats.concentration > 0.95
+        assert stats.gini > 0.95
+
+    def test_uniform_map_is_unconcentrated(self) -> None:
+        stats = saliency_stats_from_map(_uniform_map())
+        assert stats.concentration < 0.05
+        assert stats.gini < 0.05
+
+    def test_border_map_has_high_border_mass(self) -> None:
+        stats = saliency_stats_from_map(_border_map())
+        assert stats.border_mass > 0.9
+
+    def test_centre_blob_has_low_border_mass(self) -> None:
+        stats = saliency_stats_from_map(_delta_map())
+        assert stats.border_mass == pytest.approx(0.0, abs=1e-6)
+
+    def test_all_zero_map_does_not_divide_by_zero(self) -> None:
+        stats = saliency_stats_from_map(np.zeros((14, 14), dtype=np.float32))
+        assert stats.concentration == 0.0
+        assert stats.gini == 0.0
+        assert stats.border_mass == 0.0
+
+    def test_non_2d_map_rejected(self) -> None:
+        with pytest.raises(ValueError, match="2-D"):
+            saliency_stats_from_map(np.zeros((3, 14, 14), dtype=np.float32))
+
+
+class TestResolutionIsRecordedAndApplied:
+    def test_resolution_recorded_on_result(self) -> None:
+        stats = saliency_stats_from_map(_delta_map(7), resolution=(14, 14))
+        assert stats.resolution == (14, 14)
+
+    def test_default_resolution_used_when_unspecified(self) -> None:
+        stats = saliency_stats_from_map(_delta_map(7))
+        assert stats.resolution == DEFAULT_RESOLUTION
+
+    def test_native_and_upsampled_maps_land_on_the_same_grid(self) -> None:
+        """The whole point of declaring a resolution: 7x7 and its 224x224
+        upsampling must not produce two different concentrations."""
+        native = _delta_map(7)
+        upsampled = np.asarray(
+            np.kron(native, np.ones((32, 32), dtype=np.float32)), dtype=np.float32
+        )
+        a = saliency_stats_from_map(native, resolution=(7, 7))
+        b = saliency_stats_from_map(upsampled, resolution=(7, 7))
+        assert a.concentration == pytest.approx(b.concentration, abs=0.02)
+
+    def test_to_dict_carries_resolution(self) -> None:
+        d = saliency_stats_from_map(_delta_map()).to_dict()
+        assert d["resolution"] == DEFAULT_RESOLUTION
+        assert d["perturbation_fill"] is None
+
+
+class TestAggregation:
+    def test_median_reduction_ignores_one_broken_map(self) -> None:
+        good = [saliency_stats_from_map(_delta_map()) for _ in range(5)]
+        broken = saliency_stats_from_map(_uniform_map())
+        agg = aggregate_saliency_stats([*good, broken])
+        assert agg.concentration > 0.95
+        assert agg.n_maps == 6
+
+    def test_mixed_resolutions_rejected(self) -> None:
+        a = saliency_stats_from_map(_delta_map(), resolution=(7, 7))
+        b = saliency_stats_from_map(_delta_map(), resolution=(14, 14))
+        with pytest.raises(ValueError, match="different resolutions"):
+            aggregate_saliency_stats([a, b])
+
+    def test_empty_input_rejected(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            aggregate_saliency_stats([])
+
+    def test_shifts_recorded_with_their_fill(self) -> None:
+        stats = [saliency_stats_from_map(_delta_map()) for _ in range(3)]
+        agg = aggregate_saliency_stats(stats, shifts=[0.1, 0.2, 0.9])
+        assert agg.perturbation_shift == pytest.approx(0.2)
+        assert agg.perturbation_fill == PERTURBATION_FILL
+
+    def test_no_shifts_leaves_both_fields_none(self) -> None:
+        agg = aggregate_saliency_stats([saliency_stats_from_map(_delta_map())])
+        assert agg.perturbation_shift is None
+        assert agg.perturbation_fill is None
+
+
+class _StaticExplainer:
+    """Explainer that returns a fixed map regardless of the input."""
+
+    name = "static"
+
+    def __init__(self, maps: np.ndarray) -> None:
+        self.maps = maps
+        self.calls = 0
+
+    def explain(
+        self,
+        model: nn.Module,
+        images: Tensor,
+        labels: Tensor,
+        target_layers: list[nn.Module],
+    ) -> np.ndarray:
+        self.calls += 1
+        return self.maps
+
+
+class _FlippingExplainer(_StaticExplainer):
+    """Explainer whose map reverses on the second call."""
+
+    def explain(
+        self,
+        model: nn.Module,
+        images: Tensor,
+        labels: Tensor,
+        target_layers: list[nn.Module],
+    ) -> np.ndarray:
+        self.calls += 1
+        if self.calls == 1:
+            return self.maps
+        return self.maps[:, ::-1, ::-1].copy()
+
+
+def _gradient_maps(batch: int = 2, size: int = 14) -> np.ndarray:
+    single = np.linspace(0.0, 1.0, size * size, dtype=np.float32).reshape(size, size)
+    return np.stack([single] * batch)
+
+
+class TestPerturbationShift:
+    def _inputs(self, batch: int = 2) -> tuple[nn.Module, Tensor, Tensor, list[nn.Module]]:
+        model = nn.Identity()
+        images = torch.rand(batch, 3, 28, 28)
+        labels = torch.zeros(batch, dtype=torch.long)
+        return model, images, labels, []
+
+    def test_stable_explanation_gives_near_zero_shift(self) -> None:
+        model, images, labels, layers = self._inputs()
+        explainer = _StaticExplainer(_gradient_maps())
+        shifts, maps = perturbation_shift(model, explainer, images, labels, layers)
+        assert len(shifts) == 2
+        assert all(s == pytest.approx(0.0, abs=1e-6) for s in shifts)
+        assert maps.shape == (2, 14, 14)
+
+    def test_reversed_explanation_gives_shift_near_two(self) -> None:
+        model, images, labels, layers = self._inputs()
+        explainer = _FlippingExplainer(_gradient_maps())
+        shifts, _ = perturbation_shift(model, explainer, images, labels, layers)
+        assert all(s > 1.9 for s in shifts)
+
+    def test_constant_map_reports_full_shift(self) -> None:
+        """rho is undefined on a constant map; the convention is shift 1.0."""
+        model, images, labels, layers = self._inputs()
+        flat = np.ones((2, 14, 14), dtype=np.float32)
+        shifts, _ = perturbation_shift(model, _StaticExplainer(flat), images, labels, layers)
+        assert all(s == pytest.approx(1.0) for s in shifts)
+
+    def test_explainer_called_exactly_twice(self) -> None:
+        model, images, labels, layers = self._inputs()
+        explainer = _StaticExplainer(_gradient_maps())
+        perturbation_shift(model, explainer, images, labels, layers)
+        assert explainer.calls == 2
+
+    def test_perturbation_keeps_top_k_pixels_untouched(self) -> None:
+        model, images, labels, layers = self._inputs(batch=1)
+        # Strictly decreasing over the flat index, so "the top 10%" is exactly
+        # the first 78 pixels with no tie to break arbitrarily.
+        maps = np.linspace(1.0, 0.0, 28 * 28, dtype=np.float32).reshape(1, 28, 28)
+
+        captured: list[Tensor] = []
+
+        class _Capture(_StaticExplainer):
+            def explain(
+                self,
+                model: nn.Module,
+                images: Tensor,
+                labels: Tensor,
+                target_layers: list[nn.Module],
+            ) -> np.ndarray:
+                captured.append(images.clone())
+                return self.maps
+
+        perturbation_shift(model, _Capture(maps), images, labels, layers, top_k=0.1)
+        original, perturbed = captured
+        # Kept region is bit-identical, the rest was blurred.
+        assert torch.equal(original[:, :, :2, :], perturbed[:, :, :2, :])
+        assert not torch.equal(original[:, :, 10:, :], perturbed[:, :, 10:, :])
+
+    @pytest.mark.parametrize("bad", [0.0, -0.1, 1.5])
+    def test_invalid_top_k_rejected(self, bad: float) -> None:
+        model, images, labels, layers = self._inputs()
+        with pytest.raises(ValueError, match="top_k"):
+            perturbation_shift(
+                model, _StaticExplainer(_gradient_maps()), images, labels, layers, top_k=bad
+            )
+
+
+class TestDataclass:
+    def test_stats_are_frozen(self) -> None:
+        stats = saliency_stats_from_map(_delta_map())
+        with pytest.raises(Exception):
+            stats.concentration = 0.0  # type: ignore[misc]
+
+    def test_single_map_counts_as_one(self) -> None:
+        assert saliency_stats_from_map(_delta_map()).n_maps == 1
+
+    def test_is_a_saliency_stats(self) -> None:
+        assert isinstance(saliency_stats_from_map(_delta_map()), SaliencyStats)


### PR DESCRIPTION
## Summary

BNNR computes a saliency map for every image and then keeps only which pixels to mask. Everything about the *shape* of that map is discarded, and the shape is exactly what the ICD/AICD choice depends on: whether the model is already looking at the object. It is measurable from the maps that already exist, with no annotation.

New `src/bnnr/analysis/saliency_stats.py`:

| function | what it returns |
|---|---|
| `saliency_stats_from_map(map_2d)` | `concentration`, `gini`, `border_mass` for one map, no model needed |
| `perturbation_shift(model, explainer, images, ...)` | `1 - rho(before, after)` per image, plus the unperturbed maps |
| `aggregate_saliency_stats(stats, shifts=...)` | one batch-level `SaliencyStats` |

`concentration` is `1 - entropy / log2(H*W)`. Entropy, gini and the border strip come from `xai_analysis.analyze_saliency_map`, which is the library's one implementation of them; this module normalises and names them, it does not recompute them.

`perturbation_shift` blurs the complement of the top-k saliency and asks how far the explanation moves. `rho` is Spearman, so an explainer that rescales its maps does not move the number. It returns `maps_before` alongside the shifts, so a caller that also wants the pure statistics pays for one explainer pass rather than two.

## The two parameters that are pinned rather than left free

Both are called out in the issue, and both are the difference between thresholds that transfer and thresholds that do not.

**Resolution.** Normalised entropy of a 7x7 OptiCAM map upsampled to 224x224 is not the entropy of the native 7x7 map: upsampling interpolates mass into neighbouring cells and raises it. Every statistic is computed on one declared grid, `DEFAULT_RESOLUTION = (14, 14)`, and the grid is recorded on the result. `aggregate_saliency_stats` raises rather than mixing two of them, which is the failure the recorded field exists to catch. There is a test that a native 7x7 map and its 32x-upsampled copy land on the same concentration.

**Perturbation fill.** Frozen at `gaussian_blur` (`PERTURBATION_FILL`) and recorded, not a parameter. Left free, the statistic inherits the fill sensitivity T21 is currently measuring and the Block 7 calibration is confounded by it.

## Reduction

`aggregate_saliency_stats` reduces with the **median**, and this is a decision worth stating rather than an implementation detail. Saliency statistics over a real dataset are skewed by the handful of images the explainer fails on: a flat map, or one dominated by a single artefact. A mean lets those images move a threshold; a median does not. There is a test for exactly that case.

`_spearman` returns 0.0 when either map is constant, since rho is undefined there. That sends the shift to 1.0, which reads as "the map carried no ordering that survived the perturbation" rather than as a silent 0.

## Scope

Nothing consumes this yet. #403 (`diagnosis.py`, `AttentionRegime`) is the first caller, and #405 is what turns the numbers into configured thresholds. Nothing is added to `bnnr.__all__`; `bnnr.analysis` stays internal, as its `__init__` already says.

## Test plan

- `pytest -q` -> **1048 passed, 19 skipped** (26 new).
- `ruff check src tests` clean, `mypy src/bnnr/analysis/saliency_stats.py` clean.
- New coverage: delta map concentration near 1, uniform near 0, border-heavy `border_mass` > 0.9, all-zero map does not divide by zero, resolution recorded and applied, native-vs-upsampled agreement, median reduction ignoring one broken map, mixed resolutions rejected, stable explanation gives shift 0, reversed explanation gives shift near 2, constant map gives 1.0, the top-k region is bit-identical after perturbation while the complement is not, explainer called exactly twice.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [ ] Docs updated if CLI or user-facing behavior changed (internal module, no user-facing surface yet)
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #402
