### PR TITLE
feat(training): CandidateSelector protocol and the SELECTORS registry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,12 +32,28 @@ seed: 42
 - `metrics` (default: `['accuracy', 'f1_macro', 'loss']`)
 - `selection_metric` (default: `accuracy`) — the metric used to select the best augmentation branch. Can be any metric from the tables below.
 - `selection_mode` (`max` or `min`, default: `max`) — use `min` for metrics where lower is better (e.g. `loss`, `zero_one_loss`).
+- `selector` (default: `metric_argmax`) — which rule picks the winning candidate. See below.
 - `early_stopping_patience` (default: `2`)
 - `device` (`cuda`, `cpu`, `auto`; default: `auto`)
 - `seed` (default: `42`)
 - `save_checkpoints` (default: `true`)
 - `verbose` (default: `true`)
 - `log_file` (default: `null`)
+
+## Candidate selectors
+
+`selector` names the rule that picks the winning candidate once every candidate has been evaluated.
+
+| value | rule |
+|---|---|
+| `metric_argmax` (default) | greedy argmax on `selection_metric`, blended with XAI quality when `xai_selection_weight > 0` |
+| `random` | uniform pick among the candidates, seeded from `seed` |
+
+Both are gated the same way: whatever a selector picks is discarded unless it beat the baseline on `selection_metric`. That gate is deliberately shared, so a comparison between two selectors is a comparison of their ranking rules and nothing else. A selector that skipped it would look better purely by accepting runs the others reject.
+
+`random` is not a joke setting. It is the arm the T20 benchmark ran `metric_argmax` against, and `metric_argmax` did not beat it at n=10 across two datasets; having it as a named selector is what makes that contrast reproducible rather than something the benchmark harness improvises.
+
+Changing `selector` does not change what `select_best_path()` is called or how — the function is now a thin adapter over the registry, so existing code picks up the setting without modification.
 
 ## Available metrics
 

--- a/src/bnnr/config_model.py
+++ b/src/bnnr/config_model.py
@@ -26,6 +26,9 @@ class BNNRConfig(BaseModel):
     metrics: list[str] = Field(default_factory=lambda: ["accuracy", "f1_macro", "loss"])
     selection_metric: str = "accuracy"
     selection_mode: str = "max"
+    # Which rule picks the winning candidate. "metric_argmax" is what BNNR has
+    # always done and stays the default; see bnnr.training.selection.SELECTORS.
+    selector: str = "metric_argmax"
 
     # NOTE: For detection tasks, use selection_metric="map_50" (or "map_50_95")
     # and metrics=["map_50", "map_50_95", "loss"].  The model_validator below
@@ -148,6 +151,18 @@ class BNNRConfig(BaseModel):
     def validate_detection_xai_controls(cls, value: int) -> int:
         if value <= 0:
             raise ValueError("detection_xai_* controls must be > 0")
+        return value
+
+    @field_validator("selector")
+    @classmethod
+    def validate_selector(cls, value: str) -> str:
+        # Imported here rather than at module scope: selection imports the
+        # config for typing only, but a top-level import would still be a cycle
+        # waiting for the first runtime import either side adds.
+        from bnnr.training.selection import SELECTORS
+
+        if value not in SELECTORS:
+            raise ValueError(f"selector must be one of {sorted(SELECTORS)}, got {value!r}")
         return value
 
     @field_validator("selection_mode")

--- a/src/bnnr/training/branching.py
+++ b/src/bnnr/training/branching.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from bnnr.training import selection as _selection
+
 if TYPE_CHECKING:
     from bnnr.config_model import BNNRConfig
 
@@ -14,60 +16,17 @@ def select_best_path(
     config: BNNRConfig,
     xai_scores: dict[str, float] | None = None,
 ) -> str | None:
