### PR TITLE
feat(training): hard_quantile_acc and robustness_gap

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,24 @@ The XAI cache is precomputed **after** the baseline phase, so masks from `ICD`/`
 - `candidate_pruning_warmup_epochs` (default: `1`, validated `>0`)
 - `reeval_baseline_per_iteration` (default: `false`)
 
+## Hard-quantile robustness fields
+
+- `hard_quantile_q` (default: `0.2`, validated `(0,1]`)
+
+The fraction of the validation set treated as "hard", ranked by per-sample loss. Every evaluation that caches predictions adds three fields to its metrics:
+
+| field | meaning |
+|---|---|
+| `hard_quantile_acc` | accuracy restricted to the highest-loss `hard_quantile_q` fraction |
+| `robustness_gap` | `overall accuracy - hard_quantile_acc` |
+| `hard_quantile_q` | the `q` those two were computed with |
+
+This is a label-free stand-in for "poor robustness to context shift". Group labels would answer the question directly, but consuming them costs the assumption BNNR is built on: images and labels, nothing else. Inferring the hard group from the loss is what the JTT/EIIL family does instead.
+
+A model that is uniformly mediocre has a small gap. A model that is excellent on the majority and fails a minority has a large one, which is the shape of a shortcut. The attention diagnosis reads `robustness_gap`; on its own it is a diagnostic you can watch.
+
+The loss is plain cross-entropy on the logits the prediction cache already captures, so it costs no second pass over the loader. It is deliberately not the trainer's own criterion: a weighted or label-smoothed criterion ranks samples by class frequency as much as by difficulty, and the ranking is the entire point. The three fields are single-label classification only; multilabel and detection runs do not carry them.
+
 ## Event logging fields
 
 - `event_log_enabled` (default: `true`)

--- a/src/bnnr/config_model.py
+++ b/src/bnnr/config_model.py
@@ -71,6 +71,12 @@ class BNNRConfig(BaseModel):
     # ── Optional baseline re-evaluation per iteration ──
     reeval_baseline_per_iteration: bool = False
 
+    # ── Hard-quantile robustness proxy (FIX-1-3) ──
+    # Fraction of the validation set treated as "hard", by loss. The diagnosis
+    # reads robustness_gap; q is swept by the threshold calibration study, so it
+    # is a knob rather than a constant.
+    hard_quantile_q: float = 0.2
+
     # ── Multi-label-specific fields (ignored when task!="multilabel") ──
     multilabel_threshold: float = 0.5
 
@@ -87,6 +93,13 @@ class BNNRConfig(BaseModel):
     detection_xai_max_gt_boxes: int = 1
     detection_xai_max_pred_boxes: int = 1
     detection_class_names: Optional[list[str]] = None  # noqa: UP045
+
+    @field_validator("hard_quantile_q")
+    @classmethod
+    def validate_hard_quantile_q(cls, value: float) -> float:
+        if value <= 0.0 or value > 1.0:
+            raise ValueError("hard_quantile_q must be in (0, 1]")
+        return value
 
     @field_validator("multilabel_threshold")
     @classmethod

--- a/src/bnnr/training/hard_quantile.py
+++ b/src/bnnr/training/hard_quantile.py
@@ -1,0 +1,86 @@
+"""Accuracy on the hardest validation samples, as a label-free robustness proxy.
+
+The decision rule in the attention diagnosis needs to know whether a model is
+poorly robust to context shift. Group labels would say so directly, but
+consuming them forfeits the assumption-class advantage that is the whole point
+of BNNR: it asks for images and labels and nothing else. The JTT/EIIL family
+solves this by inferring the hard group from the loss, and that is what this
+does.
+
+``hard_quantile_acc`` is accuracy restricted to the highest-loss ``q`` fraction
+of the validation set. ``robustness_gap`` is ``overall_acc - hard_quantile_acc``.
+A model that is uniformly mediocre has a small gap; a model that is excellent on
+the majority and fails a minority has a large one, which is the shape of a
+shortcut.
+
+``q`` is a knob, not a constant. It defaults to 0.2, travels in the evaluation
+result next to the two numbers it produced, and is one of the parameters the
+threshold calibration study sweeps.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "HARD_QUANTILE_KEYS",
+    "hard_quantile_metrics",
+]
+
+#: Keys this module contributes to an evaluation result, so callers that filter
+#: metrics do not have to spell them out one at a time.
+HARD_QUANTILE_KEYS = ("hard_quantile_acc", "robustness_gap", "hard_quantile_q")
+
+
+def hard_quantile_metrics(
+    losses: np.ndarray,
+    correct: np.ndarray,
+    *,
+    q: float,
+) -> dict[str, float]:
+    """Accuracy on the highest-loss ``q`` fraction, and the gap to overall.
+
+    Parameters
+    ----------
+    losses
+        Per-sample loss, shape ``(N,)``. Higher is harder.
+    correct
+        Whether each sample was predicted correctly, shape ``(N,)``, bool or 0/1.
+    q
+        Fraction of the set to treat as hard, in ``(0, 1]``.
+
+    Returns a dict with ``hard_quantile_acc``, ``robustness_gap`` and the ``q``
+    that produced them. An empty input returns an empty dict rather than a
+    fabricated zero: no samples means no measurement, and a 0.0 here would read
+    as a perfectly robust model.
+
+    The count is rounded up, so a small validation set still gets at least one
+    hard sample. Samples that tie on loss at the boundary are ordered by index,
+    which makes the selection deterministic without claiming the tie was broken
+    on anything meaningful.
+    """
+    if not 0.0 < q <= 1.0:
+        raise ValueError(f"q must be in (0, 1], got {q}")
+
+    loss_arr = np.asarray(losses, dtype=np.float64).ravel()
+    correct_arr = np.asarray(correct).astype(bool).ravel()
+    if loss_arr.size != correct_arr.size:
+        raise ValueError(
+            f"losses and correct must have the same length, got {loss_arr.size} and {correct_arr.size}"
+        )
+    if loss_arr.size == 0:
+        return {}
+
+    n = loss_arr.size
+    k = max(1, int(np.ceil(q * n)))
+    # Stable sort so the boundary is broken by index rather than by whatever
+    # order a partition happened to produce.
+    hardest = np.argsort(-loss_arr, kind="stable")[:k]
+
+    overall_acc = float(correct_arr.mean())
+    hard_acc = float(correct_arr[hardest].mean())
+    return {
+        "hard_quantile_acc": hard_acc,
+        "robustness_gap": overall_acc - hard_acc,
+        "hard_quantile_q": float(q),
+    }

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -19,6 +19,7 @@ from bnnr.training import branching as _branching
 from bnnr.training import callbacks as _callbacks
 from bnnr.training import checkpoint as _ckpt
 from bnnr.training import dataset_profile as _dprofile
+from bnnr.training import hard_quantile as _hard_quantile
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
 from bnnr.training import xai_runner as _xai
@@ -83,6 +84,20 @@ def train_epoch(
 
 
 
+def _flatten_labels(labels: torch.Tensor) -> torch.Tensor:
+    """Drop the trailing singleton some datasets carry (MedMNIST returns [B, 1])."""
+    if labels.ndim > 1 and labels.shape[-1] == 1:
+        return labels.squeeze(-1)
+    return labels
+
+
+def _per_sample_loss(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    """Cross-entropy per sample, for ranking validation samples by difficulty."""
+    return torch.nn.functional.cross_entropy(
+        logits.float(), _flatten_labels(labels).long(), reduction="none"
+    )
+
+
 def evaluate(
     trainer: BNNRTrainer,
     loader: DataLoader,
@@ -101,6 +116,13 @@ def evaluate(
     label_rows: list[torch.Tensor] = []
 
     _captured_logits: list[torch.Tensor] = []
+    # Per-sample loss for the hard-quantile metrics. Derived from the logits the
+    # prediction cache already captures, so this costs no second pass over the
+    # loader. It is plain cross-entropy rather than the trainer's criterion:
+    # a weighted or smoothed criterion would rank samples by class frequency as
+    # much as by difficulty, and the ranking is the whole point here.
+    _loss_rows: list[torch.Tensor] = []
+    _correct_rows: list[torch.Tensor] = []
     _hook_handle = None
     if can_cache:
         model_impl = trainer.model.get_model()  # type: ignore[attr-defined]
@@ -139,7 +161,14 @@ def evaluate(
                         (torch.sigmoid(logits) >= trainer.config.multilabel_threshold).int().cpu()
                     )
                 else:
-                    preds_rows.append(torch.argmax(logits, dim=1).cpu())
+                    preds = torch.argmax(logits, dim=1)
+                    preds_rows.append(preds.cpu())
+                    _loss_rows.append(
+                        _per_sample_loss(logits, labels.to(logits.device)).cpu()
+                    )
+                    _correct_rows.append(
+                        (preds.cpu() == _flatten_labels(labels).cpu()).cpu()
+                    )
                 label_rows.append(labels.cpu())
     finally:
         if _hook_handle is not None:
@@ -161,6 +190,15 @@ def evaluate(
         result = avg
     else:
         result = average_metrics(all_metrics)
+
+    if _loss_rows:
+        result.update(
+            _hard_quantile.hard_quantile_metrics(
+                torch.cat(_loss_rows).numpy(),
+                torch.cat(_correct_rows).numpy(),
+                q=trainer.config.hard_quantile_q,
+            )
+        )
 
     if (
         trainer._custom_metrics

--- a/tests/test_hard_quantile.py
+++ b/tests/test_hard_quantile.py
@@ -1,0 +1,166 @@
+"""Tests for the hard-quantile robustness proxy (FIX-1-3)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from bnnr.adapter import SimpleTorchAdapter
+from bnnr.config_model import BNNRConfig
+from bnnr.training.hard_quantile import HARD_QUANTILE_KEYS, hard_quantile_metrics
+
+
+class TestHardQuantileMetrics:
+    def test_hard_quantile_isolates_the_high_loss_tail(self) -> None:
+        # Ten samples; the two hardest are the only wrong ones.
+        losses = np.arange(10, dtype=np.float64)
+        correct = np.ones(10, dtype=bool)
+        correct[8:] = False
+
+        out = hard_quantile_metrics(losses, correct, q=0.2)
+        assert out["hard_quantile_acc"] == pytest.approx(0.0)
+        assert out["robustness_gap"] == pytest.approx(0.8)
+
+    def test_uniformly_mediocre_model_has_no_gap(self) -> None:
+        """The whole point: a small gap is what a model without a shortcut looks
+        like, even when its accuracy is poor."""
+        rng = np.random.default_rng(0)
+        losses = rng.uniform(0.0, 1.0, size=400)
+        correct = rng.random(400) < 0.6  # errors independent of loss rank
+
+        out = hard_quantile_metrics(losses, correct, q=0.2)
+        assert abs(out["robustness_gap"]) < 0.12
+
+    def test_q_is_recorded_with_the_numbers_it_produced(self) -> None:
+        out = hard_quantile_metrics(np.arange(10.0), np.ones(10, dtype=bool), q=0.35)
+        assert out["hard_quantile_q"] == pytest.approx(0.35)
+        assert set(out) == set(HARD_QUANTILE_KEYS)
+
+    def test_q_of_one_is_the_whole_set(self) -> None:
+        losses = np.arange(10, dtype=np.float64)
+        correct = np.array([True] * 6 + [False] * 4)
+        out = hard_quantile_metrics(losses, correct, q=1.0)
+        assert out["hard_quantile_acc"] == pytest.approx(0.6)
+        assert out["robustness_gap"] == pytest.approx(0.0)
+
+    def test_count_rounds_up_so_a_tiny_set_still_gets_one_sample(self) -> None:
+        out = hard_quantile_metrics(np.array([0.1, 5.0]), np.array([True, False]), q=0.2)
+        assert out["hard_quantile_acc"] == pytest.approx(0.0)
+
+    def test_ties_are_broken_by_index_not_arbitrarily(self) -> None:
+        """Every loss equal: the selection must still be deterministic."""
+        losses = np.ones(10)
+        correct = np.array([True] * 5 + [False] * 5)
+        first = hard_quantile_metrics(losses, correct, q=0.3)
+        second = hard_quantile_metrics(losses, correct, q=0.3)
+        assert first == second
+        assert first["hard_quantile_acc"] == pytest.approx(1.0)  # lowest indices
+
+    def test_empty_input_reports_nothing_rather_than_zero(self) -> None:
+        assert hard_quantile_metrics(np.array([]), np.array([]), q=0.2) == {}
+
+    @pytest.mark.parametrize("bad", [0.0, -0.1, 1.5])
+    def test_invalid_q_rejected(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="q must be"):
+            hard_quantile_metrics(np.arange(4.0), np.ones(4, dtype=bool), q=bad)
+
+    def test_length_mismatch_rejected(self) -> None:
+        with pytest.raises(ValueError, match="same length"):
+            hard_quantile_metrics(np.arange(4.0), np.ones(3, dtype=bool), q=0.2)
+
+    def test_integer_correct_is_accepted(self) -> None:
+        out = hard_quantile_metrics(np.arange(4.0), np.array([1, 1, 0, 0]), q=0.5)
+        assert out["hard_quantile_acc"] == pytest.approx(0.0)
+
+
+class TestConfigKnob:
+    def test_default_is_two_tenths(self) -> None:
+        assert BNNRConfig().hard_quantile_q == pytest.approx(0.2)
+
+    @pytest.mark.parametrize("bad", [0.0, -0.5, 1.5])
+    def test_out_of_range_rejected(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="hard_quantile_q"):
+            BNNRConfig(hard_quantile_q=bad)
+
+    def test_one_is_allowed(self) -> None:
+        assert BNNRConfig(hard_quantile_q=1.0).hard_quantile_q == pytest.approx(1.0)
+
+
+class _SeparableHead(nn.Module):
+    """Maps a 1-D feature to two classes, so loss ranks with the feature."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(1, 2)
+        with torch.no_grad():
+            self.linear.weight.copy_(torch.tensor([[-4.0], [4.0]]))
+            self.linear.bias.zero_()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x.view(x.shape[0], -1))
+
+
+class TestEvaluateIntegration:
+    """The numbers must come out of the real evaluation path, no second pass."""
+
+    def _trainer(self, features: torch.Tensor, labels: torch.Tensor, **config_kwargs):
+        from bnnr.trainer import BNNRTrainer
+
+        model = _SeparableHead()
+        adapter = SimpleTorchAdapter(
+            model=model,
+            criterion=nn.CrossEntropyLoss(),
+            optimizer=torch.optim.SGD(model.parameters(), lr=0.0),
+            device="cpu",
+        )
+        loader = DataLoader(TensorDataset(features, labels), batch_size=4)
+        config = BNNRConfig(m_epochs=1, max_iterations=0, **config_kwargs)
+        trainer = BNNRTrainer(
+            model=adapter,
+            train_loader=loader,
+            val_loader=loader,
+            augmentations=[],
+            config=config,
+        )
+        return trainer, loader
+
+    def _data(self) -> tuple[torch.Tensor, torch.Tensor]:
+        # Confident-correct samples first, then samples the head gets wrong.
+        easy = torch.tensor([[2.0]] * 8)
+        hard = torch.tensor([[-2.0]] * 2)
+        features = torch.cat([easy, hard]).unsqueeze(-1).unsqueeze(-1)
+        labels = torch.ones(10, dtype=torch.long)  # class 1 everywhere
+        return features, labels
+
+    def test_metrics_appear_in_the_evaluation_result(self) -> None:
+        features, labels = self._data()
+        trainer, loader = self._trainer(features, labels)
+        result = trainer._evaluate(loader, cache_predictions=True)
+
+        for key in HARD_QUANTILE_KEYS:
+            assert key in result
+
+    def test_the_hard_tail_is_the_misclassified_one(self) -> None:
+        features, labels = self._data()
+        trainer, loader = self._trainer(features, labels)
+        result = trainer._evaluate(loader, cache_predictions=True)
+
+        assert result["hard_quantile_acc"] == pytest.approx(0.0)
+        assert result["robustness_gap"] > 0.5
+
+    def test_configured_q_reaches_the_result(self) -> None:
+        features, labels = self._data()
+        trainer, loader = self._trainer(features, labels, hard_quantile_q=0.5)
+        result = trainer._evaluate(loader, cache_predictions=True)
+        assert result["hard_quantile_q"] == pytest.approx(0.5)
+
+    def test_absent_without_the_prediction_cache(self) -> None:
+        """No cached logits means no per-sample loss, and inventing one would
+        cost the second pass this is written to avoid."""
+        features, labels = self._data()
+        trainer, loader = self._trainer(features, labels)
+        result = trainer._evaluate(loader, cache_predictions=False)
+        assert "hard_quantile_acc" not in result


### PR DESCRIPTION
## Summary

The decision rule in the attention diagnosis needs a label-free proxy for "poor robustness to context shift". Group labels would give it directly, but consuming them forfeits the assumption-class advantage that is the whole point of BNNR: it asks for images and labels and nothing else. The JTT/EIIL family solves this by inferring the hard group from the loss, and that is what this does.

Every evaluation that caches predictions now carries three more fields:

| field | meaning |
|---|---|
| `hard_quantile_acc` | accuracy restricted to the highest-loss `q` fraction |
| `robustness_gap` | `overall_acc - hard_quantile_acc` |
| `hard_quantile_q` | the `q` those two were computed with |

A model that is uniformly mediocre has a small gap. A model that is excellent on the majority and fails a minority has a large one, which is the shape of a shortcut. #403 reads `robustness_gap`; on its own it is a diagnostic you can watch today.

## No second pass

`evaluate()` already registers a forward hook that captures logits for the prediction cache. The per-sample loss comes off those same logits, so the loader is walked exactly as many times as before.

The loss is **plain cross-entropy, not the trainer's criterion**, and that is deliberate. A class-weighted or label-smoothed criterion ranks samples by class frequency as much as by difficulty, and the ranking is the entire point of the statistic. The docstring in `loop.py` says so at the capture site.

## Decisions worth flagging

- **`q` is a knob, not a constant.** `hard_quantile_q` defaults to 0.2, validated `(0, 1]`, and travels *in the evaluation result* beside the numbers it produced, so anything reading the metrics also sees what produced them. #417 sweeps it.
- **The count rounds up.** A small validation set still gets at least one hard sample rather than an empty slice.
- **Ties are ordered by index**, via a stable sort. Deterministic, without pretending the tie was broken on anything meaningful.
- **An empty set reports nothing**, not 0.0. No samples means no measurement, and a 0.0 here reads as a perfectly robust model.
- **Single-label classification only.** Multilabel accuracy has no single definition worth calibrating a threshold against (subset-exact vs per-label give different numbers), and detection has no per-sample loss on this path. Both omit the fields rather than carrying an invented one. Covered by a test.

## On the run record

The issue asks for these in the run record with `q` alongside. There is no `RunRecord` yet, that is #410. What exists today is the metrics dict, which flows into `CheckpointInfo.metrics` and `BNNRRunResult.best_metrics` and is serialised into the report JSON, so the three fields land there already. #410 picks them up from the same place.

## Test plan

- `pytest -q` -> **1078 passed, 19 skipped** (21 new).
- `ruff check src tests` clean, `mypy` clean on the three touched modules.
- New coverage: the hard tail is isolated correctly; a model whose errors are independent of loss rank has a near-zero gap; `q` is recorded with its own output; `q=1.0` degenerates to the whole set with a zero gap; a 2-sample set still gets one hard sample; ties are deterministic; empty input; invalid `q` and length mismatch; integer `correct` accepted; config default, range validation, and `1.0` accepted. Four integration tests drive `trainer._evaluate` end to end with a fixed linear head whose errors sit in a known place, including that the fields are absent without the prediction cache.

## Docs

`docs/configuration.md` gets a `Hard-quantile robustness fields` section: what the three fields mean, why the loss is not the trainer's criterion, and the single-label restriction.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #404
