### PR TITLE
feat(analysis): AttentionRegime and the attention decision rule

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Use this as the starting point when you need the shortest path to the page relev
 - `integrations.md` — pytorch-grad-cam and Ultralytics YOLO integration hub + stable URLs
 - `citation.md` — how to cite BNNR (and grad-cam / Ultralytics stacks when applicable)
 - `augmentations.md` — presets and augmentation classes available in code
+- `diagnosis.md` — the attention diagnosis: which of ICD/AICD the evidence points at, and why its thresholds have no defaults
 - `detection.md` — object detection guide (adapters, augmentations, config, metrics, XAI)
 - `examples.md` — production usage guide for Python scripts under `examples/` (by subdirectory)
 - `notebooks.md` — notebook execution and validation guide

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,11 @@ seed: 42
 |---|---|
 | `metric_argmax` (default) | greedy argmax on `selection_metric`, blended with XAI quality when `xai_selection_weight > 0` |
 | `random` | uniform pick among the candidates, seeded from `seed` |
+| `diagnosis` | picks the family the attention diagnosis recommends; see [diagnosis](diagnosis.md) |
 
 Both are gated the same way: whatever a selector picks is discarded unless it beat the baseline on `selection_metric`. That gate is deliberately shared, so a comparison between two selectors is a comparison of their ranking rules and nothing else. A selector that skipped it would look better purely by accepting runs the others reject.
+
+`diagnosis` needs calibrated thresholds and a `Diagnosis` for the iteration. Without one it selects nothing rather than falling back to argmax, because a silent fallback would make a benchmark contrast between the two measure a blend of them.
 
 `random` is not a joke setting. It is the arm the T20 benchmark ran `metric_argmax` against, and `metric_argmax` did not beat it at n=10 across two datasets; having it as a named selector is what makes that contrast reproducible rather than something the benchmark harness improvises.
 

--- a/docs/diagnosis.md
+++ b/docs/diagnosis.md
@@ -1,0 +1,92 @@
+# Attention diagnosis
+
+## What it is
+
+ICD and AICD are opposite operations on attention. ICD masks what the model is already looking at, forcing it to find something else. AICD masks everything else, sharpening what it has. Applying the wrong one is not a small loss — it is an intervention pointed the wrong way.
+
+Which one is right depends on where attention already is, and that is measurable from the saliency maps BNNR computes anyway. `bnnr.analysis.diagnosis` does the measuring and returns a `Diagnosis`: the regime, what it recommends, how confident it is, and every number that produced the answer.
+
+## Why it exists
+
+`selection_mode="xai"` never used saliency to arbitrate. It was a greedy argmax on selection-validation accuracy, and the T20 benchmark found that criterion close to orthogonal to the objective: on Waterbirds it sits at ~97% while the objective sits at 59%, and candidate accuracies differ by fractions of a point. So the selector took an argmax over sub-point differences in a saturated, majority-dominated quantity in order to choose an intervention whose entire purpose is to fix a minority-group failure. It was null at n=10 across two datasets and three protocols.
+
+## The inputs
+
+Everything the rule reads is computed from images and labels alone:
+
+| input | where it comes from |
+|---|---|
+| `concentration`, `border_mass`, `perturbation_shift` | `bnnr.analysis.saliency_stats` |
+| `overall_acc`, `hard_quantile_acc` | the evaluation result (see `hard_quantile_q` in [configuration](configuration.md)) |
+
+**No mask-derived quantity enters the rule.** Not EBPG, not anything needing annotation. That is not an aesthetic preference. BNNR's structural advantage is that it asks for nothing beyond images and labels; a rule that consumes masks stops being deployable and turns BNNR into a different method with a different assumption class. SpuriousBench masks validate this rule from the outside — they never run inside it.
+
+## The rule
+
+Two gates, then a conjunction count.
+
+**Gate 1 — the robustness gap.** With `robustness_gap` at or below `robustness_gap_hi` there is no robustness failure to act on, and the regime is `UNSTRUCTURED` regardless of what the maps look like. A directed intervention needs something to fix.
+
+**Gate 2 — usable structure.** With `concentration` inside the `[concentration_lo, concentration_hi]` band the map is neither diffuse nor concentrated, so it cannot discriminate, and the regime is `UNSTRUCTURED`.
+
+Past both gates, each regime's four-clause conjunction is evaluated:
+
+| regime | clauses | recommends |
+|---|---|---|
+| `SHORTCUT_SUSPECTED` | diffuse, border-heavy, unstable, real gap | ICD |
+| `OBJECT_FOCUSED` | concentrated, central, stable, real gap | AICD |
+| `UNSTRUCTURED` | — | ChurchNoise or plain training |
+
+The regime with more satisfied clauses wins. A tie goes to the regime whose weakest clause has the larger margin — the one that is *less nearly false* — so the decision is reproducible rather than dependent on evaluation order.
+
+## Confidence
+
+`confidence` is the fraction of the winning regime's four clauses that hold: one of `0.0`, `0.25`, `0.5`, `0.75`, `1.0`.
+
+It is a count, not a weighted score, and that is the point. A weighted scalar here would be another uncalibrated number of exactly the kind this programme is removing. For `UNSTRUCTURED` it is the fraction of clauses supporting *neither* intervention, so a firm "do nothing" and a borderline one are distinguishable.
+
+`Diagnosis.criteria` carries every clause with its value, its threshold and its margin, so any answer can be reconstructed from the record without re-running anything.
+
+## Thresholds have no defaults
+
+Every threshold in `DiagnosisThresholds` starts at `None`, and `require()` raises `MissingThresholdsError` until they are supplied.
+
+This is deliberate and it is the whole discipline of the exercise. Guessing them now would repeat exactly the mistake that produced `xai_selection_weight` and its preset values of 0.1 and 0.15: numbers nobody measured, shipped as defaults, driving selection for every user. Calibration is a separate, pre-registered study.
+
+| threshold | separates |
+|---|---|
+| `concentration_lo` / `concentration_hi` | diffuse / no structure / concentrated |
+| `border_mass_hi` | central from border-heavy |
+| `perturbation_shift_hi` | stable from unstable |
+| `robustness_gap_hi` | a gap worth acting on from noise |
+| `min_confidence` | acted on from not acted on (not required by the rule itself) |
+
+**Shadow mode needs none of this.** It records the raw statistics rather than a regime, so it can start collecting calibration samples from every run that was going to happen anyway, at no extra GPU cost, before any threshold exists.
+
+## Using it as a selector
+
+`selector: diagnosis` picks the candidate whose family matches the recommendation, with the selection metric breaking ties *within* that family — the diagnosis says which kind of intervention, not which hyperparameters of it.
+
+Without a diagnosis it selects nothing, with reason `no_diagnosis`. It does not quietly fall back to argmax: a silent fallback would make any benchmark contrast between this selector and argmax measure a blend of the two. An explicit, recorded low-confidence fallback is a policy decision and belongs in the policy layer.
+
+```python
+from bnnr.analysis.diagnosis import DiagnosisThresholds, diagnose
+
+diagnosis = diagnose(
+    stats,                       # aggregate SaliencyStats for the run
+    overall_acc=metrics["accuracy"],
+    hard_quantile_acc=metrics["hard_quantile_acc"],
+    thresholds=DiagnosisThresholds(
+        concentration_lo=...,    # from your calibration, not from us
+        concentration_hi=...,
+        border_mass_hi=...,
+        perturbation_shift_hi=...,
+        robustness_gap_hi=...,
+    ),
+)
+print(diagnosis.regime, diagnosis.recommended, diagnosis.confidence)
+```
+
+## Known limitation
+
+`perturbation_shift` is optional; when it was not measured the rule reads it as perfectly stable. That pushes the answer towards `OBJECT_FOCUSED` (sharpen what is there) rather than `SHORTCUT_SUSPECTED` (replace it), on the grounds that sharpening a model that did not need it is the cheaper mistake. It is a stated bias, not a neutral default, and a calibration run should supply the statistic rather than rely on it.