-    """Pick the best augmentation candidate from *results*, or ``None`` if no improvement."""
-    metric = config.selection_metric
-    mode = config.selection_mode
-    w = config.xai_selection_weight
+    """Pick the best augmentation candidate from *results*, or ``None`` if no improvement.
 
-    baseline_value = baseline_metrics.get(metric)
+    Thin adapter over :mod:`bnnr.training.selection`. The logic that used to live
+    here is now ``SELECTORS["metric_argmax"]``, which stays the default, so this
+    returns exactly what it always did. Setting ``config.selector`` routes the
+    same call through a different rule.
 
-    if w <= 0 or not xai_scores:
-        best_name: str | None = None
-        best_value = None
-        for aug_name, aug_metrics in results.items():
-            val = aug_metrics.get(metric)
-            if val is None:
-                continue
-            if best_value is None or (mode == "max" and val > best_value) or (mode == "min" and val < best_value):
-                best_name = aug_name
-                best_value = val
-        if best_name is None or baseline_value is None or best_value is None:
-            return None
-        improved = (best_value > baseline_value) if mode == "max" else (best_value < baseline_value)
-        return best_name if improved else None
-
-    metric_vals = {name: m.get(metric) for name, m in results.items() if m.get(metric) is not None}
-    if not metric_vals:
-        return None
-
-    all_vals = list(metric_vals.values())
-    min_m = min(v for v in all_vals if v is not None)
-    max_m = max(v for v in all_vals if v is not None)
-    m_range = max_m - min_m if max_m != min_m else 1.0  # type: ignore[operator]
-
-    best_name = None
-    best_composite: float | None = None
-    for aug_name, val in metric_vals.items():
-        if val is None:
-            continue
-        if mode == "max":
-            norm_m = (float(val) - float(min_m)) / float(m_range)  # type: ignore[arg-type]
-        else:
-            norm_m = (float(max_m) - float(val)) / float(m_range)  # type: ignore[arg-type]
-        xai_q = xai_scores.get(aug_name, 0.0)
-        composite = (1.0 - w) * norm_m + w * xai_q
-        if best_composite is None or composite > best_composite:
-            best_composite = composite
-            best_name = aug_name
-
-    if best_name is None or baseline_value is None:
-        return None
-
-    best_value = results[best_name].get(metric)
-    if best_value is None:
-        return None
-    improved = (best_value > baseline_value) if mode == "max" else (best_value < baseline_value)
-    return best_name if improved else None
+    Kept at this name and signature on purpose: it is public surface, imported
+    by ``tests/test_backward_compat.py`` and re-exported from ``bnnr.training``.
+    """
+    return _selection.run_selector(results, baseline_metrics, config, xai_scores).best
 
 
 def should_prune_candidate(

--- a/src/bnnr/training/selection.py
+++ b/src/bnnr/training/selection.py
@@ -92,7 +92,7 @@ class CandidateSelector(Protocol):
         config: BNNRConfig,
     ) -> SelectionResult:
         """Pick from *candidates*, or select nothing."""
-        ...
+        raise NotImplementedError
 
 
 def _resolved_values(candidates: list[CandidateReport], metric: str) -> dict[str, float]:

