### PR TITLE
feat(config): diagnosis thresholds as config with no defaults

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,38 @@ seed: 42
 
 Both are gated the same way: whatever a selector picks is discarded unless it beat the baseline on `selection_metric`. That gate is deliberately shared, so a comparison between two selectors is a comparison of their ranking rules and nothing else. A selector that skipped it would look better purely by accepting runs the others reject.
 
+### Diagnosis thresholds
+
+`selector: diagnosis` requires a `diagnosis:` block, and **every field in it starts unset**:
+
+```yaml
+selector: diagnosis
+diagnosis:
+  concentration_lo: 0.31
+  concentration_hi: 0.58
+  border_mass_hi: 0.34
+  perturbation_shift_hi: 0.47
+  robustness_gap_hi: 0.12
+  min_confidence: 0.75        # optional
+```
+
+Asking for the selector with any of the first five unset raises at **config construction**, not mid-run, so the failure lands before any GPU time is spent. There is deliberately no default: shipping one would repeat the mistake that produced `xai_selection_weight` and its preset 0.1 and 0.15.
+
+Thresholds are calibrated per model family and per saliency resolution, so they travel as a file rather than as library defaults:
+
+```python
+from bnnr.config import load_diagnosis_profile
+
+thresholds = load_diagnosis_profile(Path("profiles.yaml"), "imagewoof_resnet50")
+config = BNNRConfig(selector="diagnosis", diagnosis=thresholds)
+```
+
+A profile file holds one or more named sets. With several in the file the name is required — picking one silently would be the same class of mistake as a default threshold.
+
+Setting the block without setting `selector` is harmless and is what shadow mode does: it records the raw statistics and needs no thresholds at all.
+
+`hard_quantile_q` is **not** part of this block. It lives at the top level because `hard_quantile_acc` and `robustness_gap` are worth watching with no diagnosis configured; the calibration study sweeps it alongside these thresholds, which does not make it one.
+
 `diagnosis` needs calibrated thresholds and a `Diagnosis` for the iteration. Without one it selects nothing rather than falling back to argmax, because a silent fallback would make a benchmark contrast between the two measure a blend of them.
 
 `random` is not a joke setting. It is the arm the T20 benchmark ran `metric_argmax` against, and `metric_argmax` did not beat it at n=10 across two datasets; having it as a named selector is what makes that contrast reproducible rather than something the benchmark harness improvises.

--- a/docs/diagnosis.md
+++ b/docs/diagnosis.md
@@ -61,6 +61,8 @@ This is deliberate and it is the whole discipline of the exercise. Guessing them
 | `robustness_gap_hi` | a gap worth acting on from noise |
 | `min_confidence` | acted on from not acted on (not required by the rule itself) |
 