--- a/src/bnnr/analysis/diagnosis.py
+++ b/src/bnnr/analysis/diagnosis.py
@@ -1,0 +1,364 @@
+"""Which intervention the attention evidence points at, and how strongly.
+
+``selection_mode="xai"`` never used saliency to arbitrate. It was a greedy
+argmax on selection-validation accuracy, and T20 found that criterion close to
+orthogonal to the objective: on Waterbirds it sits at ~97% while the objective
+sits at 59%, and candidate accuracies differ by fractions of a point. So the
+selector took an argmax over sub-point differences in a saturated,
+majority-dominated quantity in order to choose an intervention whose entire
+purpose is to fix a minority-group failure.
+
+ICD and AICD are opposite operations on attention. ICD masks what the model is
+already looking at, forcing it to find something else; AICD masks everything
+else, sharpening what it has. Which one is right depends on where attention
+already is, and that is measurable. This module does the measuring.
+
+**Everything here is computed from images and labels alone.** No EBPG, no
+mask-derived quantity, nothing that needs annotation. That is not an aesthetic
+preference: a rule that consumes masks stops being deployable and turns BNNR
+into a different method with a different assumption class. SpuriousBench masks
+validate this rule from the outside; they never run inside it.
+
+**No threshold has a default.** Guessing them now would repeat exactly the
+mistake that produced ``xai_selection_weight`` and its preset values of 0.1 and
+0.15: numbers nobody measured, shipped as defaults, driving selection for every
+user. :class:`DiagnosisThresholds` starts fully ``None`` and
+:meth:`DiagnosisThresholds.require` refuses to proceed without them. Calibration
+is FIX-7-2; shadow mode (FIX-3-2) records the raw statistics and needs none of
+this.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bnnr.analysis.saliency_stats import SaliencyStats
+
+__all__ = [
+    "AttentionRegime",
+    "Diagnosis",
+    "DiagnosisThresholds",
+    "MissingThresholdsError",
+    "diagnose",
+]
+
+#: Doc the error message points at, so the fix is one click from the traceback.
+_CALIBRATION_DOC = "docs/diagnosis.md"
+
+
+class AttentionRegime(str, Enum):
+    """Where the model's attention already is, in the terms the rule decides on."""
+
+    #: Diffuse, drawn to the border, unstable under perturbation, with a real
+    #: robustness gap. The picture of a model reading context rather than object.
+    SHORTCUT_SUSPECTED = "shortcut_suspected"
+
+    #: Concentrated, central, stable, and still failing its hard quantile. The
+    #: model has found the object and needs the signal sharpened, not replaced.
+    OBJECT_FOCUSED = "object_focused"
+
+    #: The maps carry no usable structure, or there is no robustness gap worth
+    #: intervening on. Neither directed intervention is indicated.
+    UNSTRUCTURED = "unstructured"
+
+
+class MissingThresholdsError(RuntimeError):
+    """Diagnostic mode was requested before its thresholds were calibrated."""
+
+
+@dataclass(frozen=True)
+class DiagnosisThresholds:
+    """Cut points for the decision rule. All ``None`` until calibrated.
+
+    ``concentration_lo`` / ``concentration_hi`` bracket a middle band. A map
+    inside it is neither diffuse nor concentrated, which is the definition of
+    "no usable structure" this module uses.
+
+    The remaining three are one-sided: above ``border_mass_hi`` the mass sits at
+    the frame, above ``perturbation_shift_hi`` the explanation does not survive
+    its own perturbation, and above ``robustness_gap_hi`` there is a robustness
+    failure worth acting on.
+    """
+
+    concentration_lo: float | None = None
+    concentration_hi: float | None = None
+    border_mass_hi: float | None = None
+    perturbation_shift_hi: float | None = None
+    robustness_gap_hi: float | None = None
+
+    #: Diagnoses at or below this confidence are not acted on. FIX-4-2 falls
+    #: back to ``metric_argmax`` there.
+    min_confidence: float | None = None
+
+    #: Field names the rule cannot run without. ``min_confidence`` is not among
+    #: them: a caller may want the regime and its confidence without a policy
+    #: for what to do below the line.
+    REQUIRED = (
+        "concentration_lo",
+        "concentration_hi",
+        "border_mass_hi",
+        "perturbation_shift_hi",
+        "robustness_gap_hi",
+    )
+
+    def missing(self) -> tuple[str, ...]:
+        """Required thresholds that are still ``None``."""
+        return tuple(name for name in self.REQUIRED if getattr(self, name) is None)
+
+    def require(self) -> None:
+        """Raise unless every required threshold has been supplied."""
+        absent = self.missing()
+        if absent:
+            raise MissingThresholdsError(
+                f"Diagnostic mode needs calibrated thresholds; {', '.join(absent)} "
+                f"{'is' if len(absent) == 1 else 'are'} unset. There is deliberately no "
+                f"default: an uncalibrated cut point driving selection is the defect this "
+                f"replaces. See {_CALIBRATION_DOC}."
+            )
+        if self.concentration_lo is not None and self.concentration_hi is not None:
+            if self.concentration_lo > self.concentration_hi:
+                raise ValueError(
+                    f"concentration_lo ({self.concentration_lo}) must not exceed "
+                    f"concentration_hi ({self.concentration_hi})"
+                )
+
+
+@dataclass(frozen=True)
+class Criterion:
+    """One clause of a regime's conjunction, with the margin that decided it."""
+
+    name: str
+    satisfied: bool
+    value: float
+    threshold: float
+
+    @property
+    def margin(self) -> float:
+        """Distance from the cut point. Small means the clause nearly flipped."""
+        return abs(self.value - self.threshold)
+
+
+@dataclass(frozen=True)
+class Diagnosis:
+    """The regime, what it recommends, and everything that produced it."""
+
+    regime: AttentionRegime
+    stats: SaliencyStats
+    overall_acc: float
+    hard_quantile_acc: float
+    robustness_gap: float
+    recommended: tuple[str, ...]
+    confidence: float
+    reason: str
+    criteria: tuple[Criterion, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flat record for the run record and the report artifact."""
+        return {
+            "regime": self.regime.value,
+            "recommended": list(self.recommended),
+            "confidence": self.confidence,
+            "reason": self.reason,
+            "overall_acc": self.overall_acc,
+            "hard_quantile_acc": self.hard_quantile_acc,
+            "robustness_gap": self.robustness_gap,
+            "stats": self.stats.to_dict(),
+            "criteria": [
+                {
+                    "name": c.name,
+                    "satisfied": c.satisfied,
+                    "value": c.value,
+                    "threshold": c.threshold,
+                }
+                for c in self.criteria
+            ],
+        }
+
+
+#: What each regime asks for. Named here rather than inline so the report and
+#: the docs quote the same source as the code.
+_RECOMMENDATION = {
+    AttentionRegime.SHORTCUT_SUSPECTED: ("icd",),
+    AttentionRegime.OBJECT_FOCUSED: ("aicd",),
+    AttentionRegime.UNSTRUCTURED: ("church_noise",),
+}
+
+
+@dataclass(frozen=True)
+class _Cuts:
+    """Thresholds resolved to plain floats, after ``require()`` proved present."""
+
+    concentration_lo: float
+    concentration_hi: float
+    border_mass_hi: float
+    perturbation_shift_hi: float
+    robustness_gap_hi: float
+
+    @classmethod
+    def of(cls, thresholds: DiagnosisThresholds) -> _Cuts:
+        return cls(
+            concentration_lo=float(thresholds.concentration_lo),  # type: ignore[arg-type]
+            concentration_hi=float(thresholds.concentration_hi),  # type: ignore[arg-type]
+            border_mass_hi=float(thresholds.border_mass_hi),  # type: ignore[arg-type]
+            perturbation_shift_hi=float(thresholds.perturbation_shift_hi),  # type: ignore[arg-type]
+            robustness_gap_hi=float(thresholds.robustness_gap_hi),  # type: ignore[arg-type]
+        )
+
+
+def _shortcut_criteria(
+    stats: SaliencyStats, gap: float, cuts: _Cuts
+) -> tuple[Criterion, ...]:
+    """Diffuse, at the border, unstable, and a real gap."""
+    concentration = stats.concentration
+    border = stats.border_mass
+    shift = _shift(stats)
+    return (
+        Criterion("diffuse", concentration < cuts.concentration_lo, concentration, cuts.concentration_lo),
+        Criterion("border_heavy", border > cuts.border_mass_hi, border, cuts.border_mass_hi),
+        Criterion("unstable", shift > cuts.perturbation_shift_hi, shift, cuts.perturbation_shift_hi),
+        Criterion("robustness_gap", gap > cuts.robustness_gap_hi, gap, cuts.robustness_gap_hi),
+    )
+
+
+def _object_focused_criteria(
+    stats: SaliencyStats, gap: float, cuts: _Cuts
+) -> tuple[Criterion, ...]:
+    """Concentrated, central, stable, and a real gap."""
+    concentration = stats.concentration
+    border = stats.border_mass
+    shift = _shift(stats)
+    return (
+        Criterion("concentrated", concentration > cuts.concentration_hi, concentration, cuts.concentration_hi),
+        Criterion("central", border <= cuts.border_mass_hi, border, cuts.border_mass_hi),
+        Criterion("stable", shift <= cuts.perturbation_shift_hi, shift, cuts.perturbation_shift_hi),
+        Criterion("robustness_gap", gap > cuts.robustness_gap_hi, gap, cuts.robustness_gap_hi),
+    )
+
+
+def _shift(stats: SaliencyStats) -> float:
+    """``perturbation_shift``, or 0.0 when it was not measured.
+
+    0.0 reads as "perfectly stable", which is the conservative direction: it
+    pushes the rule towards OBJECT_FOCUSED (sharpen what is there) rather than
+    towards SHORTCUT_SUSPECTED (replace it), and sharpening a model that did not
+    need it is the cheaper mistake.
+    """
+    return 0.0 if stats.perturbation_shift is None else stats.perturbation_shift
+
+
+def _fraction(criteria: tuple[Criterion, ...]) -> float:
+    return sum(1 for c in criteria if c.satisfied) / len(criteria)
+
+
+def _smallest_margin(criteria: tuple[Criterion, ...]) -> float:
+    return min(c.margin for c in criteria)
+
+
+def diagnose(
+    stats: SaliencyStats,
+    *,
+    overall_acc: float,
+    hard_quantile_acc: float,
+    thresholds: DiagnosisThresholds,
+) -> Diagnosis:
+    """Classify the attention regime and say which intervention it indicates.
+
+    ``stats`` is the batch-level :class:`~bnnr.analysis.saliency_stats.SaliencyStats`;
+    ``overall_acc`` and ``hard_quantile_acc`` come from the evaluation result, so
+    ``robustness_gap`` here is the same quantity the metrics carry.
+
+    Raises :class:`MissingThresholdsError` when the thresholds are uncalibrated.
+
+    How the regime is chosen, stated in full because an unexplainable rule is
+    the thing this replaces:
+
+    1. **The gap gates everything.** With ``robustness_gap`` at or below its
+       threshold there is no robustness failure to act on, and the answer is
+       UNSTRUCTURED regardless of what the maps look like. A directed
+       intervention needs something to fix.
+    2. **A map with no shape is not evidence.** With ``concentration`` inside
+       the ``[lo, hi]`` band it is neither diffuse nor concentrated, so the
+       maps cannot discriminate and the answer is UNSTRUCTURED.
+    3. Otherwise both regimes' conjunctions are evaluated and the one with more
+       satisfied clauses wins. A tie goes to the regime whose weakest clause has
+       the larger margin, i.e. the one that is less nearly false.
+
+    ``confidence`` is the fraction of the winning regime's four clauses that
+    hold. It is a count, not a weighted score, and that is deliberate: a
+    weighted scalar here would be another uncalibrated number of exactly the
+    kind FIX-2-4 is removing. For UNSTRUCTURED it is the fraction of clauses
+    that support *neither* intervention, so a confident "do nothing" and a
+    borderline one are distinguishable.
+    """
+    thresholds.require()
+    cuts = _Cuts.of(thresholds)
+    gap = overall_acc - hard_quantile_acc
+
+    shortcut = _shortcut_criteria(stats, gap, cuts)
+    focused = _object_focused_criteria(stats, gap, cuts)
+
+    gap_criterion = shortcut[-1]
+    if not gap_criterion.satisfied:
+        return _unstructured(
+            stats, overall_acc, hard_quantile_acc, gap, shortcut, focused,
+            reason="no robustness gap to act on",
+        )
+
+    if cuts.concentration_lo <= stats.concentration <= cuts.concentration_hi:
+        return _unstructured(
+            stats, overall_acc, hard_quantile_acc, gap, shortcut, focused,
+            reason="saliency has no usable structure",
+        )
+
+    shortcut_score = _fraction(shortcut)
+    focused_score = _fraction(focused)
+
+    if shortcut_score > focused_score:
+        winner, criteria, score = AttentionRegime.SHORTCUT_SUSPECTED, shortcut, shortcut_score
+    elif focused_score > shortcut_score:
+        winner, criteria, score = AttentionRegime.OBJECT_FOCUSED, focused, focused_score
+    elif _smallest_margin(shortcut) >= _smallest_margin(focused):
+        winner, criteria, score = AttentionRegime.SHORTCUT_SUSPECTED, shortcut, shortcut_score
+    else:
+        winner, criteria, score = AttentionRegime.OBJECT_FOCUSED, focused, focused_score
+
+    satisfied = [c.name for c in criteria if c.satisfied]
+    return Diagnosis(
+        regime=winner,
+        stats=stats,
+        overall_acc=overall_acc,
+        hard_quantile_acc=hard_quantile_acc,
+        robustness_gap=gap,
+        recommended=_RECOMMENDATION[winner],
+        confidence=score,
+        reason=f"{winner.value}: {', '.join(satisfied)}" if satisfied else winner.value,
+        criteria=criteria,
+    )
+
+
+def _unstructured(
+    stats: SaliencyStats,
+    overall_acc: float,
+    hard_quantile_acc: float,
+    gap: float,
+    shortcut: tuple[Criterion, ...],
+    focused: tuple[Criterion, ...],
+    *,
+    reason: str,
+) -> Diagnosis:
+    """Neither intervention is indicated; say how firmly."""
+    against = 1.0 - max(_fraction(shortcut), _fraction(focused))
+    return Diagnosis(
+        regime=AttentionRegime.UNSTRUCTURED,
+        stats=stats,
+        overall_acc=overall_acc,
+        hard_quantile_acc=hard_quantile_acc,
+        robustness_gap=gap,
+        recommended=_RECOMMENDATION[AttentionRegime.UNSTRUCTURED],
+        confidence=against,
+        reason=f"unstructured: {reason}",
+        criteria=(),
+    )

--- a/src/bnnr/training/selection.py
+++ b/src/bnnr/training/selection.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
+    from bnnr.analysis.diagnosis import Diagnosis
     from bnnr.config_model import BNNRConfig
 
 __all__ = [
@@ -90,8 +91,16 @@ class CandidateSelector(Protocol):
         candidates: list[CandidateReport],
         baseline: dict[str, float],
         config: BNNRConfig,
+        *,
+        diagnosis: Diagnosis | None = None,
     ) -> SelectionResult:
-        """Pick from *candidates*, or select nothing."""
+        """Pick from *candidates*, or select nothing.
+
+        *diagnosis* is the attention diagnosis for this iteration when one was
+        computed. It is keyword-only and optional so a selector that does not
+        read attention is not forced to know the concept exists; the two
+        metric-driven selectors ignore it entirely.
+        """
         raise NotImplementedError
 
 
@@ -161,7 +170,10 @@ class MetricArgmaxSelector:
         candidates: list[CandidateReport],
         baseline: dict[str, float],
         config: BNNRConfig,
+        *,
+        diagnosis: Diagnosis | None = None,
     ) -> SelectionResult:
+        del diagnosis  # this selector decides on the metric alone
         metric = config.selection_metric
         mode = config.selection_mode
         weight = config.xai_selection_weight
@@ -206,7 +218,10 @@ class RandomSelector:
         candidates: list[CandidateReport],
         baseline: dict[str, float],
         config: BNNRConfig,
+        *,
+        diagnosis: Diagnosis | None = None,
     ) -> SelectionResult:
+        del diagnosis  # a random arm reads nothing
         values = _resolved_values(candidates, config.selection_metric)
         if not values:
             return SelectionResult((), self.name, "no_candidates", {})
@@ -222,9 +237,79 @@ class RandomSelector:
         return _gate_on_baseline(picked, candidates, baseline, config, self.name, scores)
 
 
+class DiagnosisSelector:
+    """Pick the candidate the attention diagnosis asked for.
+
+    This is the selector the whole remediation programme exists to make
+    possible: the intervention is chosen by *where attention already is*, not by
+    an argmax over sub-point differences in a saturated accuracy.
+
+    It refuses to guess. Without a diagnosis it returns nothing with reason
+    ``"no_diagnosis"`` rather than quietly falling back to argmax, because a
+    silent fallback would make a benchmark contrast between this selector and
+    argmax measure a blend of the two. FIX-4-2 adds an explicit, recorded
+    fallback for the low-confidence case; that is a policy decision and it
+    belongs in the policy layer, not hidden in here.
+
+    Matching is by substring against the candidate name, because a candidate is
+    an augmentation instance (``icd_p50``, ``aicd``) while a recommendation is a
+    family (``icd``). ``aicd`` is checked before ``icd`` would match it, since
+    ``"icd" in "aicd"`` is true and the wrong way round would recommend ICD for
+    every AICD candidate.
+    """
+
+    name = "diagnosis"
+
+    def select(
+        self,
+        candidates: list[CandidateReport],
+        baseline: dict[str, float],
+        config: BNNRConfig,
+        *,
+        diagnosis: Diagnosis | None = None,
+    ) -> SelectionResult:
+        values = _resolved_values(candidates, config.selection_metric)
+        if not values:
+            return SelectionResult((), self.name, "no_candidates", {})
+        if diagnosis is None:
+            return SelectionResult((), self.name, "no_diagnosis", {})
+
+        scores = {name: 0.0 for name in values}
+        for family in diagnosis.recommended:
+            for name in values:
+                if _matches_family(name, family):
+                    scores[name] = 1.0
+
+        wanted = [name for name, score in scores.items() if score > 0.0]
+        if not wanted:
+            return SelectionResult((), self.name, "no_matching_candidate", scores)
+
+        # Among candidates of the recommended family, the metric still breaks
+        # the tie: the diagnosis says which *kind* of intervention, not which
+        # hyperparameters of it.
+        sign = 1.0 if config.selection_mode == "max" else -1.0
+        best = max(wanted, key=lambda name: sign * values[name])
+        return _gate_on_baseline(best, candidates, baseline, config, self.name, scores)
+
+
+#: Longest first, so a family that contains another as a substring is tested
+#: before the shorter one can claim its candidates.
+_FAMILY_ALIASES = ("aicd", "icd", "church_noise")
+
+
+def _matches_family(candidate_name: str, family: str) -> bool:
+    """Whether *candidate_name* is an instance of the recommended *family*."""
+    name = candidate_name.lower()
+    for alias in _FAMILY_ALIASES:
+        if alias in name:
+            return alias == family
+    return family in name
+
+
 SELECTORS: dict[str, CandidateSelector] = {
     MetricArgmaxSelector.name: MetricArgmaxSelector(),
     RandomSelector.name: RandomSelector(),
+    DiagnosisSelector.name: DiagnosisSelector(),
 }
 
 
@@ -243,6 +328,8 @@ def run_selector(
     baseline_metrics: dict[str, float],
     config: BNNRConfig,
     xai_scores: dict[str, float] | None = None,
+    *,
+    diagnosis: Diagnosis | None = None,
 ) -> SelectionResult:
     """Build the candidate reports and run the configured selector over them."""
     candidates = [
@@ -257,4 +344,6 @@ def run_selector(
         )
         for name, metrics in results.items()
     ]
-    return get_selector(config.selector).select(candidates, baseline_metrics, config)
+    return get_selector(config.selector).select(
+        candidates, baseline_metrics, config, diagnosis=diagnosis
+    )

--- a/tests/test_diagnosis.py
+++ b/tests/test_diagnosis.py
@@ -1,0 +1,274 @@
+"""Tests for bnnr.analysis.diagnosis (FIX-1-2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bnnr.analysis.diagnosis import (
+    AttentionRegime,
+    Diagnosis,
+    DiagnosisThresholds,
+    MissingThresholdsError,
+    diagnose,
+)
+from bnnr.analysis.saliency_stats import SaliencyStats
+
+CALIBRATED = DiagnosisThresholds(
+    concentration_lo=0.30,
+    concentration_hi=0.60,
+    border_mass_hi=0.35,
+    perturbation_shift_hi=0.50,
+    robustness_gap_hi=0.15,
+    min_confidence=0.75,
+)
+
+
+def _stats(
+    *,
+    concentration: float,
+    border_mass: float,
+    shift: float | None = None,
+    gini: float = 0.5,
+) -> SaliencyStats:
+    return SaliencyStats(
+        concentration=concentration,
+        gini=gini,
+        border_mass=border_mass,
+        resolution=(14, 14),
+        perturbation_shift=shift,
+        perturbation_fill="gaussian_blur" if shift is not None else None,
+        n_maps=64,
+    )
+
+
+def _shortcut_stats() -> SaliencyStats:
+    """Diffuse, border-heavy, unstable."""
+    return _stats(concentration=0.10, border_mass=0.60, shift=0.80)
+
+
+def _focused_stats() -> SaliencyStats:
+    """Concentrated, central, stable."""
+    return _stats(concentration=0.85, border_mass=0.10, shift=0.15)
+
+
+class TestThresholdsAreMandatory:
+    def test_uncalibrated_thresholds_refuse_to_run(self) -> None:
+        with pytest.raises(MissingThresholdsError, match="calibrated thresholds"):
+            diagnose(
+                _shortcut_stats(),
+                overall_acc=0.9,
+                hard_quantile_acc=0.4,
+                thresholds=DiagnosisThresholds(),
+            )
+
+    def test_every_required_threshold_defaults_to_none(self) -> None:
+        blank = DiagnosisThresholds()
+        assert set(blank.missing()) == set(DiagnosisThresholds.REQUIRED)
+
+    def test_error_names_the_missing_fields(self) -> None:
+        partial = DiagnosisThresholds(
+            concentration_lo=0.3, concentration_hi=0.6, border_mass_hi=0.35
+        )
+        with pytest.raises(MissingThresholdsError) as excinfo:
+            partial.require()
+        message = str(excinfo.value)
+        assert "perturbation_shift_hi" in message
+        assert "robustness_gap_hi" in message
+        assert "concentration_lo" not in message
+
+    def test_error_points_at_the_calibration_doc(self) -> None:
+        with pytest.raises(MissingThresholdsError, match="docs/diagnosis.md"):
+            DiagnosisThresholds().require()
+
+    def test_min_confidence_is_not_required(self) -> None:
+        """A caller may want the regime without a policy for acting on it."""
+        thresholds = DiagnosisThresholds(
+            concentration_lo=0.3,
+            concentration_hi=0.6,
+            border_mass_hi=0.35,
+            perturbation_shift_hi=0.5,
+            robustness_gap_hi=0.15,
+        )
+        thresholds.require()  # must not raise
+
+    def test_inverted_concentration_band_rejected(self) -> None:
+        thresholds = DiagnosisThresholds(
+            concentration_lo=0.8,
+            concentration_hi=0.2,
+            border_mass_hi=0.35,
+            perturbation_shift_hi=0.5,
+            robustness_gap_hi=0.15,
+        )
+        with pytest.raises(ValueError, match="must not exceed"):
+            thresholds.require()
+
+
+class TestRegimeRule:
+    def test_diffuse_border_unstable_with_a_gap_means_icd(self) -> None:
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.90, hard_quantile_acc=0.40, thresholds=CALIBRATED
+        )
+        assert result.regime is AttentionRegime.SHORTCUT_SUSPECTED
+        assert result.recommended == ("icd",)
+        assert result.confidence == pytest.approx(1.0)
+
+    def test_concentrated_central_stable_with_a_gap_means_aicd(self) -> None:
+        result = diagnose(
+            _focused_stats(), overall_acc=0.90, hard_quantile_acc=0.40, thresholds=CALIBRATED
+        )
+        assert result.regime is AttentionRegime.OBJECT_FOCUSED
+        assert result.recommended == ("aicd",)
+        assert result.confidence == pytest.approx(1.0)
+
+    def test_no_robustness_gap_means_no_directed_intervention(self) -> None:
+        """Even a textbook shortcut signature: with nothing failing, nothing to fix."""
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.90, hard_quantile_acc=0.88, thresholds=CALIBRATED
+        )
+        assert result.regime is AttentionRegime.UNSTRUCTURED
+        assert result.recommended == ("church_noise",)
+        assert "no robustness gap" in result.reason
+
+    def test_concentration_inside_the_band_means_no_usable_structure(self) -> None:
+        middling = _stats(concentration=0.45, border_mass=0.60, shift=0.80)
+        result = diagnose(
+            middling, overall_acc=0.90, hard_quantile_acc=0.40, thresholds=CALIBRATED
+        )
+        assert result.regime is AttentionRegime.UNSTRUCTURED
+        assert "no usable structure" in result.reason
+
+    @pytest.mark.parametrize("concentration", [0.30, 0.60])
+    def test_band_edges_count_as_inside_it(self, concentration: float) -> None:
+        edge = _stats(concentration=concentration, border_mass=0.60, shift=0.80)
+        result = diagnose(edge, overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED)
+        assert result.regime is AttentionRegime.UNSTRUCTURED
+
+    def test_mixed_evidence_picks_the_better_supported_regime(self) -> None:
+        """Diffuse and border-heavy but stable: 3 of 4 shortcut clauses hold."""
+        mixed = _stats(concentration=0.10, border_mass=0.60, shift=0.20)
+        result = diagnose(
+            mixed, overall_acc=0.90, hard_quantile_acc=0.40, thresholds=CALIBRATED
+        )
+        assert result.regime is AttentionRegime.SHORTCUT_SUSPECTED
+        assert result.confidence == pytest.approx(0.75)
+
+
+class TestConfidence:
+    def test_confidence_is_a_count_out_of_four(self) -> None:
+        mixed = _stats(concentration=0.10, border_mass=0.10, shift=0.20)
+        result = diagnose(
+            mixed, overall_acc=0.90, hard_quantile_acc=0.40, thresholds=CALIBRATED
+        )
+        assert result.confidence in {0.0, 0.25, 0.5, 0.75, 1.0}
+
+    def test_full_agreement_is_one(self) -> None:
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED
+        )
+        assert result.confidence == pytest.approx(1.0)
+
+    def test_unstructured_confidence_distinguishes_firm_from_borderline(self) -> None:
+        """A clear no-gap case and a near-miss must not report the same number."""
+        firm = diagnose(
+            _stats(concentration=0.45, border_mass=0.10, shift=0.20),
+            overall_acc=0.90,
+            hard_quantile_acc=0.89,
+            thresholds=CALIBRATED,
+        )
+        borderline = diagnose(
+            _shortcut_stats(), overall_acc=0.90, hard_quantile_acc=0.88, thresholds=CALIBRATED
+        )
+        assert firm.confidence != borderline.confidence
+
+    def test_criteria_are_exposed_with_their_margins(self) -> None:
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED
+        )
+        names = [c.name for c in result.criteria]
+        assert names == ["diffuse", "border_heavy", "unstable", "robustness_gap"]
+        assert all(c.margin >= 0 for c in result.criteria)
+
+    def test_margin_is_distance_to_the_cut_point(self) -> None:
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED
+        )
+        diffuse = next(c for c in result.criteria if c.name == "diffuse")
+        assert diffuse.margin == pytest.approx(abs(0.10 - 0.30))
+
+
+class TestTieBreaking:
+    def test_a_tie_goes_to_the_regime_that_is_less_nearly_false(self) -> None:
+        """Two clauses each: the winner is the one whose weakest clause has the
+        larger margin, so the decision is reproducible rather than dict-ordered."""
+        tied = _stats(concentration=0.05, border_mass=0.10, shift=0.20)
+        result = diagnose(
+            tied, overall_acc=0.90, hard_quantile_acc=0.40, thresholds=CALIBRATED
+        )
+        # shortcut: diffuse yes, border no, unstable no, gap yes  -> 2/4
+        # focused:  concentrated no, central yes, stable yes, gap yes -> 3/4
+        assert result.regime is AttentionRegime.OBJECT_FOCUSED
+
+    def test_the_same_input_always_gives_the_same_regime(self) -> None:
+        stats = _stats(concentration=0.05, border_mass=0.35, shift=0.50)
+        first = diagnose(stats, overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED)
+        second = diagnose(stats, overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED)
+        assert first.regime is second.regime
+        assert first.confidence == second.confidence
+
+
+class TestUnmeasuredPerturbationShift:
+    def test_absent_shift_reads_as_stable(self) -> None:
+        """The conservative direction: sharpen rather than replace."""
+        no_shift = _stats(concentration=0.85, border_mass=0.10, shift=None)
+        result = diagnose(
+            no_shift, overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED
+        )
+        stable = next(c for c in result.criteria if c.name == "stable")
+        assert stable.satisfied
+        assert result.regime is AttentionRegime.OBJECT_FOCUSED
+
+
+class TestRecord:
+    def test_to_dict_is_flat_enough_for_a_run_record(self) -> None:
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED
+        )
+        record = result.to_dict()
+        assert record["regime"] == "shortcut_suspected"
+        assert record["recommended"] == ["icd"]
+        assert record["robustness_gap"] == pytest.approx(0.5)
+        assert record["stats"]["resolution"] == (14, 14)
+        assert len(record["criteria"]) == 4
+
+    def test_gap_is_derived_from_the_two_accuracies(self) -> None:
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.82, hard_quantile_acc=0.31, thresholds=CALIBRATED
+        )
+        assert result.robustness_gap == pytest.approx(0.51)
+
+    def test_reason_names_the_clauses_that_held(self) -> None:
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED
+        )
+        assert "diffuse" in result.reason
+        assert "border_heavy" in result.reason
+
+    def test_regime_is_a_str_enum_so_it_serialises(self) -> None:
+        result = diagnose(
+            _shortcut_stats(), overall_acc=0.9, hard_quantile_acc=0.4, thresholds=CALIBRATED
+        )
+        assert isinstance(result, Diagnosis)
+        assert result.regime == "shortcut_suspected"
+
+
+class TestNoMaskDerivedInputs:
+    def test_diagnose_takes_only_saliency_stats_and_accuracies(self) -> None:
+        """The assumption-class guarantee, enforced at the signature.
+
+        A rule that consumed masks would stop being deployable, so the only
+        inputs are things BNNR computes from images and labels alone.
+        """
+        import inspect
+
+        params = set(inspect.signature(diagnose).parameters)
+        assert params == {"stats", "overall_acc", "hard_quantile_acc", "thresholds"}

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -250,8 +250,8 @@ class TestRegistry:
     def test_default_selector_is_metric_argmax(self) -> None:
         assert BNNRConfig().selector == "metric_argmax"
 