--- a/src/bnnr/training/selection.py
+++ b/src/bnnr/training/selection.py
@@ -1,0 +1,260 @@
+"""Candidate selection as a named, swappable component.
+
+Selection used to be a branch inside ``select_best_path`` plus a composite score
+with a weight nobody calibrated. That shape has two costs. The benchmark cannot
+record *which* rule ran, so a contrast between two rules is not expressible; and
+a new rule cannot compete with argmax on equal terms, because argmax is not a
+thing you can name, it is the shape of the function.
+
+This module makes the rule explicit. A selector takes the candidates, the
+baseline and the config, and returns a :class:`SelectionResult` that says what
+it picked, on what scores, and why. ``SELECTORS`` maps a config string to one.
+
+Nothing here changes default behaviour. ``metric_argmax`` is the logic
+``select_best_path`` has always run, moved rather than rewritten, and it stays
+the default. ``select_best_path`` keeps its name, signature and ``str | None``
+return, and is now a thin adapter over the registry.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from bnnr.config_model import BNNRConfig
+
+__all__ = [
+    "SELECTORS",
+    "CandidateReport",
+    "CandidateSelector",
+    "SelectionResult",
+    "get_selector",
+    "run_selector",
+]
+
+
+@dataclass(frozen=True)
+class CandidateReport:
+    """One candidate as a selector sees it.
+
+    ``metrics`` is the candidate's evaluation result, so a selector reads the
+    configured selection metric out of it rather than being handed a single
+    pre-chosen number. That is what lets a selector look at something other
+    than the metric being optimised, which is the entire point of the exercise.
+    """
+
+    name: str
+    metrics: dict[str, float]
+    xai_score: float | None = None
+
+    def value(self, metric: str) -> float | None:
+        """The named metric, or ``None`` when this candidate did not report it."""
+        raw = self.metrics.get(metric)
+        return None if raw is None else float(raw)
+
+
+@dataclass(frozen=True)
+class SelectionResult:
+    """What a selector decided, and enough context to explain it afterwards.
+
+    ``selected`` is a tuple rather than a single name. Today every selector
+    returns zero or one, but a policy that advances several candidates at once
+    (successive halving, FIX-4-1) needs the plural, and widening the type later
+    would be the breaking change this avoids.
+
+    ``reason`` is a short machine-readable slug, not prose: ``"improved"``,
+    ``"no_improvement"``, ``"no_candidates"``. The run record stores it.
+    """
+
+    selected: tuple[str, ...]
+    selector: str
+    reason: str
+    scores: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def best(self) -> str | None:
+        """The single selected name, for callers that only handle one."""
+        return self.selected[0] if self.selected else None
+
+
+class CandidateSelector(Protocol):
+    """Chooses which candidate augmentation to keep, if any."""
+
+    name: str
+
+    def select(
+        self,
+        candidates: list[CandidateReport],
+        baseline: dict[str, float],
+        config: BNNRConfig,
+    ) -> SelectionResult:
+        """Pick from *candidates*, or select nothing."""
+        ...
+
+
+def _resolved_values(candidates: list[CandidateReport], metric: str) -> dict[str, float]:
+    """Candidates that reported *metric*, in their original order."""
+    resolved = {}
+    for candidate in candidates:
+        value = candidate.value(metric)
+        if value is not None:
+            resolved[candidate.name] = value
+    return resolved
+
+
+def _improved(value: float, baseline_value: float, mode: str) -> bool:
+    return value > baseline_value if mode == "max" else value < baseline_value
+
+
+def _gate_on_baseline(
+    name: str,
+    candidates: list[CandidateReport],
+    baseline: dict[str, float],
+    config: BNNRConfig,
+    selector: str,
+    scores: dict[str, float],
+) -> SelectionResult:
+    """Apply the shared rule: a pick only counts if it beat the baseline.
+
+    Every selector goes through this, so a contrast between two selectors is a
+    contrast between their ranking rules and nothing else. A selector that
+    skipped the gate would look better simply by accepting runs the others
+    rejected.
+    """
+    baseline_value = baseline.get(config.selection_metric)
+    chosen = next((c for c in candidates if c.name == name), None)
+    value = chosen.value(config.selection_metric) if chosen is not None else None
+
+    if baseline_value is None or value is None:
+        return SelectionResult((), selector, "no_baseline", scores)
+    if not _improved(value, float(baseline_value), config.selection_mode):
+        return SelectionResult((), selector, "no_improvement", scores)
+    return SelectionResult((name,), selector, "improved", scores)
+
+
+class MetricArgmaxSelector:
+    """Greedy argmax on the selection metric, optionally blended with XAI quality.
+
+    This is what BNNR has always done, moved here unchanged. Two paths, chosen
+    by ``xai_selection_weight``:
+
+    ``w <= 0`` or no XAI scores
+        Plain argmax on the selection metric.
+    ``w > 0``
+        Composite of a min-max normalised metric and the XAI quality score.
+
+    The composite path is the one T20 found wanting: the normalisation stretches
+    whatever spread the candidates happened to have across the full [0, 1] range,
+    so on a saturated metric the weight is applied to scatter rather than to
+    signal. FIX-2-2 replaces the scale and FIX-2-4 deprecates the weight; both
+    are deliberately out of scope here, because this change has to be provably
+    behaviour-preserving before anything is allowed to alter what it does.
+    """
+
+    name = "metric_argmax"
+
+    def select(
+        self,
+        candidates: list[CandidateReport],
+        baseline: dict[str, float],
+        config: BNNRConfig,
+    ) -> SelectionResult:
+        metric = config.selection_metric
+        mode = config.selection_mode
+        weight = config.xai_selection_weight
+
+        values = _resolved_values(candidates, metric)
+        if not values:
+            return SelectionResult((), self.name, "no_candidates", {})
+
+        has_xai = any(c.xai_score is not None for c in candidates)
+        if weight <= 0 or not has_xai:
+            sign = 1.0 if mode == "max" else -1.0
+            best_name = max(values, key=lambda name: sign * values[name])
+            return _gate_on_baseline(best_name, candidates, baseline, config, self.name, values)
+
+        lo, hi = min(values.values()), max(values.values())
+        span = hi - lo if hi != lo else 1.0
+        xai_by_name = {c.name: (c.xai_score or 0.0) for c in candidates}
+
+        scores = {}
+        for name, value in values.items():
+            normalised = (value - lo) / span if mode == "max" else (hi - value) / span
+            scores[name] = (1.0 - weight) * normalised + weight * xai_by_name.get(name, 0.0)
+
+        best_name = max(scores, key=lambda name: scores[name])
+        return _gate_on_baseline(best_name, candidates, baseline, config, self.name, scores)
+
+
+class RandomSelector:
+    """Uniform pick among the candidates, still gated on beating the baseline.
+
+    This is the arm T20 benchmarked ``selection_mode="xai"`` against and failed
+    to beat, so it exists as a first-class selector rather than as something the
+    benchmark harness improvises. Seeded from ``config.seed`` so a run is
+    reproducible; the seed is mixed with the candidate names, otherwise every
+    iteration of a run with the same arity would make the same choice.
+    """
+
+    name = "random"
+
+    def select(
+        self,
+        candidates: list[CandidateReport],
+        baseline: dict[str, float],
+        config: BNNRConfig,
+    ) -> SelectionResult:
+        values = _resolved_values(candidates, config.selection_metric)
+        if not values:
+            return SelectionResult((), self.name, "no_candidates", {})
+
+        # Not hash(): Python randomises str hashing per process, so a run would
+        # not reproduce across invocations, which is the one thing the seed is for.
+        digest = hashlib.sha256(
+            "\x00".join([str(config.seed), *sorted(values)]).encode()
+        ).digest()
+        rng = random.Random(int.from_bytes(digest[:8], "big"))
+        picked = rng.choice(sorted(values))
+        scores = {name: (1.0 if name == picked else 0.0) for name in values}
+        return _gate_on_baseline(picked, candidates, baseline, config, self.name, scores)
+
+
+SELECTORS: dict[str, CandidateSelector] = {
+    MetricArgmaxSelector.name: MetricArgmaxSelector(),
+    RandomSelector.name: RandomSelector(),
+}
+
+
+def get_selector(name: str) -> CandidateSelector:
+    """Look up a selector by its config name."""
+    try:
+        return SELECTORS[name]
+    except KeyError:
+        raise ValueError(
+            f"Unknown selector {name!r}. Available: {sorted(SELECTORS)}"
+        ) from None
+
+
+def run_selector(
+    results: dict[str, dict[str, float]],
+    baseline_metrics: dict[str, float],
+    config: BNNRConfig,
+    xai_scores: dict[str, float] | None = None,
+) -> SelectionResult:
+    """Build the candidate reports and run the configured selector over them."""
+    candidates = [
+        CandidateReport(
+            name=name,
+            metrics=metrics,
+            # A non-empty dict whose keys miss this candidate still means "XAI
+            # scoring is on", and the legacy code scored the miss as 0.0. None
+            # is reserved for "no XAI scoring at all", which is the condition
+            # that selects the plain-argmax path.
+            xai_score=(xai_scores.get(name, 0.0) if xai_scores else None),
+        )
+        for name, metrics in results.items()
+    ]
+    return get_selector(config.selector).select(candidates, baseline_metrics, config)

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,273 @@
+"""Tests for bnnr.training.selection (FIX-2-1)."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from bnnr.config_model import BNNRConfig
+from bnnr.training.branching import select_best_path
+from bnnr.training.selection import (
+    SELECTORS,
+    CandidateReport,
+    SelectionResult,
+    get_selector,
+    run_selector,
+)
+
+
+def _config(**overrides) -> BNNRConfig:
+    return BNNRConfig(**overrides)
+
+
+# ---------------------------------------------------------------------------
+# The reference implementation, copied verbatim from branching.py as it stood
+# before this change. The differential test below is the actual proof that
+# metric_argmax is behaviour-preserving; hand-written cases only cover what
+# someone thought to write down.
+# ---------------------------------------------------------------------------
+
+
+def _legacy_select_best_path(results, baseline_metrics, config, xai_scores=None):
+    metric = config.selection_metric
+    mode = config.selection_mode
+    w = config.xai_selection_weight
+
+    baseline_value = baseline_metrics.get(metric)
+
+    if w <= 0 or not xai_scores:
+        best_name = None
+        best_value = None
+        for aug_name, aug_metrics in results.items():
+            val = aug_metrics.get(metric)
+            if val is None:
+                continue
+            if best_value is None or (mode == "max" and val > best_value) or (mode == "min" and val < best_value):
+                best_name = aug_name
+                best_value = val
+        if best_name is None or baseline_value is None or best_value is None:
+            return None
+        improved = (best_value > baseline_value) if mode == "max" else (best_value < baseline_value)
+        return best_name if improved else None
+
+    metric_vals = {name: m.get(metric) for name, m in results.items() if m.get(metric) is not None}
+    if not metric_vals:
+        return None
+
+    all_vals = list(metric_vals.values())
+    min_m = min(v for v in all_vals if v is not None)
+    max_m = max(v for v in all_vals if v is not None)
+    m_range = max_m - min_m if max_m != min_m else 1.0
+
+    best_name = None
+    best_composite = None
+    for aug_name, val in metric_vals.items():
+        if val is None:
+            continue
+        if mode == "max":
+            norm_m = (float(val) - float(min_m)) / float(m_range)
+        else:
+            norm_m = (float(max_m) - float(val)) / float(m_range)
+        xai_q = xai_scores.get(aug_name, 0.0)
+        composite = (1.0 - w) * norm_m + w * xai_q
+        if best_composite is None or composite > best_composite:
+            best_composite = composite
+            best_name = aug_name
+
+    if best_name is None or baseline_value is None:
+        return None
+
+    best_value = results[best_name].get(metric)
+    if best_value is None:
+        return None
+    improved = (best_value > baseline_value) if mode == "max" else (best_value < baseline_value)
+    return best_name if improved else None
+
+
+class TestMetricArgmaxIsBehaviourPreserving:
+    """The default path must return what it returned before the refactor."""
+
+    @pytest.mark.parametrize("trial", range(300))
+    def test_matches_the_legacy_implementation(self, trial: int) -> None:
+        rng = random.Random(trial)
+        mode = rng.choice(["max", "min"])
+        weight = rng.choice([0.0, 0.0, 0.1, 0.5, 0.9, 1.0])
+        config = _config(selection_mode=mode, xai_selection_weight=weight)
+
+        n = rng.randint(1, 5)
+        names = [f"aug_{i}" for i in range(n)]
+        results = {}
+        for name in names:
+            if rng.random() < 0.15:
+                results[name] = {}  # candidate that never reported the metric
+            else:
+                # Deliberately include near-ties and exact ties.
+                results[name] = {"accuracy": round(rng.uniform(0.80, 0.86), rng.choice([2, 4]))}
+
+        baseline = {"accuracy": round(rng.uniform(0.78, 0.86), 3)}
+        if rng.random() < 0.1:
+            baseline = {}
+
+        xai_scores = None
+        if rng.random() < 0.6:
+            xai_scores = {name: round(rng.random(), 3) for name in names if rng.random() < 0.8}
+
+        expected = _legacy_select_best_path(results, baseline, config, xai_scores)
+        assert select_best_path(results, baseline, config, xai_scores) == expected
+
+    def test_exact_tie_keeps_the_first_candidate(self) -> None:
+        """Legacy used a strict >, so ties resolved to insertion order."""
+        results = {"aug_a": {"accuracy": 0.9}, "aug_b": {"accuracy": 0.9}}
+        baseline = {"accuracy": 0.5}
+        assert select_best_path(results, baseline, _config()) == "aug_a"
+
+    def test_non_empty_xai_dict_with_no_matching_keys_uses_composite(self) -> None:
+        """Legacy branched on the dict being non-empty, not on any candidate
+        actually having a score. At w=1.0 that is observable: every composite is
+        0.0, so the first candidate wins rather than the best-scoring one."""
+        results = {"aug_a": {"accuracy": 0.80}, "aug_b": {"accuracy": 0.90}}
+        baseline = {"accuracy": 0.50}
+        config = _config(xai_selection_weight=1.0)
+        stranger = {"not_a_candidate": 0.7}
+        assert select_best_path(results, baseline, config, stranger) == _legacy_select_best_path(
+            results, baseline, config, stranger
+        )
+
+
+class TestSelectionResult:
+    def test_selected_is_a_tuple(self) -> None:
+        result = run_selector(
+            {"aug_a": {"accuracy": 0.9}}, {"accuracy": 0.5}, _config()
+        )
+        assert isinstance(result.selected, tuple)
+        assert result.selected == ("aug_a",)
+
+    def test_best_is_none_when_nothing_selected(self) -> None:
+        result = run_selector(
+            {"aug_a": {"accuracy": 0.4}}, {"accuracy": 0.5}, _config()
+        )
+        assert result.selected == ()
+        assert result.best is None
+
+    @pytest.mark.parametrize(
+        ("results", "baseline", "reason"),
+        [
+            ({"aug_a": {"accuracy": 0.9}}, {"accuracy": 0.5}, "improved"),
+            ({"aug_a": {"accuracy": 0.4}}, {"accuracy": 0.5}, "no_improvement"),
+            ({}, {"accuracy": 0.5}, "no_candidates"),
+            ({"aug_a": {"accuracy": 0.9}}, {}, "no_baseline"),
+        ],
+    )
+    def test_reason_is_a_slug_describing_the_outcome(self, results, baseline, reason) -> None:
+        assert run_selector(results, baseline, _config()).reason == reason
+
+    def test_scores_carry_what_was_ranked(self) -> None:
+        result = run_selector(
+            {"aug_a": {"accuracy": 0.9}, "aug_b": {"accuracy": 0.8}},
+            {"accuracy": 0.5},
+            _config(),
+        )
+        assert result.scores == {"aug_a": 0.9, "aug_b": 0.8}
+
+    def test_selector_name_is_recorded(self) -> None:
+        result = run_selector({"aug_a": {"accuracy": 0.9}}, {"accuracy": 0.5}, _config())
+        assert result.selector == "metric_argmax"
+
+
+class TestCandidateReport:
+    def test_value_reads_the_named_metric(self) -> None:
+        report = CandidateReport("aug_a", {"accuracy": 0.9, "f1_macro": 0.7})
+        assert report.value("f1_macro") == pytest.approx(0.7)
+
+    def test_missing_metric_is_none_not_zero(self) -> None:
+        assert CandidateReport("aug_a", {}).value("accuracy") is None
+
+    def test_xai_score_defaults_to_none(self) -> None:
+        assert CandidateReport("aug_a", {}).xai_score is None
+
+
+class TestRandomSelector:
+    def test_switching_selector_changes_the_choice(self) -> None:
+        """The point of the registry: the same call, a different rule."""
+        results = {f"aug_{i}": {"accuracy": 0.80 + i * 0.01} for i in range(5)}
+        baseline = {"accuracy": 0.5}
+
+        argmax = run_selector(results, baseline, _config()).best
+        assert argmax == "aug_4"  # the highest accuracy
+
+        picks = {
+            run_selector(results, baseline, _config(selector="random", seed=s)).best
+            for s in range(30)
+        }
+        assert len(picks) > 1  # not always the argmax winner
+        assert picks <= set(results)
+
+    def test_is_reproducible_for_a_seed(self) -> None:
+        results = {f"aug_{i}": {"accuracy": 0.8} for i in range(5)}
+        baseline = {"accuracy": 0.5}
+        config = _config(selector="random", seed=7)
+        first = run_selector(results, baseline, config).best
+        second = run_selector(results, baseline, config).best
+        assert first == second
+
+    def test_seed_is_not_python_hash_dependent(self) -> None:
+        """A hash()-derived seed would differ between processes, which defeats
+        the point of seeding at all. Assert against a value computed from the
+        stable digest instead."""
+        import hashlib
+
+        names = sorted(f"aug_{i}" for i in range(5))
+        digest = hashlib.sha256("\x00".join(["7", *names]).encode()).digest()
+        expected_rng = random.Random(int.from_bytes(digest[:8], "big"))
+        expected = expected_rng.choice(names)
+
+        results = {name: {"accuracy": 0.8} for name in names}
+        got = run_selector(results, {"accuracy": 0.5}, _config(selector="random", seed=7)).best
+        assert got == expected
+
+    def test_still_gated_on_beating_the_baseline(self) -> None:
+        """A random arm that skipped the gate would look better than argmax by
+        accepting runs argmax rejects."""
+        results = {f"aug_{i}": {"accuracy": 0.4} for i in range(5)}
+        result = run_selector(results, {"accuracy": 0.9}, _config(selector="random"))
+        assert result.selected == ()
+        assert result.reason == "no_improvement"
+
+    def test_select_best_path_honours_the_configured_selector(self) -> None:
+        """The legacy entry point routes through the registry too."""
+        results = {f"aug_{i}": {"accuracy": 0.80 + i * 0.01} for i in range(5)}
+        baseline = {"accuracy": 0.5}
+        seeds_giving_non_argmax = [
+            s
+            for s in range(30)
+            if select_best_path(results, baseline, _config(selector="random", seed=s)) != "aug_4"
+        ]
+        assert seeds_giving_non_argmax
+
+
+class TestRegistry:
+    def test_default_selector_is_metric_argmax(self) -> None:
+        assert BNNRConfig().selector == "metric_argmax"
+
+    def test_both_selectors_are_registered(self) -> None:
+        assert set(SELECTORS) == {"metric_argmax", "random"}
+
+    def test_unknown_selector_rejected_by_config(self) -> None:
+        with pytest.raises(ValueError, match="selector must be one of"):
+            BNNRConfig(selector="vibes")
+
+    def test_unknown_selector_rejected_by_lookup(self) -> None:
+        with pytest.raises(ValueError, match="Unknown selector"):
+            get_selector("vibes")
+
+    def test_every_registered_selector_satisfies_the_protocol(self) -> None:
+        for name, selector in SELECTORS.items():
+            assert selector.name == name
+            result = selector.select(
+                [CandidateReport("aug_a", {"accuracy": 0.9})],
+                {"accuracy": 0.5},
+                _config(),
+            )
+            assert isinstance(result, SelectionResult)
+            assert isinstance(result.selected, tuple)