+In a config these live under the `diagnosis:` key, and requesting `selector: diagnosis` with any required one unset fails at construction. See [configuration](configuration.md#diagnosis-thresholds) for the YAML shape and `bnnr.config.load_diagnosis_profile` for loading a calibrated set from file.
+
 **Shadow mode needs none of this.** It records the raw statistics rather than a regime, so it can start collecting calibration samples from every run that was going to happen anyway, at no extra GPU cost, before any threshold exists.
 
 ## Using it as a selector

--- a/src/bnnr/config.py
+++ b/src/bnnr/config.py
@@ -8,7 +8,7 @@ from typing import Any
 import yaml
 from pydantic import ValidationError
 
-from bnnr.config_model import BNNRConfig
+from bnnr.config_model import BNNRConfig, DiagnosisConfig
 from bnnr.utils import _parse_fbeta
 
 
@@ -58,6 +58,63 @@ def load_config(config_path: Path) -> BNNRConfig:
         return BNNRConfig(**(data or {}))
     except ValidationError as exc:
         raise ValueError(f"Invalid BNNRConfig in {config_path}: {exc}") from exc
+
+
+def load_diagnosis_profile(profile_path: Path, name: str | None = None) -> DiagnosisConfig:
+    """Load a named set of calibrated diagnosis thresholds from a YAML file.
+
+    A profile file holds one or more named threshold sets::
+
+        imagewoof_resnet50:
+          concentration_lo: 0.31
+          concentration_hi: 0.58
+          border_mass_hi: 0.34
+          perturbation_shift_hi: 0.47
+          robustness_gap_hi: 0.12
+          min_confidence: 0.75
+
+    Thresholds are calibrated per model family and per saliency resolution, so
+    they travel as a file rather than as library defaults. This is what lets the
+    calibration study publish a profile without anything being hard-coded here.
+
+    With one profile in the file *name* may be omitted. With several it is
+    required, because picking one silently would be the same class of mistake
+    as a default threshold.
+
+    The result is not validated for completeness here: a partial profile is a
+    legitimate thing to load and then finish by hand. Completeness is checked
+    when a config that uses it asks for the ``diagnosis`` selector.
+    """
+    if not profile_path.exists():
+        raise FileNotFoundError(f"Diagnosis profile not found: {profile_path}")
+    try:
+        data = yaml.safe_load(profile_path.read_text())
+    except yaml.YAMLError as exc:
+        raise yaml.YAMLError(f"Invalid YAML in {profile_path}: {exc}") from exc
+
+    if not isinstance(data, dict) or not data:
+        raise ValueError(f"{profile_path} holds no named threshold profiles")
+
+    if name is None:
+        if len(data) > 1:
+            raise ValueError(
+                f"{profile_path} holds {len(data)} profiles ({', '.join(sorted(data))}); "
+                f"name the one you want rather than letting it be picked for you"
+            )
+        name = next(iter(data))
+    elif name not in data:
+        raise KeyError(
+            f"Profile {name!r} not in {profile_path}. Available: {sorted(data)}"
+        )
+
+    entry = data[name]
+    if not isinstance(entry, dict):
+        raise ValueError(f"Profile {name!r} in {profile_path} is not a mapping")
+
+    try:
+        return DiagnosisConfig(**entry)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid diagnosis profile {name!r} in {profile_path}: {exc}") from exc
 
 
 def save_config(config: BNNRConfig, save_path: Path) -> None:

--- a/src/bnnr/config_model.py
+++ b/src/bnnr/config_model.py
@@ -3,9 +3,73 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+if TYPE_CHECKING:
+    from bnnr.analysis.diagnosis import DiagnosisThresholds
+
+#: Selectors that cannot run without calibrated thresholds. A diagnosis-driven
+#: search policy (#413) joins this set rather than growing a second check.
+_DIAGNOSIS_DRIVEN_SELECTORS = frozenset({"diagnosis"})
+
+
+class DiagnosisConfig(BaseModel):
+    """Cut points for the attention diagnosis. Every one starts unset.
+
+    There is deliberately no numeric default anywhere in this model. Shipping
+    one would repeat exactly the mistake that produced ``xai_selection_weight``
+    and its preset values of 0.1 and 0.15: a number nobody measured, driving
+    selection for every user. Calibration is a separate pre-registered study,
+    and until it reports, requesting the ``diagnosis`` selector fails at config
+    construction rather than at some point mid-run.
+
+    **Shadow mode needs none of these.** It records the raw saliency statistics
+    rather than a regime, so it collects calibration samples from runs that
+    were going to happen anyway, at no extra GPU cost, before any threshold
+    exists.
+
+    ``hard_quantile_q`` is deliberately *not* here. It lives on
+    :class:`BNNRConfig` because the metrics it produces, ``hard_quantile_acc``
+    and ``robustness_gap``, are worth watching with no diagnosis configured at
+    all. The calibration study sweeps it alongside these, which does not make
+    it a diagnosis field.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    concentration_lo: Optional[float] = None  # noqa: UP045
+    concentration_hi: Optional[float] = None  # noqa: UP045
+    border_mass_hi: Optional[float] = None  # noqa: UP045
+    perturbation_shift_hi: Optional[float] = None  # noqa: UP045
+    robustness_gap_hi: Optional[float] = None  # noqa: UP045
+    min_confidence: Optional[float] = None  # noqa: UP045
+
+    def to_thresholds(self) -> DiagnosisThresholds:
+        """Convert to the :class:`~bnnr.analysis.diagnosis.DiagnosisThresholds`
+        the rule consumes. Imported lazily to keep config import-light."""
+        from bnnr.analysis.diagnosis import DiagnosisThresholds
+
+        return DiagnosisThresholds(
+            concentration_lo=self.concentration_lo,
+            concentration_hi=self.concentration_hi,
+            border_mass_hi=self.border_mass_hi,
+            perturbation_shift_hi=self.perturbation_shift_hi,
+            robustness_gap_hi=self.robustness_gap_hi,
+            min_confidence=self.min_confidence,
+        )
+
+    def missing(self) -> tuple[str, ...]:
+        """Required thresholds still unset, in declaration order."""
+        return self.to_thresholds().missing()
+
+    @field_validator("min_confidence")
+    @classmethod
+    def validate_min_confidence(cls, value: float | None) -> float | None:
+        if value is not None and not (0.0 <= value <= 1.0):
+            raise ValueError("min_confidence must be in [0, 1]")
+        return value
 
 
 class BNNRConfig(BaseModel):
@@ -29,6 +93,9 @@ class BNNRConfig(BaseModel):
     # Which rule picks the winning candidate. "metric_argmax" is what BNNR has
     # always done and stays the default; see bnnr.training.selection.SELECTORS.
     selector: str = "metric_argmax"
+    #: Cut points for the ``diagnosis`` selector. Unset by design; see
+    #: DiagnosisConfig and docs/diagnosis.md.
+    diagnosis: DiagnosisConfig = Field(default_factory=DiagnosisConfig)
 
     # NOTE: For detection tasks, use selection_metric="map_50" (or "map_50_95")
     # and metrics=["map_50", "map_50_95", "loss"].  The model_validator below
@@ -152,6 +219,28 @@ class BNNRConfig(BaseModel):
         if value <= 0:
             raise ValueError("detection_xai_* controls must be > 0")
         return value
+
+    @model_validator(mode="after")
+    def validate_diagnosis_is_calibrated(self) -> BNNRConfig:
+        """Refuse a diagnosis-driven run whose thresholds were never measured.
+
+        This fires at config construction, so the failure lands before any GPU
+        time is spent rather than at the first selection round. A run that got
+        several epochs in before discovering it cannot decide anything is the
+        worst version of this error.
+        """
+        if self.selector in _DIAGNOSIS_DRIVEN_SELECTORS:
+            absent = self.diagnosis.missing()
+            if absent:
+                raise ValueError(
+                    f"selector={self.selector!r} needs calibrated diagnosis thresholds; "
+                    f"{', '.join(absent)} {'is' if len(absent) == 1 else 'are'} unset. "
+                    f"There is deliberately no default: an uncalibrated cut point driving "
+                    f"selection is the defect this replaces. Supply them under the "
+                    f"'diagnosis:' key, or load a profile with "
+                    f"bnnr.config.load_diagnosis_profile(). See docs/diagnosis.md."
+                )
+        return self
 
     @field_validator("selector")
     @classmethod

--- a/tests/test_diagnosis_config.py
+++ b/tests/test_diagnosis_config.py
@@ -1,0 +1,178 @@
+"""Tests for diagnosis thresholds as config (FIX-1-4)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bnnr.config import load_diagnosis_profile
+from bnnr.config_model import BNNRConfig, DiagnosisConfig
+
+CALIBRATED = {
+    "concentration_lo": 0.31,
+    "concentration_hi": 0.58,
+    "border_mass_hi": 0.34,
+    "perturbation_shift_hi": 0.47,
+    "robustness_gap_hi": 0.12,
+    "min_confidence": 0.75,
+}
+
+
+class TestNoDefaults:
+    @pytest.mark.parametrize("field", sorted(DiagnosisConfig.model_fields))
+    def test_every_threshold_starts_unset(self, field: str) -> None:
+        """The whole discipline of the exercise: no number nobody measured."""
+        assert getattr(DiagnosisConfig(), field) is None
+
+    def test_a_blank_config_reports_every_required_field_missing(self) -> None:
+        missing = DiagnosisConfig().missing()
+        assert set(missing) == {
+            "concentration_lo",
+            "concentration_hi",
+            "border_mass_hi",
+            "perturbation_shift_hi",
+            "robustness_gap_hi",
+        }
+
+    def test_min_confidence_is_not_counted_as_missing(self) -> None:
+        """A caller may want the regime without a policy for acting on it."""
+        partial = DiagnosisConfig(**{k: v for k, v in CALIBRATED.items() if k != "min_confidence"})
+        assert partial.missing() == ()
+
+    def test_default_config_carries_an_empty_diagnosis_block(self) -> None:
+        assert BNNRConfig().diagnosis == DiagnosisConfig()
+
+
+class TestTheGate:
+    def test_diagnosis_selector_without_thresholds_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="calibrated diagnosis thresholds"):
+            BNNRConfig(selector="diagnosis")
+
+    def test_the_error_names_the_missing_fields(self) -> None:
+        partial = {"concentration_lo": 0.3, "concentration_hi": 0.6}
+        with pytest.raises(ValueError) as excinfo:
+            BNNRConfig(selector="diagnosis", diagnosis=partial)
+        message = str(excinfo.value)
+        assert "border_mass_hi" in message
+        assert "robustness_gap_hi" in message
+        assert "concentration_lo" not in message.split("unset")[0]
+
+    def test_the_error_points_at_the_doc(self) -> None:
+        with pytest.raises(ValueError, match="docs/diagnosis.md"):
+            BNNRConfig(selector="diagnosis")
+
+    def test_the_error_names_the_profile_loader(self) -> None:
+        with pytest.raises(ValueError, match="load_diagnosis_profile"):
+            BNNRConfig(selector="diagnosis")
+
+    def test_fully_calibrated_thresholds_are_accepted(self) -> None:
+        config = BNNRConfig(selector="diagnosis", diagnosis=CALIBRATED)
+        assert config.selector == "diagnosis"
+        assert config.diagnosis.concentration_lo == pytest.approx(0.31)
+
+    def test_other_selectors_do_not_need_thresholds(self) -> None:
+        """Only a diagnosis-driven run is gated."""
+        for selector in ("metric_argmax", "random"):
+            assert BNNRConfig(selector=selector).selector == selector
+
+    def test_thresholds_without_the_selector_are_harmless(self) -> None:
+        """Shadow mode records statistics with the selector left alone."""
+        config = BNNRConfig(diagnosis=CALIBRATED)
+        assert config.selector == "metric_argmax"
+        assert config.diagnosis.missing() == ()
+
+
+class TestConversion:
+    def test_to_thresholds_round_trips_every_field(self) -> None:
+        thresholds = DiagnosisConfig(**CALIBRATED).to_thresholds()
+        for name, value in CALIBRATED.items():
+            assert getattr(thresholds, name) == pytest.approx(value)
+
+    def test_converted_thresholds_satisfy_the_rule(self) -> None:
+        DiagnosisConfig(**CALIBRATED).to_thresholds().require()  # must not raise
+
+    def test_min_confidence_range_is_validated(self) -> None:
+        with pytest.raises(ValueError, match="min_confidence"):
+            DiagnosisConfig(min_confidence=1.5)
+
+
+class TestProfileLoading:
+    def _write(self, tmp_path: Path, data: dict) -> Path:
+        path = tmp_path / "profiles.yaml"
+        path.write_text(yaml.safe_dump(data))
+        return path
+
+    def test_loads_a_named_profile(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, {"imagewoof_resnet50": CALIBRATED, "other": CALIBRATED})
+        loaded = load_diagnosis_profile(path, "imagewoof_resnet50")
+        assert loaded.concentration_lo == pytest.approx(0.31)
+
+    def test_a_single_profile_needs_no_name(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, {"only_one": CALIBRATED})
+        assert load_diagnosis_profile(path).min_confidence == pytest.approx(0.75)
+
+    def test_several_profiles_require_an_explicit_name(self, tmp_path: Path) -> None:
+        """Picking one silently would be the same mistake as a default."""
+        path = self._write(tmp_path, {"a": CALIBRATED, "b": CALIBRATED})
+        with pytest.raises(ValueError, match="name the one you want"):
+            load_diagnosis_profile(path)
+
+    def test_unknown_name_lists_what_is_available(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, {"a": CALIBRATED, "b": CALIBRATED})
+        with pytest.raises(KeyError, match="Available"):
+            load_diagnosis_profile(path, "c")
+
+    def test_missing_file_is_reported_as_such(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="Diagnosis profile not found"):
+            load_diagnosis_profile(tmp_path / "nope.yaml")
+
+    def test_empty_file_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.yaml"
+        path.write_text("")
+        with pytest.raises(ValueError, match="no named threshold profiles"):
+            load_diagnosis_profile(path)
+
+    def test_non_mapping_profile_rejected(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, {"a": [1, 2, 3]})
+        with pytest.raises(ValueError, match="not a mapping"):
+            load_diagnosis_profile(path, "a")
+
+    def test_unknown_key_in_a_profile_rejected(self, tmp_path: Path) -> None:
+        """extra="forbid" turns a typo into an error naming the key."""
+        path = self._write(tmp_path, {"a": {**CALIBRATED, "concentraton_lo": 0.3}})
+        with pytest.raises(ValueError, match="Invalid diagnosis profile"):
+            load_diagnosis_profile(path, "a")
+
+    def test_a_partial_profile_loads(self, tmp_path: Path) -> None:
+        """Loading is not the completeness check; using it for selection is."""
+        path = self._write(tmp_path, {"a": {"concentration_lo": 0.3}})
+        loaded = load_diagnosis_profile(path, "a")
+        assert loaded.concentration_lo == pytest.approx(0.3)
+        assert loaded.missing()
+
+    def test_a_loaded_profile_satisfies_the_gate(self, tmp_path: Path) -> None:
+        path = self._write(tmp_path, {"a": CALIBRATED})
+        config = BNNRConfig(selector="diagnosis", diagnosis=load_diagnosis_profile(path, "a"))
+        assert config.selector == "diagnosis"
+
+
+class TestYamlRoundTrip:
+    def test_diagnosis_survives_save_and_load(self, tmp_path: Path) -> None:
+        from bnnr.config import load_config, save_config
+
+        original = BNNRConfig(selector="diagnosis", diagnosis=CALIBRATED)
+        path = tmp_path / "config.yaml"
+        save_config(original, path)
+        assert load_config(path).diagnosis == original.diagnosis
+
+    def test_a_yaml_config_asking_for_diagnosis_without_thresholds_fails(
+        self, tmp_path: Path
+    ) -> None:
+        from bnnr.config import load_config
+
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.safe_dump({"selector": "diagnosis"}))
+        with pytest.raises(ValueError, match="calibrated diagnosis thresholds"):
+            load_config(path)

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -16,8 +16,21 @@ from bnnr.training.selection import (
     run_selector,
 )
 