-    def test_both_selectors_are_registered(self) -> None:
-        assert set(SELECTORS) == {"metric_argmax", "random"}
+    def test_every_selector_is_registered(self) -> None:
+        assert set(SELECTORS) == {"metric_argmax", "random", "diagnosis"}
 
     def test_unknown_selector_rejected_by_config(self) -> None:
         with pytest.raises(ValueError, match="selector must be one of"):
@@ -271,3 +271,102 @@ class TestRegistry:
             )
             assert isinstance(result, SelectionResult)
             assert isinstance(result.selected, tuple)
+
+
+# ---------------------------------------------------------------------------
+# The diagnosis selector (FIX-1-2 step 3 of FIX-2-1)
+# ---------------------------------------------------------------------------
+
+
+def _diagnosis(recommended: tuple[str, ...], confidence: float = 1.0):
+    from bnnr.analysis.diagnosis import AttentionRegime, Diagnosis
+    from bnnr.analysis.saliency_stats import SaliencyStats
+
+    regime = {
+        ("icd",): AttentionRegime.SHORTCUT_SUSPECTED,
+        ("aicd",): AttentionRegime.OBJECT_FOCUSED,
+        ("church_noise",): AttentionRegime.UNSTRUCTURED,
+    }[recommended]
+    return Diagnosis(
+        regime=regime,
+        stats=SaliencyStats(0.5, 0.5, 0.2, (14, 14)),
+        overall_acc=0.9,
+        hard_quantile_acc=0.4,
+        robustness_gap=0.5,
+        recommended=recommended,
+        confidence=confidence,
+        reason="synthetic",
+    )
+
+
+class TestDiagnosisSelector:
+    RESULTS = {
+        "icd": {"accuracy": 0.81},
+        "aicd": {"accuracy": 0.85},
+        "church_noise": {"accuracy": 0.83},
+    }
+    BASELINE = {"accuracy": 0.50}
+
+    def _run(self, recommended, results=None):
+        return run_selector(
+            results if results is not None else self.RESULTS,
+            self.BASELINE,
+            _config(selector="diagnosis"),
+            diagnosis=_diagnosis(recommended),
+        )
+
+    @pytest.mark.parametrize("family", ["icd", "aicd", "church_noise"])
+    def test_picks_the_recommended_family(self, family: str) -> None:
+        assert self._run((family,)).best == family
+
+    def test_ignores_a_better_metric_outside_the_recommendation(self) -> None:
+        """The whole point: attention decides the kind, not the accuracy."""
+        result = self._run(("icd",))
+        assert result.best == "icd"  # 0.81, while aicd scores 0.85
+
+    def test_aicd_is_not_matched_by_the_icd_family(self) -> None:
+        """"icd" in "aicd" is true; the wrong ordering would recommend ICD for
+        every AICD candidate."""
+        result = self._run(("icd",), results={"aicd_p50": {"accuracy": 0.9}})
+        assert result.selected == ()
+        assert result.reason == "no_matching_candidate"
+
+    def test_metric_breaks_ties_within_the_recommended_family(self) -> None:
+        """The diagnosis says which intervention, not which hyperparameters."""
+        results = {
+            "icd_p50": {"accuracy": 0.81},
+            "icd_p90": {"accuracy": 0.88},
+            "aicd": {"accuracy": 0.95},
+        }
+        assert self._run(("icd",), results=results).best == "icd_p90"
+
+    def test_refuses_to_run_without_a_diagnosis(self) -> None:
+        """A silent fallback to argmax would make a benchmark contrast between
+        this selector and argmax measure a blend of the two."""
+        result = run_selector(self.RESULTS, self.BASELINE, _config(selector="diagnosis"))
+        assert result.selected == ()
+        assert result.reason == "no_diagnosis"
+
+    def test_still_gated_on_beating_the_baseline(self) -> None:
+        result = run_selector(
+            {"icd": {"accuracy": 0.30}},
+            {"accuracy": 0.90},
+            _config(selector="diagnosis"),
+            diagnosis=_diagnosis(("icd",)),
+        )
+        assert result.selected == ()
+        assert result.reason == "no_improvement"
+
+    def test_is_registered_and_configurable(self) -> None:
+        assert "diagnosis" in SELECTORS
+        assert BNNRConfig(selector="diagnosis").selector == "diagnosis"
+
+    def test_metric_selectors_ignore_a_supplied_diagnosis(self) -> None:
+        """Passing one must not change what the metric-driven arms do."""
+        for name in ("metric_argmax", "random"):
+            config = _config(selector=name, seed=3)
+            without = run_selector(self.RESULTS, self.BASELINE, config).best
+            with_diag = run_selector(
+                self.RESULTS, self.BASELINE, config, diagnosis=_diagnosis(("icd",))
+            ).best
+            assert without == with_diag