### PR DESCRIPTION
## Summary

Selection was a branch inside `select_best_path` plus a composite score with a weight nobody calibrated. That shape has two costs:

- the benchmark cannot record *which* rule ran, so a contrast between two rules is not expressible;
- a new rule cannot compete with argmax on equal terms, because argmax is not a thing you can name, it is the shape of the function.

New `src/bnnr/training/selection.py` makes the rule explicit:

| piece | what it is |
|---|---|
| `CandidateReport` | one candidate as a selector sees it: name, full metrics dict, optional XAI score |
| `SelectionResult` | `selected` (tuple), `selector`, `reason` slug, `scores` |
| `CandidateSelector` | the Protocol |
| `SELECTORS` | `{"metric_argmax", "random"}` |
| `selector` | new config field, default `"metric_argmax"` |

`select_best_path` keeps its name, signature and `str | None` return, and is now a thin adapter over the registry. Setting `selector` routes every existing caller through a different rule with no code change.

## Behaviour preservation is proved, not asserted

The issue's bar is "byte-identical by default". Hand-written cases only cover what someone thought to write down, so `tests/test_selection.py` carries **the pre-change implementation verbatim** and runs 300 randomised trials against it: both weight paths, `max` and `min`, exact ties, near-ties at 2 and 4 decimal places, candidates missing the metric, and a missing baseline.