+#: Any values will do here: these tests exercise the selector, not the rule.
+#: What matters is that they are present, since a diagnosis-driven config
+#: without calibrated thresholds is refused at construction (FIX-1-4).
+CALIBRATED_DIAGNOSIS = {
+    "concentration_lo": 0.30,
+    "concentration_hi": 0.60,
+    "border_mass_hi": 0.35,
+    "perturbation_shift_hi": 0.50,
+    "robustness_gap_hi": 0.15,
+}
+
 
 def _config(**overrides) -> BNNRConfig:
+    if overrides.get("selector") == "diagnosis" and "diagnosis" not in overrides:
+        overrides["diagnosis"] = CALIBRATED_DIAGNOSIS
     return BNNRConfig(**overrides)
 
 
@@ -359,7 +372,12 @@ class TestDiagnosisSelector:
 
     def test_is_registered_and_configurable(self) -> None:
         assert "diagnosis" in SELECTORS
-        assert BNNRConfig(selector="diagnosis").selector == "diagnosis"
+        assert _config(selector="diagnosis").selector == "diagnosis"
+
+    def test_config_refuses_the_selector_without_thresholds(self) -> None:
+        """FIX-1-4: the gate fires at construction, before any GPU time."""
+        with pytest.raises(ValueError, match="calibrated diagnosis thresholds"):
+            BNNRConfig(selector="diagnosis")
 
     def test_metric_selectors_ignore_a_supplied_diagnosis(self) -> None:
         """Passing one must not change what the metric-driven arms do."""


