### PR TITLE
feat(training): mandatory run-record fields for selection and compute

### DIFF
--- a/benchmarks/lib.py
+++ b/benchmarks/lib.py
@@ -513,10 +513,17 @@ def _result_entry(
     xai_meta: dict[str, Any],
     baseline_val: float | None = None,
     gain_pp: float | None = None,
+    run_record: Any | None = None,
     extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     sel = cfg.selection_metric
     agg = xai_meta.get("aggregate_stats") or {}
+    # Conditions that never build a BNNRTrainer (plain training, RandAugment)
+    # have no run record, but they still have to carry the compute fields or
+    # they cannot be placed on an equal-compute axis at all. For them the two
+    # epoch counts coincide: there is no search, so every epoch trained is an
+    # epoch the deployed model received.
+    record = _record_fields(run_record, cfg=cfg, condition=condition)
     return {
         "condition": condition.id,
         "strategy": condition.strategy,
@@ -541,8 +548,34 @@ def _result_entry(
         "wall_clock_s": round(elapsed_s, 1),
         "report_json": _rel(report_path),
         "run_dir": _rel(run_dir),
+        **record,
         **(extra or {}),
     }
+
+
+def _record_fields(
+    run_record: Any | None, *, cfg: Any, condition: ConditionSpec
+) -> dict[str, Any]:
+    """The FIX-3-1 mandatory fields, for a row with or without a BNNR run.
+
+    Without a run record this is a non-search condition, so the deployed model
+    got every epoch that was trained and the two counts are the same number.
+    That is a fact about the condition, not a fallback: a plain-training row
+    with ``deployed_epochs != total_gpu_epochs`` would be a bug.
+    """
+    if run_record is None:
+        epochs = int(cfg.m_epochs)
+        return {
+            "deployed_epochs": epochs,
+            "total_gpu_epochs": epochs,
+            "search_policy": "none",
+            "selector": None,
+            "selected_candidate": [],
+            "diagnosis": None,
+            "hard_quantile_q": getattr(cfg, "hard_quantile_q", None),
+            "augmentation_modes": {},
+        }
+    return run_record.to_dict()
 
 
 def run_no_bnnr(
@@ -682,6 +715,7 @@ def run_bnnr_branch_search(
         xai_meta=xai_meta,
         baseline_val=baseline_val,
         gain_pp=gain,
+        run_record=result.run_record,
         extra={
             "selected_augmentations": selected,
             "augmentation_names": [a.name for a in augmentations],

--- a/benchmarks/summarize_grand.py
+++ b/benchmarks/summarize_grand.py
@@ -6,7 +6,7 @@ Loads all ``results_*.json`` files from a directory and produces:
   2. Cross-dataset summary table (median accuracy per dataset, mean Δ vs no_aug)
   3. XAI correlation section (Spearman ρ between edge_ratio and accuracy)
   4. Key comparison section (bnnr_xai vs bnnr_random, per dataset, with p-values)
-  5. Compute transparency (total_gpu_epochs per condition)
+  5. Compute transparency (total and deployed epochs per condition)
   6. Which fill is best (fill-using methods ranked across strategies)
 
 Examples
@@ -311,6 +311,7 @@ def _analyze_dataset(
     # Group by condition → seed → metric
     by_cond: dict[str, dict[int, float]] = defaultdict(dict)
     gpu_epochs_by_cond: dict[str, list[int]] = defaultdict(list)
+    deployed_epochs_by_cond: dict[str, list[int]] = defaultdict(list)
     for r in ds_runs:
         cid = r["condition"]
         seed = int(r["seed"])
@@ -319,6 +320,11 @@ def _analyze_dataset(
         ep = r.get("total_gpu_epochs")
         if ep is not None:
             gpu_epochs_by_cond[cid].append(int(ep))
+        # Absent in records written before FIX-3-1. Those rows print "?" rather
+        # than crashing the summarizer, which is the point of reading with .get.
+        dep = r.get("deployed_epochs")
+        if dep is not None:
+            deployed_epochs_by_cond[cid].append(int(dep))
 
     print(f"\n{'='*70}")
     print(f"  DATASET: {dataset.upper()}  |  fill={strategy}")
@@ -396,6 +402,8 @@ def _analyze_dataset(
 
         gpu_epochs_list = gpu_epochs_by_cond.get(cid, [])
         gpu_ep_s = str(int(statistics.median(gpu_epochs_list))) if gpu_epochs_list else "?"
+        deployed_list = deployed_epochs_by_cond.get(cid, [])
+        dep_ep_s = str(int(statistics.median(deployed_list))) if deployed_list else "?"
 
         rows.append({
             "cid": cid,
@@ -410,6 +418,7 @@ def _analyze_dataset(
             "r": r_s,
             "ci": ci_s,
             "gpu_epochs": gpu_ep_s,
+            "deployed_epochs": dep_ep_s,
             "per_seed": ", ".join(f"{v*100:.2f}%" for v in sorted(vals)),
         })
 
@@ -426,7 +435,7 @@ def _print_text_table(rows: list[dict[str, Any]]) -> None:
     w = 38
     header = (
         f"{'Condition':<{w}} {'Median':>8} {'±IQR':>8} {'Mean':>8} {'±Std':>7} "
-        f"{'n':>3} {'Δ vs no_aug':>12} {'p(Holm)':>18} {'r':>6} {'GPU-ep':>8}"
+        f"{'n':>3} {'Δ vs no_aug':>12} {'p(Holm)':>18} {'r':>6} {'GPU-ep':>8} {'Depl-ep':>8}"
     )
     print(header)
     print("-" * len(header))
@@ -438,7 +447,7 @@ def _print_text_table(rows: list[dict[str, Any]]) -> None:
         print(
             f"{row['label']:<{w}} {med_s:>8} {iqr_s:>8} {mn_s:>8} {std_s:>7} "
             f"{row['n']:>3} {row['delta']:>12} {row['p_holm']:>18} {row['r']:>6} "
-            f"{row['gpu_epochs']:>8}"
+            f"{row['gpu_epochs']:>8} {row['deployed_epochs']:>8}"
         )
         print(f"  per-seed: {row['per_seed']}")
     print()
@@ -447,11 +456,13 @@ def _print_text_table(rows: list[dict[str, Any]]) -> None:
 def _print_markdown_table(rows: list[dict[str, Any]]) -> None:
     print(
         "| Condition | Median | ±IQR | mean±std | n | "
-        "Δ vs no_aug | p (Holm) vs bnnr_xai | r | Bootstrap 95% CI | GPU-epochs |"
+        "Δ vs no_aug | p (Holm) vs bnnr_xai | r | Bootstrap 95% CI | "
+        "GPU-epochs | Deployed epochs |"
     )
     print(
         "|-----------|--------|------|----------|---|"
-        "------------|---------------------|---|-----------------|-----------|"
+        "------------|---------------------|---|-----------------|"
+        "-----------|-----------------|"
     )
     for row in rows:
         med_s = f"{row['median']*100:.2f}%"
@@ -467,7 +478,7 @@ def _print_markdown_table(rows: list[dict[str, Any]]) -> None:
             f"| {row['p_holm']} "
             f"| {row['r']} "
             f"| {row['ci']} "
-            f"| {row['gpu_epochs']} |"
+            f"| {row['gpu_epochs']} | {row['deployed_epochs']} |"
         )
 
 
@@ -775,26 +786,41 @@ def _compute_transparency_section(
     *,
     strategy: str = "none",
 ) -> None:
-    """Print median total_gpu_epochs per condition."""
+    """Print median total and deployed epochs per condition.
+
+    Both numbers, because they answer different questions and T20's headline
+    deficit turned out to be the difference between them. total_gpu_epochs is
+    what an equal-compute protocol matches; deployed_epochs is what the shipped
+    model actually received. Printing only one is how the confound survived
+    into the results the first time.
+    """
     print("\n" + "=" * 70)
-    print(f"  COMPUTE TRANSPARENCY: median total_gpu_epochs per condition  |  fill={strategy}")
+    print(f"  COMPUTE TRANSPARENCY: median epochs per condition  |  fill={strategy}")
+    print("  total = every epoch trained;  deployed = epochs the shipped model got")
     print("=" * 70)
     for ds in datasets:
         ds_runs = [r for r in all_runs if r.get("dataset") == ds]
         if not ds_runs:
             continue
-        by_cond: dict[str, list[int]] = defaultdict(list)
+        total_by_cond: dict[str, list[int]] = defaultdict(list)
+        deployed_by_cond: dict[str, list[int]] = defaultdict(list)
         for r in ds_runs:
             ep = r.get("total_gpu_epochs")
             if ep is not None:
-                by_cond[r["condition"]].append(int(ep))
-        parts = [
-            f"{c}={int(statistics.median(by_cond[c]))}"
-            for c in ALL_CONDITIONS_ORDERED
-            if c in by_cond and by_cond[c]
-        ]
+                total_by_cond[r["condition"]].append(int(ep))
+            dep = r.get("deployed_epochs")
+            if dep is not None:
+                deployed_by_cond[r["condition"]].append(int(dep))
+        parts = []
+        for c in ALL_CONDITIONS_ORDERED:
+            if not total_by_cond.get(c):
+                continue
+            total = int(statistics.median(total_by_cond[c]))
+            deployed_list = deployed_by_cond.get(c)
+            deployed = int(statistics.median(deployed_list)) if deployed_list else None
+            parts.append(f"{c}={total}/{deployed if deployed is not None else '?'}")
         if parts:
-            print(f"  {ds}: {', '.join(parts)}")
+            print(f"  {ds}: {', '.join(parts)}  (total/deployed)")
     print()
 
 # ---------------------------------------------------------------------------

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -85,6 +85,28 @@ Common top-level keys:
 - `checkpoints`
 - `iteration_summaries`
 - `analysis`
+- `run_record`
+
+### `run_record`
+
+The fields a run must carry for its result to be comparable with another run. Written by `bnnr.training.run_record.RunRecord`.
+
+| key | meaning |
+|---|---|
+| `total_gpu_epochs` | every epoch trained anywhere: baseline, every candidate of every iteration, pruned and losing candidates included |
+| `deployed_epochs` | epochs of training the shipped model actually received |
+| `search_policy` | how candidates were enumerated; `"exhaustive"` is the only one today |
+| `selector` | which rule picked the winner, from `config.selector` |
+| `selected_candidate` | list of names the selector chose |
+| `diagnosis` | the attention diagnosis when one was computed, else `null` |
+| `hard_quantile_q` | the loss quantile the robustness metrics used |
+| `augmentation_modes` | `{name: mode}` for augmentations whose transform depends on a mode |
+
+**The two epoch counts are the point.** They differ whenever a branch search runs, and confusing them is what made BNNR look worse than it was: under "equal compute" the deployed model trained for a third of the budget while single-augmentation baselines trained all of it. Matching deployed epochs instead closed a 4.46 pp gap to 0.09 pp. They are equal only for a run with no search.
+
+Both are **counted as epochs run**, not derived from `m_epochs × max_iterations`. Pruning stops candidates early and the deployed model keeps its best epoch rather than its last, so the arithmetic would be an upper bound rather than an answer.
+
+A report written before this key existed still loads: `RunRecord.from_dict` falls back to defaults for absent fields and ignores unknown ones, so old runs summarize rather than crashing a reader.
 
 ## `events.jsonl`
 

--- a/src/bnnr/reporting.py
+++ b/src/bnnr/reporting.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 
 from bnnr.core import BNNRConfig
 from bnnr.events import JsonlEventSink
+from bnnr.training.run_record import RunRecord
 from bnnr.utils import ensure_dir, get_timestamp, portable_path
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,10 @@ class BNNRRunResult:
     report_json_path: Path
     report_html_path: Path | None
     analysis: dict[str, Any] = field(default_factory=dict)
+    #: Mandatory comparison fields: the two epoch counts, the decision path and
+    #: the diagnosis. Defaulted so a result built by older code still
+    #: constructs; see bnnr.training.run_record for why each field is required.
+    run_record: RunRecord = field(default_factory=RunRecord)
 
 
 class Reporter:
@@ -541,6 +546,7 @@ class Reporter:
             ],
             "iteration_summaries": self._iteration_summaries,
             "analysis": result.analysis,
+            "run_record": result.run_record.to_dict(),
         }
         _atomic_write_text(json_path, json.dumps(payload, indent=2), encoding="utf-8")
         return json_path
@@ -551,6 +557,7 @@ class Reporter:
         best_metrics: dict[str, float],
         selected_augmentations: list[str],
         analysis: dict[str, Any] | None = None,
+        run_record: RunRecord | None = None,
     ) -> BNNRRunResult:
         if self._config is None or self._start_time is None:
             raise RuntimeError("Reporter.start() must be called before finalize()")
@@ -567,6 +574,7 @@ class Reporter:
             report_json_path=placeholder_json,
             report_html_path=None,
             analysis=analysis or {},
+            run_record=run_record or RunRecord(),
         )
 
         if self.save_json:

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -27,6 +27,7 @@ from bnnr.training import image_utils as _img
 from bnnr.training import loop as _loop
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
+from bnnr.training import run_record as _run_record
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
     _RuntimeState,
     _TrainerState,
@@ -89,6 +90,13 @@ class BNNRTrainer:
         # Cache for merged _evaluate + _compute_eval_class_details (classification only)
         self._last_eval_preds: np.ndarray | None = None
         self._last_eval_labels: np.ndarray | None = None
+        # Epoch accounting. Counted as epochs run rather than derived from
+        # m_epochs * iterations, because pruning stops candidates early and the
+        # deployed model keeps its best epoch rather than its last.
+        self._ledger = _run_record.ComputeLedger()
+        # Set when a diagnosis was computed for the run. Stays None until
+        # shadow mode (#411) starts filling it on every run.
+        self._last_diagnosis: Any | None = None
         self.logger = setup_logging("bnnr", config.log_file, json_format=True)
         self._custom_metrics: dict[str, Any] = custom_metrics or {}
 

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -22,6 +22,7 @@ from bnnr.training import dataset_profile as _dprofile
 from bnnr.training import hard_quantile as _hard_quantile
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
+from bnnr.training import run_record as _run_record
 from bnnr.training import xai_runner as _xai
 from bnnr.training.metrics import average_metrics
 from bnnr.utils import set_seed
@@ -36,6 +37,11 @@ def train_epoch(
     augmentations: list[BaseAugmentation] | None = None,
 ) -> dict[str, float]:
     """Run one training epoch (delegates augmentation application to *trainer*)."""
+    # Every training epoch in the run passes through here: baseline, every
+    # candidate of every iteration, pruned ones included. Counting at the
+    # chokepoint is what makes total_gpu_epochs a measurement rather than an
+    # estimate from m_epochs * iterations.
+    trainer._ledger.count_trained_epoch()
     epoch_metrics: list[dict[str, float]] = []
 
     if trainer._is_detection:
@@ -480,6 +486,9 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
         # the best baseline (not the last epoch), then re-evaluate to refresh
         # the cached predictions used by the report.
         trainer.model.load_state_dict(best_baseline_state)
+        # The deployed model carries the best baseline epoch's weights, not the
+        # last epoch's, so credit what was kept rather than what was run.
+        trainer._ledger.credit_deployed(best_baseline_epoch)
         if best_baseline_epoch and best_baseline_epoch != trainer.config.m_epochs:
             trainer.console.print(
                 f"  (baseline best epoch: e{best_baseline_epoch})",
@@ -793,6 +802,9 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
         # (already saved from the epoch with the highest selection metric)
         winner_state = candidate_states.get(selected_name)
         winner_best_epoch = candidate_best_epochs.get(selected_name, trainer.config.m_epochs)
+        # This iteration was accepted, so the winner's kept epochs are now part
+        # of the deployed model's training history.
+        trainer._ledger.credit_deployed(winner_best_epoch)
         if winner_state is not None:
             trainer.model.load_state_dict(winner_state)
             final_metrics = iteration_results[selected_name]
@@ -933,7 +945,30 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
         best_metrics=best_metrics,
         selected_augmentations=selected_augmentations,
         analysis=analysis,
+        run_record=_build_run_record(trainer, selected_augmentations),
     )
     assert isinstance(result, BNNRRunResult)
     return result
 
+
+def _build_run_record(
+    trainer: BNNRTrainer, selected_augmentations: list[str]
+) -> _run_record.RunRecord:
+    """Collect the mandatory record fields at the end of a run.
+
+    ``search_policy`` is hard-coded to ``"exhaustive"`` because that is the only
+    policy that exists; #413 adds the alternatives and reads the config instead.
+    Recording it now rather than then is deliberate: rows written before the
+    feature lands stay distinguishable from rows written after it.
+    """
+    diagnosis = trainer._last_diagnosis
+    return _run_record.RunRecord(
+        total_gpu_epochs=trainer._ledger.total_gpu_epochs,
+        deployed_epochs=trainer._ledger.deployed_epochs,
+        search_policy="exhaustive",
+        selector=trainer.config.selector,
+        selected_candidate=tuple(selected_augmentations),
+        diagnosis=diagnosis.to_dict() if diagnosis is not None else None,
+        hard_quantile_q=trainer.config.hard_quantile_q,
+        augmentation_modes=_run_record.collect_augmentation_modes(trainer.augmentations),
+    )

--- a/src/bnnr/training/run_record.py
+++ b/src/bnnr/training/run_record.py
@@ -1,0 +1,150 @@
+"""What a run has to record about how it decided and what it cost.
+
+Two findings drive this.
+
+**The compute confound.** T20's apparent deficit under "equal compute" was the
+epoch split, not the method: the deployed model trains for ``B/3`` while a
+single-augmentation baseline trains the full ``B``. Matching deployed epochs
+closed a 4.46 pp gap to 0.09 pp on Imagewoof. The old record carried
+``max_iterations`` and ``m_epochs`` but neither of the two numbers that actually
+separate the protocols, so the confound had to be reconstructed by hand months
+later, from run directories, by someone who remembered it existed.
+
+**The path.** Once behaviour depends on a selector, a diagnosis, or a search
+policy, "BNNR vs baseline" is not a single number unless every row says which
+path it took. A benchmark that mixes two selectors and reports one mean is
+measuring their average, which is a quantity nobody wanted.
+
+Both epoch counts are **counted, not derived**. Candidate pruning stops a
+candidate early and the deployed model keeps its best epoch rather than its
+last, so ``m_epochs * iterations`` is an upper bound rather than an answer.
+:class:`ComputeLedger` counts what actually ran.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+__all__ = [
+    "ComputeLedger",
+    "RunRecord",
+]
+
+
+@dataclass
+class ComputeLedger:
+    """Counts epochs as they run, rather than inferring them from config.
+
+    ``total_gpu_epochs`` is every epoch trained anywhere: the baseline phase,
+    every candidate of every iteration, including candidates that were pruned
+    and candidates that lost. It is what an equal-compute protocol has to match.
+
+    ``deployed_epochs`` is how much training the model you ship actually
+    received: the baseline's best epoch, plus the winning candidate's best
+    epoch for each accepted iteration. It is what an equal-deployed-epoch
+    protocol has to match. Best rather than last, because that is the checkpoint
+    the run keeps.
+
+    The two are equal only for a plain training run with no search.
+    """
+
+    total_gpu_epochs: int = 0
+    deployed_epochs: int = 0
+
+    def count_trained_epoch(self) -> None:
+        """One epoch of training happened, for whatever candidate."""
+        self.total_gpu_epochs += 1
+
+    def credit_deployed(self, epochs: int) -> None:
+        """*epochs* of the model that ships were kept, from a phase that ended."""
+        if epochs > 0:
+            self.deployed_epochs += epochs
+
+
+@dataclass
+class RunRecord:
+    """The fields every run must carry for its result to be comparable.
+
+    Anything optional here is optional because the feature that fills it has not
+    landed yet, not because it is nice to have. ``search_policy`` is
+    ``"exhaustive"`` for every run today; #413 introduces the alternatives and
+    this field is what makes a benchmark row from before and after that change
+    distinguishable.
+    """
+
+    #: Every epoch trained anywhere in the run.
+    total_gpu_epochs: int = 0
+    #: Epochs of training the shipped model received.
+    deployed_epochs: int = 0
+
+    #: How candidates were enumerated. Only "exhaustive" exists today (#413).
+    search_policy: str = "exhaustive"
+    #: Which rule picked the winner, from ``config.selector``.
+    selector: str = "metric_argmax"
+    #: Names the selector chose. A tuple, matching ``SelectionResult.selected``,
+    #: because a policy that advances several candidates at once needs the
+    #: plural and widening the type later would break every reader.
+    selected_candidate: tuple[str, ...] = ()
+
+    #: ``Diagnosis.to_dict()`` when one was computed, else ``None``. Shadow mode
+    #: fills this on runs whose selector ignored it, which is the point of
+    #: shadow mode.
+    diagnosis: dict[str, Any] | None = None
+
+    #: The loss quantile the robustness metrics used, from
+    #: ``config.hard_quantile_q``. Recorded beside the numbers it produced so a
+    #: reader never has to guess which sweep value a row belongs to.
+    hard_quantile_q: float | None = None
+
+    #: ``{augmentation_name: mode}`` for augmentations whose transform depends
+    #: on a mode argument (``noise_mode``, ``effect_mode``, ``camera_mode``).
+    #: Before those existed the device decided which transform ran, so a run
+    #: without this is not reproducible across machines.
+    augmentation_modes: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-ready mapping. ``selected_candidate`` becomes a list."""
+        data = asdict(self)
+        data["selected_candidate"] = list(self.selected_candidate)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> RunRecord:
+        """Rebuild from a record, tolerating one written before a field existed.
+
+        Old records must keep summarizing rather than crashing a reader, so
+        unknown keys are dropped and absent ones fall back to the field default.
+        """
+        if not data:
+            return cls()
+        known = {f for f in cls.__dataclass_fields__}
+        kwargs = {k: v for k, v in data.items() if k in known}
+        selected = kwargs.get("selected_candidate")
+        # An explicit null is as good as absent: an older writer may have left
+        # the key in place with no value.
+        if selected is None:
+            kwargs.pop("selected_candidate", None)
+        else:
+            kwargs["selected_candidate"] = tuple(selected)
+        return cls(**kwargs)
+
+
+#: Mode attributes an augmentation may carry, in the order they are looked up.
+_MODE_ATTRS = ("noise_mode", "effect_mode", "camera_mode")
+
+
+def collect_augmentation_modes(augmentations: list[Any]) -> dict[str, str]:
+    """Read the mode of every augmentation that has one.
+
+    Augmentations without a mode contribute nothing rather than a ``None``, so
+    the recorded mapping stays a statement about what was configurable.
+    """
+    modes: dict[str, str] = {}
+    for augmentation in augmentations:
+        for attr in _MODE_ATTRS:
+            mode = getattr(augmentation, attr, None)
+            if mode is not None:
+                modes[augmentation.name] = str(mode)
+                break
+    return modes

--- a/tests/test_run_record.py
+++ b/tests/test_run_record.py
@@ -1,0 +1,202 @@
+"""Tests for the mandatory run-record fields (FIX-3-1)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bnnr.training.run_record import (
+    ComputeLedger,
+    RunRecord,
+    collect_augmentation_modes,
+)
+
+
+class TestComputeLedger:
+    def test_counts_every_trained_epoch(self) -> None:
+        ledger = ComputeLedger()
+        for _ in range(7):
+            ledger.count_trained_epoch()
+        assert ledger.total_gpu_epochs == 7
+
+    def test_deployed_is_credited_separately(self) -> None:
+        """The two are different quantities, not two names for one."""
+        ledger = ComputeLedger()
+        for _ in range(12):
+            ledger.count_trained_epoch()
+        ledger.credit_deployed(3)
+        ledger.credit_deployed(2)
+        assert ledger.total_gpu_epochs == 12
+        assert ledger.deployed_epochs == 5
+
+    def test_crediting_zero_is_a_no_op(self) -> None:
+        """An iteration that kept nothing must not move the deployed count."""
+        ledger = ComputeLedger()
+        ledger.credit_deployed(0)
+        assert ledger.deployed_epochs == 0
+
+    def test_starts_at_zero(self) -> None:
+        ledger = ComputeLedger()
+        assert (ledger.total_gpu_epochs, ledger.deployed_epochs) == (0, 0)
+
+
+class TestRunRecordRoundTrip:
+    def _record(self) -> RunRecord:
+        return RunRecord(
+            total_gpu_epochs=45,
+            deployed_epochs=15,
+            search_policy="exhaustive",
+            selector="metric_argmax",
+            selected_candidate=("icd", "church_noise"),
+            diagnosis={"regime": "shortcut_suspected", "confidence": 0.75},
+            hard_quantile_q=0.2,
+            augmentation_modes={"church_noise": "regional"},
+        )
+
+    def test_to_dict_is_json_serialisable(self) -> None:
+        payload = json.dumps(self._record().to_dict())
+        assert "shortcut_suspected" in payload
+
+    def test_selected_candidate_becomes_a_list_in_json(self) -> None:
+        assert self._record().to_dict()["selected_candidate"] == ["icd", "church_noise"]
+
+    def test_from_dict_restores_the_tuple(self) -> None:
+        restored = RunRecord.from_dict(self._record().to_dict())
+        assert restored.selected_candidate == ("icd", "church_noise")
+        assert isinstance(restored.selected_candidate, tuple)
+
+    def test_round_trip_preserves_every_field(self) -> None:
+        original = self._record()
+        assert RunRecord.from_dict(original.to_dict()) == original
+
+
+class TestOldRecordsStillRead:
+    """Records written before this change must summarize, not crash."""
+
+    def test_an_empty_record_falls_back_to_defaults(self) -> None:
+        record = RunRecord.from_dict({})
+        assert record.total_gpu_epochs == 0
+        assert record.search_policy == "exhaustive"
+
+    def test_none_is_tolerated(self) -> None:
+        assert RunRecord.from_dict(None) == RunRecord()
+
+    def test_a_record_missing_new_fields_loads(self) -> None:
+        """The shape a pre-FIX-3-1 row would have."""
+        record = RunRecord.from_dict({"total_gpu_epochs": 30})
+        assert record.total_gpu_epochs == 30
+        assert record.deployed_epochs == 0
+        assert record.diagnosis is None
+
+    def test_an_unknown_key_is_dropped_rather_than_raising(self) -> None:
+        """A record written by a later version must not break an older reader."""
+        record = RunRecord.from_dict({"total_gpu_epochs": 5, "field_from_the_future": 1})
+        assert record.total_gpu_epochs == 5
+
+    def test_a_null_selected_candidate_does_not_crash(self) -> None:
+        assert RunRecord.from_dict({"selected_candidate": None}).selected_candidate == ()
+
+
+class _FakeAug:
+    def __init__(self, name: str, **modes: str) -> None:
+        self.name = name
+        for key, value in modes.items():
+            setattr(self, key, value)
+
+
+class TestAugmentationModes:
+    def test_reads_each_mode_attribute(self) -> None:
+        augs = [
+            _FakeAug("church_noise", noise_mode="regional"),
+            _FakeAug("dif_presets", effect_mode="circles"),
+            _FakeAug("procam", camera_mode="profile"),
+        ]
+        assert collect_augmentation_modes(augs) == {
+            "church_noise": "regional",
+            "dif_presets": "circles",
+            "procam": "profile",
+        }
+
+    def test_augmentations_without_a_mode_contribute_nothing(self) -> None:
+        """The mapping is a statement about what was configurable."""
+        assert collect_augmentation_modes([_FakeAug("drust")]) == {}
+
+    def test_empty_list_is_empty(self) -> None:
+        assert collect_augmentation_modes([]) == {}
+
+
+class TestRealRunPopulatesTheRecord:
+    """The counts must come from a real run, not from config arithmetic."""
+
+    def _trainer(self, tmp_path, **config_kwargs):
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, TensorDataset
+
+        from bnnr.adapter import SimpleTorchAdapter
+        from bnnr.config_model import BNNRConfig
+        from bnnr.reporting import Reporter
+        from bnnr.trainer import BNNRTrainer
+
+        torch.manual_seed(0)
+        model = nn.Sequential(nn.Flatten(), nn.Linear(3 * 8 * 8, 2))
+        adapter = SimpleTorchAdapter(
+            model=model,
+            criterion=nn.CrossEntropyLoss(),
+            optimizer=torch.optim.SGD(model.parameters(), lr=0.01),
+            device="cpu",
+        )
+        images = torch.rand(8, 3, 8, 8)
+        labels = torch.randint(0, 2, (8,))
+        loader = DataLoader(TensorDataset(images, labels), batch_size=4)
+        config = BNNRConfig(
+            m_epochs=2,
+            max_iterations=0,
+            report_dir=tmp_path / "reports",
+            verbose=False,
+            save_checkpoints=False,
+            # A two-layer Linear stack has no conv layer for OptiCAM to hook,
+            # and this test is about the epoch counts, not about saliency.
+            xai_enabled=False,
+            **config_kwargs,
+        )
+        return BNNRTrainer(
+            model=adapter,
+            train_loader=loader,
+            val_loader=loader,
+            augmentations=[],
+            config=config,
+            reporter=Reporter(tmp_path / "reports", save_html=False),
+        )
+
+    def test_a_baseline_only_run_records_both_counts(self, tmp_path) -> None:
+        result = self._trainer(tmp_path).run()
+        assert result.run_record.total_gpu_epochs == 2
+        assert result.run_record.deployed_epochs > 0
+
+    def test_deployed_never_exceeds_total(self, tmp_path) -> None:
+        record = self._trainer(tmp_path).run().run_record
+        assert record.deployed_epochs <= record.total_gpu_epochs
+
+    def test_the_selector_and_quantile_are_recorded(self, tmp_path) -> None:
+        record = self._trainer(tmp_path, hard_quantile_q=0.3).run().run_record
+        assert record.selector == "metric_argmax"
+        assert record.hard_quantile_q == pytest.approx(0.3)
+
+    def test_search_policy_is_recorded_before_alternatives_exist(self, tmp_path) -> None:
+        """So rows from before #413 stay distinguishable from rows after it."""
+        assert self._trainer(tmp_path).run().run_record.search_policy == "exhaustive"
+
+    def test_the_record_lands_in_the_json_report(self, tmp_path) -> None:
+        result = self._trainer(tmp_path).run()
+        payload = json.loads(result.report_json_path.read_text())
+        assert "run_record" in payload
+        assert payload["run_record"]["total_gpu_epochs"] == 2
+
+    def test_the_json_report_still_loads(self, tmp_path) -> None:
+        """A new key must not break the reader that validates required ones."""
+        from bnnr.reporting import load_report
+
+        result = self._trainer(tmp_path).run()
+        assert load_report(result.report_json_path) is not None


### PR DESCRIPTION
## Summary

Two findings drive this.

**The compute confound.** T20's apparent deficit under "equal compute" was the epoch split, not the method: the deployed model trains for `B/3` while a single-augmentation baseline trains the full `B`. Matching deployed epochs closed a 4.46 pp gap to 0.09 pp on Imagewoof. The record carried `max_iterations` and `m_epochs` but neither of the two numbers that actually separate the protocols, so the confound had to be reconstructed by hand, months later, by someone who remembered it existed.

**The path.** Once behaviour depends on a selector, a diagnosis, or a search policy, "BNNR vs baseline" is not a single number unless every row says which path it took. A benchmark that mixes two selectors and reports one mean is measuring their average, which is a quantity nobody wanted.

New `src/bnnr/training/run_record.py`. `BNNRRunResult` carries a `RunRecord`, `report.json` gains a `run_record` block, and `benchmarks/lib.py:_result_entry` carries every field.

| field | meaning |
|---|---|
| `total_gpu_epochs` | every epoch trained anywhere, pruned and losing candidates included |
| `deployed_epochs` | epochs the shipped model actually received |
| `search_policy` | `"exhaustive"` is the only one today |
| `selector` | from `config.selector` |
| `selected_candidate` | tuple, matching `SelectionResult.selected` |
| `diagnosis` | the attention diagnosis when one was computed |
| `hard_quantile_q` | the loss quantile the robustness metrics used |
| `augmentation_modes` | `{name: mode}` for `noise_mode` / `effect_mode` / `camera_mode` |

## The counts are counted, not derived

`m_epochs × max_iterations` is an upper bound, not an answer: pruning stops candidates early, and the deployed model keeps its **best** epoch rather than its last.

- `train_epoch` is the single chokepoint every training epoch passes through, so `total_gpu_epochs` increments there. Nothing can train an epoch without being counted.
- `deployed_epochs` is credited when a phase ends and its weights are kept: the baseline's best epoch, plus the winner's best epoch for each accepted iteration.

There is a test that runs a real trainer end to end and asserts the counts, rather than testing the ledger in isolation and hoping it is wired up.

## Decisions worth flagging

**`search_policy` is recorded as `"exhaustive"` before the alternatives exist.** That is the point rather than a placeholder: rows written before #413 stay distinguishable from rows written after it, which they would not be if the field arrived together with the feature.

**Non-search conditions get the fields too, with the two counts equal.** `no_bnnr` and `randaugment` never build a `BNNRTrainer`, but a row without the compute fields cannot be placed on an equal-compute axis at all. For them there is no search, so every epoch trained is an epoch the deployed model received. That is a fact about the condition, not a fallback — a plain-training row where the two differ would be a bug.

**`_last_diagnosis` is a slot on the trainer that stays `None`.** #411 (shadow mode) fills it. The record reads it now so shadow mode is a one-line change there rather than a second pass through this plumbing.

## Old records still summarize

- `RunRecord.from_dict` falls back to defaults for absent fields, **drops unknown ones** so a record written by a later version does not break an older reader, and treats an explicit `null` `selected_candidate` as absent.
- The summarizers read with `.get` and print `?` for a missing count.

Four tests cover exactly these shapes.

## Summarizer output

Both counts now print side by side, in the text table (`GPU-ep` / `Depl-ep`), the markdown table, and the compute-transparency section, which now reads `condition=total/deployed`. Printing only the total is how the confound survived into the results the first time.

## Test plan

- `pytest -q` -> **1491 passed, 19 skipped** (22 new).
- `ruff check src tests benchmarks` clean; `mypy` clean on the touched modules.
- Coverage: the ledger counting and crediting independently; JSON round-trip; the tuple surviving it; the four old-record shapes; mode collection including augmentations that have no mode; and six end-to-end assertions on a real run, including that the record reaches `report.json` and that `load_report` still accepts the file.

## Docs

`docs/artifacts.md` documents the `run_record` block, what each field means, why the two epoch counts differ and why they are counted rather than derived, and the backward-compatibility guarantee.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #410