### PR DESCRIPTION
## Summary

`selection_mode="xai"` never used saliency to arbitrate. It was a greedy argmax on selection-validation accuracy, and T20 found that criterion close to orthogonal to the objective: on Waterbirds it sits at ~97% while the objective sits at 59%, and candidate accuracies differ by fractions of a point. So the selector took an argmax over sub-point differences in a saturated, majority-dominated quantity in order to choose an intervention whose entire purpose is to fix a minority-group failure.

ICD and AICD are opposite operations on attention. Which one is right depends on where attention already is, and that is measurable. New `src/bnnr/analysis/diagnosis.py` does the measuring:

```
AttentionRegime: SHORTCUT_SUSPECTED | OBJECT_FOCUSED | UNSTRUCTURED
Diagnosis: regime, stats, overall_acc, hard_quantile_acc, robustness_gap,
           recommended, confidence, reason, criteria
```

## The hard constraint, enforced at the signature

Everything the rule reads comes from #402 (`concentration`, `border_mass`, `perturbation_shift`) and #404 (`overall_acc`, `hard_quantile_acc`). No EBPG, no mask-derived quantity, nothing needing annotation.

`diagnose()` takes exactly four parameters and there is a test asserting the parameter set, so a future change that reaches for a mask has to delete a test that says why it must not. SpuriousBench masks validate this rule from the outside; they never run inside it.