### PR DESCRIPTION
## Summary

The thresholds in the decision rule are unknown, and this PR is the part of the plan that keeps them that way until someone measures them.

New `DiagnosisConfig`, nested on `BNNRConfig` under `diagnosis:`, holding the five cut points the rule needs plus `min_confidence`. **Every one starts `None`, and no threshold has a numeric default anywhere in the codebase.**

```yaml
selector: diagnosis
diagnosis:
  concentration_lo: 0.31
  concentration_hi: 0.58
  border_mass_hi: 0.34
  perturbation_shift_hi: 0.47
  robustness_gap_hi: 0.12
  min_confidence: 0.75    # optional
```

## The gate fails early, not mid-run

A model validator refuses `selector="diagnosis"` while any required threshold is unset. It runs at **config construction**, so the failure lands before any GPU time is spent — a run that got several epochs in before discovering it cannot decide anything is the worst version of this error.

The message names the missing fields, points at `docs/diagnosis.md`, and names `load_diagnosis_profile` so the fix is one step from the traceback. There are tests for each of those three.

The set of gated selectors is named once as `_DIAGNOSIS_DRIVEN_SELECTORS`, so the diagnosis-driven search policy in #413 joins the set rather than growing a second check that can drift out of sync.

## Profiles travel as files

`load_diagnosis_profile(path, name)` reads a named threshold set from a YAML file holding one or more. Thresholds are calibrated per model family and per saliency resolution, so they are not library constants — this is what lets #417 publish a calibrated set without anything being hard-coded here.