To check the test is not vacuous I inverted a single comparison in the new code: **78 of the 300 trials fail.** Restored, all pass.

Two details the differential test pinned down that a from-scratch rewrite would have quietly lost:

- an exact tie resolves to **insertion order**, because the legacy loop used a strict `>`;
- a non-empty `xai_scores` dict whose keys match **no** candidate still takes the composite path. Legacy branched on `not xai_scores`, i.e. on the dict being non-empty, not on any candidate actually having a score. At `weight=1.0` that is observable: every composite is 0.0, so the first candidate wins rather than the best-scoring one. `run_selector` reproduces it by mapping a present-but-missing key to `0.0` and reserving `None` for "no XAI scoring at all".

`tests/test_training_branching.py`, `test_backward_compat.py`, `test_core.py` and `test_training_loop.py` pass **untouched**.

## Decisions worth flagging

**One shared baseline gate.** Every selector returns nothing unless its pick beat the baseline on `selection_metric`. A selector that skipped the gate would look better than the others purely by accepting runs they reject, which would make every future comparison meaningless. It lives in `_gate_on_baseline`, not in each selector.

**`random` is not a joke setting.** It is the arm T20 ran `metric_argmax` against, and `metric_argmax` did not beat it at n=10 across two datasets. Making it a named selector is what makes that contrast reproducible instead of something the benchmark harness improvises.