## The rule

Two gates, then a conjunction count.

1. **The gap gates everything.** At or below `robustness_gap_hi` there is no robustness failure to act on, so the regime is `UNSTRUCTURED` regardless of what the maps look like. A directed intervention needs something to fix.
2. **A map with no shape is not evidence.** Inside the `[concentration_lo, concentration_hi]` band the map is neither diffuse nor concentrated, so it cannot discriminate.

Past both, both conjunctions are evaluated and the one with more satisfied clauses wins. A tie goes to the regime whose weakest clause has the **larger** margin — the one that is less nearly false — so the decision is reproducible rather than dependent on evaluation order.

## Confidence, defined rather than invented

`confidence` is the fraction of the winning regime's four clauses that hold: one of `0.0`, `0.25`, `0.5`, `0.75`, `1.0`. A count, not a weighted score — a weighted scalar here would be another uncalibrated number of exactly the kind #409 is removing.

For `UNSTRUCTURED` it is the fraction of clauses supporting *neither* intervention, so a firm "no gap at all" and a borderline one do not report the same number. There is a test for that specifically.

`Diagnosis.criteria` carries each clause with its value, threshold and margin, so any answer reconstructs from the record without re-running anything.

## Thresholds have no defaults

`DiagnosisThresholds` starts fully `None`; `require()` raises `MissingThresholdsError` naming the missing fields and pointing at `docs/diagnosis.md`. `min_confidence` is deliberately *not* required — a caller may want the regime without a policy for acting on it.