Two deliberate choices:

- **With several profiles in a file the name is required.** Picking one silently would be the same class of mistake as a default threshold.
- **Loading does not check completeness.** A partial profile is a legitimate thing to load and finish by hand; completeness is checked when a config actually asks for the selector. The two concerns are separate and conflating them would make hand-editing awkward for no gain.

## Two decisions worth flagging

**`hard_quantile_q` stays on `BNNRConfig` rather than moving into this block.** The issue lists "the loss quantile `q` from FIX-1-3" among the fields. I kept it where #430 put it: `hard_quantile_acc` and `robustness_gap` are worth watching with no diagnosis configured at all, so `q` is a metrics knob the diagnosis happens to consume. #417 sweeping it alongside these thresholds does not make it one of them. Duplicating it in both places would be worse than either choice. Say the word and I'll move it — nothing has released yet, so it is still free.

**`min_confidence` is not required.** A caller may want the regime and its confidence without a policy for what to do below the line; that policy is #414. It is validated to `[0, 1]` when supplied.

## Test churn that is the feature working

The diagnosis-selector tests added in #432 constructed `BNNRConfig(selector="diagnosis")` with no thresholds. They now raise, correctly, so they supply a calibrated block. One new test asserts the bare construction still fails.

## Test plan

- `pytest -q` -> **1469 passed, 19 skipped** (31 new).
- `ruff check src tests` clean; `mypy` clean on all three touched modules.
- Coverage: every field unset by default (parametrised over `model_fields`, so a field added without a `None` default fails); the missing-field set; `min_confidence` excluded from it; the gate firing and its three message contents; other selectors ungated; thresholds without the selector being harmless (shadow mode); `to_thresholds` round-trip and that the result satisfies `require()`; profile loading by name, single-profile inference, the multi-profile refusal, unknown name, missing file, empty file, non-mapping entry, a typo'd key caught by `extra="forbid"`, a partial profile loading; and a YAML save/load round-trip plus a YAML config that asks for the selector without thresholds.

## Docs

`docs/configuration.md` gains a `Diagnosis thresholds` section with the YAML shape, the profile loader, the shadow-mode note and the `hard_quantile_q` explanation. `docs/diagnosis.md` links to it from the thresholds section.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #405