**`selected` is a tuple.** Every selector here returns zero or one name. Successive halving (#413) advances several, and widening the type then would be the breaking change this avoids.

**The random seed is a sha256, not `hash()`.** Python randomises `str` hashing per process, so a `hash()`-derived seed would not reproduce across invocations, which is the one thing a seed is for. There is a test asserting the choice against an independently computed digest.

**Scope held deliberately narrow.** `metric_argmax` is moved, not improved. The min-max normalisation T20 criticised is still there, unchanged, because this change has to be provably behaviour-preserving before anything is allowed to alter what it does. #407 replaces the scale, #409 deprecates the weight.

## Not in this PR

The `diagnosis` selector (step 3) needs #403, which I also have; it lands there. Recording `selector` in the run record is #410, which depends on this.

## Compatibility

- Nothing added to `bnnr.__all__`; `selection` stays internal, as the issue recommends. Both snapshot lists in `test_backward_compat.py` are untouched and pass.
- `bnnr.training.__all__` also unchanged.
- `select_best_path` and `should_prune_candidate` keep their names and signatures.

## Test plan

- `pytest -q` -> **1401 passed, 19 skipped** (323 new, of which 300 are the differential trials).
- `ruff check src tests` clean; `mypy` clean on all three touched modules, with no new `type: ignore`.
- Mutation check described above.

## Docs

`docs/configuration.md` gains a `Candidate selectors` section covering both rules, the shared gate and why it is shared, and a note that `select_best_path` picks the setting up without modification.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #406