This overlaps #405 by design: #405 turns these into config fields and wires the validator into the config layer. The dataclass here is what it will wrap.

## Three judgement calls I had to make, because the issue underspecifies them

The issue gives the rule as two conjunctions plus "no usable structure", and confidence as "the fraction of the four criteria that agree with the chosen regime, broken by the smallest margin to its threshold". Turning that into code needed three decisions. All are documented in `docs/diagnosis.md`; flagging them here because they are yours to overrule:

1. **The gap is a shared precondition, not a discriminator.** It appears in both conjunctions in the issue text, so I made a small gap a hard gate to `UNSTRUCTURED` rather than a vote.
2. **`UNSTRUCTURED` confidence is `1 - max(other two)`.** The issue defines confidence only for a chosen regime, and `UNSTRUCTURED` has no conjunction of its own. Without this, every "do nothing" would report the same number.
3. **A tie goes to the larger minimum margin.** "Broken by the smallest margin to its threshold" is ambiguous about direction; I read it as preferring the regime that is less nearly false.

## The diagnosis selector

Step 3 of #406, which was waiting on this issue. The `CandidateSelector` protocol gains a keyword-only, defaulted `diagnosis`; `metric_argmax` and `random` `del` it, and there is a test that passing one does not change what they do.

- **Without a diagnosis it selects nothing**, reason `no_diagnosis`. It does not fall back to argmax, because a silent fallback would make a benchmark contrast between this selector and argmax measure a blend of the two. The explicit low-confidence fallback is #414 and belongs in the policy layer.
- **`aicd` is matched before `icd`.** `"icd" in "aicd"` is true, so the naive ordering would recommend ICD for every AICD candidate. There is a test.
- **The metric breaks ties within the recommended family**, because the diagnosis says which *kind* of intervention, not which hyperparameters of it.

## Known limitation

`perturbation_shift` is optional, and an absent one reads as perfectly stable. That biases towards `OBJECT_FOCUSED` (sharpen) over `SHORTCUT_SUSPECTED` (replace), on the grounds that sharpening a model that did not need it is the cheaper mistake. It is a stated bias, not a neutral default, and the doc says so under its own heading.

## Test plan

- `pytest -q` -> **1437 passed, 19 skipped** (26 for the rule, 8 for the selector).
- `ruff check src tests` clean; `mypy` clean on both touched modules.
- Coverage: both regimes at full confidence; both gates; band edges counted as inside; mixed evidence at 3/4; the tie-break; determinism; missing thresholds by name; the doc pointer in the message; `min_confidence` not required; inverted band rejected; absent shift reading as stable; the record shape; and the parameter-set assertion.

## Docs

New `docs/diagnosis.md`: what it is, why it exists, the inputs and the assumption-class constraint, the rule, confidence, why thresholds are `None`, the selector, and the limitation. Linked from `docs/README.md` and `docs/configuration.md`.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #403
