### PR TITLE
feat(training): shadow mode, record the diagnosis evidence without acting on it

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -108,6 +108,24 @@ Both are **counted as epochs run**, not derived from `m_epochs × max_iterations
 
 A report written before this key existed still loads: `RunRecord.from_dict` falls back to defaults for absent fields and ignores unknown ones, so old runs summarize rather than crashing a reader.
 
+## `shadow_records.jsonl`
+
+Written when `shadow_mode=true` (default) and XAI is enabled. One JSON object per line — JSONL rather than JSON so a run killed halfway still leaves every record it had already written.
+
+| key | meaning |
+|---|---|
+| `phase` | `"baseline"` or `"candidate"` |
+| `iteration` | which iteration produced it (`0` for the baseline phase) |
+| `candidate` | augmentation name, or `"baseline"` |
+| `stats` | the saliency statistics, or `null` when no maps were available |
+| `overall_acc`, `hard_quantile_acc`, `robustness_gap` | from the evaluation result; `null` when not measured |
+| `sample_size` | how many maps the statistics were computed over |
+| `selected` | whether this arm is the one the run kept |
+
+Every candidate of every iteration appears, not only the winner: a calibration set with only winning arms cannot answer whether the other choice would have been better.
+
+No record contains a regime or a recommendation. Producing one would need thresholds, and these records exist to calibrate them.
+
 ## `events.jsonl`
 
 Written when `event_log_enabled=true` (default). Each line is a JSON object with `schema_version` (`"2.1"`, from `bnnr.events.EVENT_SCHEMA_VERSION`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,20 @@ seed: 42
 
 Both are gated the same way: whatever a selector picks is discarded unless it beat the baseline on `selection_metric`. That gate is deliberately shared, so a comparison between two selectors is a comparison of their ranking rules and nothing else. A selector that skipped it would look better purely by accepting runs the others reject.
 
+### Shadow mode
+
+- `shadow_mode` (default: `true`)
+
+Records the attention evidence on every run and lets none of it influence selection. For each candidate of each iteration it writes the saliency statistics, the robustness metrics, and whether that candidate was the one the run kept, to `shadow_records.jsonl` in the run directory.
+
+It is on by default because it costs nothing beyond maps the run already produces. It does nothing when `xai_enabled` is `false`, since there are no maps to read.
+
+**Records are raw statistics, never a regime.** Writing a regime would need thresholds, and the thresholds are exactly what these records exist to calibrate. It needs no `diagnosis:` block and guesses nothing.
+
+**Every candidate is recorded, not only the winner.** A calibration set containing only winning arms cannot answer "would the other choice have been better", which is the question the whole exercise turns on.
+
+`perturbation_shift` is deliberately not computed here: it needs a second explainer pass, and shadow mode's claim is that it is free. The three statistics that come from maps the run already made are what get recorded.
+
 ### Diagnosis thresholds
 
 `selector: diagnosis` requires a `diagnosis:` block, and **every field in it starts unset**:

--- a/docs/diagnosis.md
+++ b/docs/diagnosis.md
@@ -63,7 +63,7 @@ This is deliberate and it is the whole discipline of the exercise. Guessing them
 
 In a config these live under the `diagnosis:` key, and requesting `selector: diagnosis` with any required one unset fails at construction. See [configuration](configuration.md#diagnosis-thresholds) for the YAML shape and `bnnr.config.load_diagnosis_profile` for loading a calibrated set from file.
 
-**Shadow mode needs none of this.** It records the raw statistics rather than a regime, so it can start collecting calibration samples from every run that was going to happen anyway, at no extra GPU cost, before any threshold exists.
+**Shadow mode needs none of this.** It records the raw statistics rather than a regime, so it can start collecting calibration samples from every run that was going to happen anyway, at no extra GPU cost, before any threshold exists. It is on by default; see [`shadow_records.jsonl`](artifacts.md#shadow_recordsjsonl) for what it writes.
 
 ## Using it as a selector
 

--- a/src/bnnr/config_model.py
+++ b/src/bnnr/config_model.py
@@ -103,6 +103,11 @@ class BNNRConfig(BaseModel):
     checkpoint_dir: Path = Path("checkpoints")
     report_dir: Path = Path("reports")
     xai_enabled: bool = True
+    #: Record the attention evidence on every run without letting it decide
+    #: anything, so calibration has something to calibrate on. Costs nothing
+    #: beyond maps the run already produces, hence on by default; it does
+    #: nothing when xai_enabled is False, since there are no maps to read.
+    shadow_mode: bool = True
     xai_samples: int = 4
     xai_method: str = "opticam"
     device: str = "auto"

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -28,6 +28,7 @@ from bnnr.training import loop as _loop
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
 from bnnr.training import run_record as _run_record
+from bnnr.training import shadow as _shadow
 from bnnr.training.checkpoint import (  # noqa: F401 — re-exported for backward compat
     _RuntimeState,
     _TrainerState,
@@ -97,6 +98,10 @@ class BNNRTrainer:
         # Set when a diagnosis was computed for the run. Stays None until
         # shadow mode (#411) starts filling it on every run.
         self._last_diagnosis: Any | None = None
+        # Shadow-mode observations for this run. Recorded on every candidate,
+        # acted on by nothing.
+        self._shadow = _shadow.ShadowRecorder()
+        self._last_saliency_maps: Any | None = None
         self.logger = setup_logging("bnnr", config.log_file, json_format=True)
         self._custom_metrics: dict[str, Any] = custom_metrics or {}
 

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -23,6 +23,7 @@ from bnnr.training import hard_quantile as _hard_quantile
 from bnnr.training import metrics as _metrics
 from bnnr.training import probe as _probe
 from bnnr.training import run_record as _run_record
+from bnnr.training import shadow as _shadow
 from bnnr.training import xai_runner as _xai
 from bnnr.training.metrics import average_metrics
 from bnnr.utils import set_seed
@@ -512,6 +513,13 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
         )
 
         # Emit XAI-guided augmentation hints after baseline
+        _record_shadow(
+            trainer,
+            phase="baseline",
+            iteration=0,
+            candidate="baseline",
+            metrics=baseline_metrics,
+        )
         if xai_diagnoses and trainer._prev_xai_batch_stats:
             _xai.generate_augmentation_hints(trainer,
                 xai_diagnoses, trainer._prev_xai_batch_stats, phase="baseline",
@@ -672,6 +680,13 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
                 _, cand_xai_diag, _ = _xai.generate_xai_lightweight(trainer,
                     iteration, augmentation.name, confusion=confusion_candidate,
                 )
+                _record_shadow(
+                    trainer,
+                    phase="candidate",
+                    iteration=iteration,
+                    candidate=augmentation.name,
+                    metrics=cand_best_metrics,
+                )
                 if cand_xai_diag:
                     avg_q = float(np.mean([
                         d.get("quality_score", 0.0) for d in cand_xai_diag.values()
@@ -749,6 +764,8 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
             baseline_metrics,
             xai_scores=xai_scores_by_candidate if candidates else None,
         )
+        # Shadow records are only a calibration set once they say which arm won.
+        trainer._shadow.mark_selected(iteration, selected_name)
         top_candidate_names = _branching.top_k_candidate_names(iteration_results, trainer.config, k=3)
         candidate_preview_pairs: dict[str, list[tuple[Path, Path]]] = {}
         aug_by_name = {aug.name: aug for aug in trainer.augmentations}
@@ -939,6 +956,8 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
     dual_xai_analysis = _xai.generate_dual_xai_analysis(trainer)
     if dual_xai_analysis:
         analysis["dual_xai"] = dual_xai_analysis
+    if trainer.config.shadow_mode:
+        trainer._shadow.write(trainer.reporter.run_dir)
     trainer._emit_pipeline_complete()
     result = trainer.reporter.finalize(
         best_path=best_path,
@@ -971,4 +990,36 @@ def _build_run_record(
         diagnosis=diagnosis.to_dict() if diagnosis is not None else None,
         hard_quantile_q=trainer.config.hard_quantile_q,
         augmentation_modes=_run_record.collect_augmentation_modes(trainer.augmentations),
+    )
+
+
+def _record_shadow(
+    trainer: BNNRTrainer,
+    *,
+    phase: str,
+    iteration: int,
+    candidate: str,
+    metrics: dict[str, float] | None,
+) -> None:
+    """Record one shadow observation from the maps the run just produced.
+
+    Reads ``trainer._last_saliency_maps``, which the XAI runner stashes, and
+    clears it afterwards so a candidate whose XAI probe produced nothing cannot
+    silently inherit the previous candidate's attention.
+    """
+    if not trainer.config.shadow_mode:
+        return
+    maps = trainer._last_saliency_maps
+    trainer._last_saliency_maps = None
+    if maps is None:
+        return
+    stats = _shadow.stats_from_maps(maps)
+    if stats is None:
+        return
+    trainer._shadow.record(
+        phase=phase,
+        iteration=iteration,
+        candidate=candidate,
+        stats=stats,
+        metrics=metrics,
     )

--- a/src/bnnr/training/shadow.py
+++ b/src/bnnr/training/shadow.py
@@ -1,0 +1,178 @@
+"""Record the attention evidence on every run, without letting it decide anything.
+
+The thresholds the diagnosis needs have no defaults and the library refuses
+diagnostic mode until they are supplied. Something has to supply them, and the
+only alternatives are to guess — the mistake this whole programme exists to
+undo — or to collect evidence first.
+
+Shadow mode collects it. Every run computes the saliency statistics and the
+robustness metrics it was going to compute anyway, records them per candidate
+alongside which candidate the run actually kept and how it turned out, and lets
+none of it touch selection. From the moment it is on, a run that was going to
+happen regardless becomes a sample of *(statistics, chosen arm, outcome)* at no
+extra GPU cost.
+
+This is why Phase 3 sits before Phase 4 rather than inside it.
+
+**Records are raw statistics, never a regime.** Writing a regime would need
+thresholds, and the thresholds are the thing being calibrated. A record that
+already assumed an answer would be useless for finding it.
+
+**Every candidate is recorded, not only the winner.** A calibration set with
+only winning arms cannot answer "would the other choice have been better",
+which is the question the whole exercise turns on.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bnnr.analysis.saliency_stats import SaliencyStats
+
+__all__ = [
+    "SHADOW_RECORDS_FILENAME",
+    "ShadowRecord",
+    "ShadowRecorder",
+]
+
+#: One JSON object per line, in the run directory. JSONL rather than JSON so a
+#: run killed halfway still leaves every record it had already written.
+SHADOW_RECORDS_FILENAME = "shadow_records.jsonl"
+
+
+@dataclass
+class ShadowRecord:
+    """One observation: what the attention looked like, and what happened.
+
+    ``candidate`` is the augmentation name, or ``"baseline"`` for the phase
+    before any augmentation was applied. ``selected`` says whether this arm is
+    the one the run kept, which is what turns a pile of statistics into a
+    supervised calibration set.
+    """
+
+    phase: str
+    iteration: int
+    candidate: str
+
+    #: ``SaliencyStats.to_dict()``, or ``None`` when no maps were available.
+    stats: dict[str, Any] | None = None
+
+    overall_acc: float | None = None
+    hard_quantile_acc: float | None = None
+    robustness_gap: float | None = None
+
+    #: How many images the statistics were computed over. Recorded because the
+    #: probe set is a sample, and a statistic without its sample size cannot be
+    #: weighted against another run's.
+    sample_size: int = 0
+
+    #: Whether this arm was the one the run kept. Filled in after selection, so
+    #: it is False on every record until the iteration resolves.
+    selected: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ShadowRecorder:
+    """Accumulates records for a run and writes them as JSONL.
+
+    Held in memory until the run ends because ``selected`` is only knowable
+    after the iteration resolves, and rewriting a line in place is worse than
+    holding a few hundred small dicts.
+    """
+
+    records: list[ShadowRecord] = field(default_factory=list)
+
+    def record(
+        self,
+        *,
+        phase: str,
+        iteration: int,
+        candidate: str,
+        stats: SaliencyStats | None,
+        metrics: dict[str, float] | None,
+    ) -> ShadowRecord:
+        """Add one observation, reading the robustness fields off *metrics*.
+
+        The metrics dict is whatever the evaluation returned. The three
+        robustness keys are absent for multilabel and detection runs, and that
+        is recorded as ``None`` rather than as zero: no measurement and a
+        measurement of zero are different facts about a run.
+        """
+        metrics = metrics or {}
+        entry = ShadowRecord(
+            phase=phase,
+            iteration=iteration,
+            candidate=candidate,
+            stats=stats.to_dict() if stats is not None else None,
+            overall_acc=_maybe_float(metrics.get("accuracy")),
+            hard_quantile_acc=_maybe_float(metrics.get("hard_quantile_acc")),
+            robustness_gap=_maybe_float(metrics.get("robustness_gap")),
+            sample_size=stats.n_maps if stats is not None else 0,
+        )
+        self.records.append(entry)
+        return entry
+
+    def mark_selected(self, iteration: int, candidate: str | None) -> None:
+        """Flag the arm this iteration kept, if it kept one."""
+        if candidate is None:
+            return
+        for entry in self.records:
+            if entry.iteration == iteration and entry.candidate == candidate:
+                entry.selected = True
+
+    def write(self, run_dir: Path) -> Path | None:
+        """Write the records to *run_dir*, or do nothing when there are none."""
+        if not self.records:
+            return None
+        path = run_dir / SHADOW_RECORDS_FILENAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = [json.dumps(entry.to_dict()) for entry in self.records]
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+
+
+def _maybe_float(value: Any) -> float | None:
+    """Coerce to float, keeping the difference between absent and zero."""
+    return None if value is None else float(value)
+
+
+def stats_from_maps(maps: Any, *, n_maps: int | None = None) -> SaliencyStats | None:
+    """Aggregate saliency statistics over a batch of maps.
+
+    Returns ``None`` rather than a zeroed record when there are no maps, so a
+    run with XAI disabled contributes nothing instead of contributing a
+    misleading "perfectly uniform attention" sample.
+
+    ``perturbation_shift`` is deliberately not computed here. It needs a second
+    explainer pass, and shadow mode's entire claim is that it costs nothing;
+    paying for it silently on every run would break that. The three pure
+    statistics come free from maps the run already produced.
+    """
+    import numpy as np
+
+    from bnnr.analysis.saliency_stats import aggregate_saliency_stats, saliency_stats_from_map
+
+    array = np.asarray(maps)
+    if array.size == 0:
+        return None
+    if array.ndim == 2:
+        array = array[None, ...]
+    if array.ndim != 3:
+        return None
+
+    per_map = [saliency_stats_from_map(array[i]) for i in range(array.shape[0])]
+    if not per_map:
+        return None
+    aggregate = aggregate_saliency_stats(per_map)
+    if n_maps is not None and n_maps != aggregate.n_maps:
+        from dataclasses import replace
+
+        aggregate = replace(aggregate, n_maps=n_maps)
+    return aggregate

--- a/src/bnnr/training/xai_runner.py
+++ b/src/bnnr/training/xai_runner.py
@@ -342,6 +342,9 @@ def generate_xai(trainer, iteration: int, augmentation_name: str, confusion: dic
         target_layers=trainer.model.get_target_layers(),
         method=trainer.config.xai_method,
     )
+    # Shadow mode reads these where the candidate and its metrics are in scope.
+    # Stashing rather than threading keeps the XAI signatures unchanged.
+    trainer._last_saliency_maps = maps
 
     # Lightweight predictions for insight context (no extra forward pass cost
     # when the model is already in eval mode from generate_saliency_maps).
@@ -418,6 +421,9 @@ def generate_xai_lightweight(trainer, iteration: int, augmentation_name: str, co
         target_layers=trainer.model.get_target_layers(),
         method=trainer.config.xai_method,
     )
+    # Shadow mode reads these where the candidate and its metrics are in scope.
+    # Stashing rather than threading keeps the XAI signatures unchanged.
+    trainer._last_saliency_maps = maps
 
     # For multi-label: XAI maps target one class, so we use dominant (argmax).
     with torch.no_grad():

--- a/tests/test_run_record.py
+++ b/tests/test_run_record.py
@@ -186,7 +186,11 @@ class TestRealRunPopulatesTheRecord:
 
     def test_search_policy_is_recorded_before_alternatives_exist(self, tmp_path) -> None:
         """So rows from before #413 stay distinguishable from rows after it."""
-        assert self._trainer(tmp_path).run().run_record.search_policy == "exhaustive"
+        # The run happens on its own line: an assert is stripped under
+        # python -O, and one that also performs the action under test would
+        # take the action with it.
+        record = self._trainer(tmp_path).run().run_record
+        assert record.search_policy == "exhaustive"
 
     def test_the_record_lands_in_the_json_report(self, tmp_path) -> None:
         result = self._trainer(tmp_path).run()
@@ -199,4 +203,5 @@ class TestRealRunPopulatesTheRecord:
         from bnnr.reporting import load_report
 
         result = self._trainer(tmp_path).run()
-        assert load_report(result.report_json_path) is not None
+        reloaded = load_report(result.report_json_path)
+        assert reloaded is not None

--- a/tests/test_shadow_mode.py
+++ b/tests/test_shadow_mode.py
@@ -1,0 +1,346 @@
+"""Tests for shadow mode (FIX-3-2)."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from bnnr.analysis.saliency_stats import SaliencyStats
+from bnnr.config_model import BNNRConfig
+from bnnr.training.shadow import (
+    SHADOW_RECORDS_FILENAME,
+    ShadowRecord,
+    ShadowRecorder,
+    stats_from_maps,
+)
+
+
+def _stats(n_maps: int = 4) -> SaliencyStats:
+    return SaliencyStats(
+        concentration=0.42,
+        gini=0.55,
+        border_mass=0.18,
+        resolution=(14, 14),
+        n_maps=n_maps,
+    )
+
+
+class TestRecorder:
+    def test_records_the_raw_statistics_not_a_regime(self) -> None:
+        """A regime would need thresholds, and thresholds are what this
+        collects evidence for."""
+        recorder = ShadowRecorder()
+        entry = recorder.record(
+            phase="baseline", iteration=0, candidate="baseline",
+            stats=_stats(), metrics={"accuracy": 0.9},
+        )
+        assert "regime" not in entry.to_dict()
+        assert entry.stats is not None
+        assert entry.stats["concentration"] == pytest.approx(0.42)
+
+    def test_reads_the_robustness_metrics(self) -> None:
+        recorder = ShadowRecorder()
+        entry = recorder.record(
+            phase="candidate", iteration=1, candidate="icd", stats=_stats(),
+            metrics={"accuracy": 0.9, "hard_quantile_acc": 0.4, "robustness_gap": 0.5},
+        )
+        assert entry.overall_acc == pytest.approx(0.9)
+        assert entry.hard_quantile_acc == pytest.approx(0.4)
+        assert entry.robustness_gap == pytest.approx(0.5)
+
+    def test_absent_metrics_are_none_not_zero(self) -> None:
+        """No measurement and a measurement of zero are different facts."""
+        recorder = ShadowRecorder()
+        entry = recorder.record(
+            phase="candidate", iteration=1, candidate="icd",
+            stats=_stats(), metrics={"accuracy": 0.9},
+        )
+        assert entry.hard_quantile_acc is None
+        assert entry.robustness_gap is None
+
+    def test_sample_size_travels_with_the_statistics(self) -> None:
+        recorder = ShadowRecorder()
+        entry = recorder.record(
+            phase="baseline", iteration=0, candidate="baseline",
+            stats=_stats(n_maps=7), metrics={},
+        )
+        assert entry.sample_size == 7
+
+    def test_no_stats_records_a_zero_sample(self) -> None:
+        recorder = ShadowRecorder()
+        entry = recorder.record(
+            phase="baseline", iteration=0, candidate="baseline", stats=None, metrics={},
+        )
+        assert entry.stats is None
+        assert entry.sample_size == 0
+
+
+class TestSelectionFlag:
+    def _recorder(self) -> ShadowRecorder:
+        recorder = ShadowRecorder()
+        for name in ("icd", "aicd", "church_noise"):
+            recorder.record(
+                phase="candidate", iteration=1, candidate=name, stats=_stats(), metrics={},
+            )
+        return recorder
+
+    def test_only_the_winner_is_flagged(self) -> None:
+        recorder = self._recorder()
+        recorder.mark_selected(1, "aicd")
+        flagged = [r.candidate for r in recorder.records if r.selected]
+        assert flagged == ["aicd"]
+
+    def test_every_candidate_is_kept_not_only_the_winner(self) -> None:
+        """A calibration set with only winning arms cannot answer 'would the
+        other choice have been better'."""
+        recorder = self._recorder()
+        recorder.mark_selected(1, "aicd")
+        assert len(recorder.records) == 3
+
+    def test_no_selection_flags_nothing(self) -> None:
+        recorder = self._recorder()
+        recorder.mark_selected(1, None)
+        assert not any(r.selected for r in recorder.records)
+
+    def test_a_different_iteration_is_not_touched(self) -> None:
+        recorder = self._recorder()
+        recorder.record(phase="candidate", iteration=2, candidate="icd", stats=_stats(), metrics={})
+        recorder.mark_selected(1, "icd")
+        by_iteration = {(r.iteration, r.selected) for r in recorder.records if r.candidate == "icd"}
+        assert by_iteration == {(1, True), (2, False)}
+
+
+class TestWriting:
+    def test_writes_one_json_object_per_line(self, tmp_path) -> None:
+        recorder = ShadowRecorder()
+        for i in range(3):
+            recorder.record(
+                phase="candidate", iteration=1, candidate=f"aug_{i}",
+                stats=_stats(), metrics={"accuracy": 0.8},
+            )
+        path = recorder.write(tmp_path)
+        assert path is not None
+        lines = path.read_text().strip().split("\n")
+        assert len(lines) == 3
+        assert json.loads(lines[0])["candidate"] == "aug_0"
+
+    def test_the_filename_is_stable(self, tmp_path) -> None:
+        recorder = ShadowRecorder()
+        recorder.record(phase="baseline", iteration=0, candidate="baseline", stats=_stats(), metrics={})
+        assert recorder.write(tmp_path).name == SHADOW_RECORDS_FILENAME
+
+    def test_nothing_recorded_writes_no_file(self, tmp_path) -> None:
+        assert ShadowRecorder().write(tmp_path) is None
+        assert not (tmp_path / SHADOW_RECORDS_FILENAME).exists()
+
+    def test_creates_the_directory(self, tmp_path) -> None:
+        recorder = ShadowRecorder()
+        recorder.record(phase="baseline", iteration=0, candidate="baseline", stats=_stats(), metrics={})
+        target = tmp_path / "nested" / "run"
+        assert recorder.write(target) is not None
+
+
+class TestStatsFromMaps:
+    def test_aggregates_a_batch(self) -> None:
+        maps = np.random.default_rng(0).random((5, 14, 14)).astype(np.float32)
+        stats = stats_from_maps(maps)
+        assert stats is not None
+        assert stats.n_maps == 5
+
+    def test_a_single_map_is_accepted(self) -> None:
+        stats = stats_from_maps(np.zeros((14, 14), dtype=np.float32))
+        assert stats is not None
+        assert stats.n_maps == 1
+
+    def test_empty_maps_contribute_nothing(self) -> None:
+        """Not a zeroed record: that would be a misleading 'perfectly uniform
+        attention' sample rather than an absent one."""
+        assert stats_from_maps(np.zeros((0, 14, 14), dtype=np.float32)) is None
+
+    def test_wrong_rank_is_refused(self) -> None:
+        assert stats_from_maps(np.zeros((2, 3, 14, 14), dtype=np.float32)) is None
+
+    def test_perturbation_shift_is_not_computed(self) -> None:
+        """It needs a second explainer pass, and shadow mode's whole claim is
+        that it costs nothing."""
+        stats = stats_from_maps(np.random.default_rng(1).random((3, 14, 14)).astype(np.float32))
+        assert stats is not None
+        assert stats.perturbation_shift is None
+
+
+class TestConfig:
+    def test_shadow_mode_is_on_by_default(self) -> None:
+        assert BNNRConfig().shadow_mode is True
+
+    def test_it_can_be_turned_off(self) -> None:
+        assert BNNRConfig(shadow_mode=False).shadow_mode is False
+
+
+class TestSelectionIsUnchanged:
+    """The load-bearing claim: shadow mode observes and changes nothing."""
+
+    def _run(self, tmp_path, *, shadow: bool):
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, TensorDataset
+
+        from bnnr.adapter import SimpleTorchAdapter
+        from bnnr.augmentations import BasicAugmentation, ChurchNoise
+        from bnnr.reporting import Reporter
+        from bnnr.trainer import BNNRTrainer
+
+        torch.manual_seed(0)
+        model = nn.Sequential(
+            nn.Conv2d(3, 4, 3, padding=1), nn.ReLU(),
+            nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(4, 2),
+        )
+        adapter = SimpleTorchAdapter(
+            model=model,
+            criterion=nn.CrossEntropyLoss(),
+            optimizer=torch.optim.SGD(model.parameters(), lr=0.01),
+            device="cpu",
+        )
+        images = torch.rand(8, 3, 8, 8)
+        labels = torch.randint(0, 2, (8,))
+        loader = DataLoader(TensorDataset(images, labels), batch_size=4)
+        config = BNNRConfig(
+            m_epochs=1,
+            max_iterations=1,
+            report_dir=tmp_path / f"reports_{shadow}",
+            verbose=False,
+            save_checkpoints=False,
+            xai_enabled=False,
+            shadow_mode=shadow,
+        )
+        trainer = BNNRTrainer(
+            model=adapter,
+            train_loader=loader,
+            val_loader=loader,
+            augmentations=[
+                BasicAugmentation(probability=1.0, random_state=0),
+                ChurchNoise(probability=1.0, random_state=0),
+            ],
+            config=config,
+            reporter=Reporter(tmp_path / f"reports_{shadow}", save_html=False),
+        )
+        return trainer.run()
+
+    def test_the_same_candidate_is_selected_either_way(self, tmp_path) -> None:
+        with_shadow = self._run(tmp_path, shadow=True)
+        without = self._run(tmp_path, shadow=False)
+        assert with_shadow.best_path == without.best_path
+        assert with_shadow.selected_augmentations == without.selected_augmentations
+
+    def test_the_metrics_are_identical(self, tmp_path) -> None:
+        with_shadow = self._run(tmp_path, shadow=True)
+        without = self._run(tmp_path, shadow=False)
+        assert with_shadow.best_metrics == without.best_metrics
+
+    def test_disabled_shadow_mode_writes_no_file(self, tmp_path) -> None:
+        result = self._run(tmp_path, shadow=False)
+        assert not (result.report_json_path.parent / SHADOW_RECORDS_FILENAME).exists()
+
+
+class TestRecordShape:
+    def test_a_record_serialises_to_json(self) -> None:
+        entry = ShadowRecord(phase="baseline", iteration=0, candidate="baseline")
+        assert json.loads(json.dumps(entry.to_dict()))["phase"] == "baseline"
+
+    def test_selected_starts_false(self) -> None:
+        assert ShadowRecord(phase="candidate", iteration=1, candidate="icd").selected is False
+
+
+class TestARealRunProducesTheRecordsFile:
+    """The 'done when' criterion: a normal run with XAI on writes a record for
+    every candidate, and selection is still unchanged."""
+
+    def _run(self, tmp_path, *, shadow: bool, tag: str):
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, TensorDataset
+
+        from bnnr.adapter import SimpleTorchAdapter
+        from bnnr.augmentations import BasicAugmentation, ChurchNoise
+        from bnnr.reporting import Reporter
+        from bnnr.trainer import BNNRTrainer
+
+        torch.manual_seed(0)
+        conv = nn.Conv2d(3, 4, 3, padding=1)
+        model = nn.Sequential(
+            conv, nn.ReLU(), nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(4, 2)
+        )
+        adapter = SimpleTorchAdapter(
+            model=model,
+            criterion=nn.CrossEntropyLoss(),
+            optimizer=torch.optim.SGD(model.parameters(), lr=0.01),
+            device="cpu",
+        )
+        images = torch.rand(8, 3, 16, 16)
+        labels = torch.randint(0, 2, (8,))
+        loader = DataLoader(TensorDataset(images, labels), batch_size=4)
+        config = BNNRConfig(
+            m_epochs=1,
+            max_iterations=1,
+            report_dir=tmp_path / tag,
+            verbose=False,
+            save_checkpoints=False,
+            xai_enabled=True,
+            xai_samples=2,
+            shadow_mode=shadow,
+        )
+        trainer = BNNRTrainer(
+            model=adapter,
+            train_loader=loader,
+            val_loader=loader,
+            augmentations=[
+                BasicAugmentation(probability=1.0, random_state=0),
+                ChurchNoise(probability=1.0, random_state=0),
+            ],
+            config=config,
+            reporter=Reporter(tmp_path / tag, save_html=False),
+        )
+        return trainer.run()
+
+    def _records(self, result) -> list[dict]:
+        path = result.report_json_path.parent / SHADOW_RECORDS_FILENAME
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text().strip().split("\n")]
+
+    def test_a_record_exists_for_every_candidate(self, tmp_path) -> None:
+        result = self._run(tmp_path, shadow=True, tag="on")
+        candidates = {r["candidate"] for r in self._records(result) if r["phase"] == "candidate"}
+        assert candidates == {"basic_augmentation", "church_noise"}
+
+    def test_the_baseline_phase_is_recorded_too(self, tmp_path) -> None:
+        result = self._run(tmp_path, shadow=True, tag="on")
+        phases = {r["phase"] for r in self._records(result)}
+        assert "baseline" in phases
+
+    def test_records_carry_statistics_and_a_sample_size(self, tmp_path) -> None:
+        result = self._run(tmp_path, shadow=True, tag="on")
+        records = self._records(result)
+        assert records
+        for record in records:
+            assert record["stats"] is not None
+            assert record["stats"]["resolution"] == [14, 14]
+            assert record["sample_size"] > 0
+
+    def test_no_record_claims_a_regime(self, tmp_path) -> None:
+        result = self._run(tmp_path, shadow=True, tag="on")
+        for record in self._records(result):
+            assert "regime" not in record
+            assert "recommended" not in record
+
+    def test_selection_is_unchanged_with_records_actually_written(
+        self, tmp_path
+    ) -> None:
+        """The claim that matters, tested where shadow mode is doing work."""
+        with_shadow = self._run(tmp_path, shadow=True, tag="on")
+        without = self._run(tmp_path, shadow=False, tag="off")
+        assert self._records(with_shadow)  # it really did record
+        assert not self._records(without)
+        assert with_shadow.best_path == without.best_path
+        assert with_shadow.best_metrics == without.best_metrics

--- a/tests/test_shadow_mode.py
+++ b/tests/test_shadow_mode.py
@@ -129,17 +129,25 @@ class TestWriting:
     def test_the_filename_is_stable(self, tmp_path) -> None:
         recorder = ShadowRecorder()
         recorder.record(phase="baseline", iteration=0, candidate="baseline", stats=_stats(), metrics={})
-        assert recorder.write(tmp_path).name == SHADOW_RECORDS_FILENAME
+        # The write happens on its own line: under python -O an assert is
+        # stripped, and an assertion that also performs the action under test
+        # would take the action with it.
+        path = recorder.write(tmp_path)
+        assert path is not None
+        assert path.name == SHADOW_RECORDS_FILENAME
 
     def test_nothing_recorded_writes_no_file(self, tmp_path) -> None:
-        assert ShadowRecorder().write(tmp_path) is None
+        path = ShadowRecorder().write(tmp_path)
+        assert path is None
         assert not (tmp_path / SHADOW_RECORDS_FILENAME).exists()
 
     def test_creates_the_directory(self, tmp_path) -> None:
         recorder = ShadowRecorder()
         recorder.record(phase="baseline", iteration=0, candidate="baseline", stats=_stats(), metrics={})
         target = tmp_path / "nested" / "run"
-        assert recorder.write(target) is not None
+        path = recorder.write(target)
+        assert path is not None
+        assert path.parent == target
 
 
 class TestStatsFromMaps:


### PR DESCRIPTION
## Summary

#405 says the diagnosis thresholds have no defaults and the library refuses diagnostic mode until they are supplied. #417 has to supply them. Without shadow mode there is nothing to calibrate on, and the only way out would be to guess — the mistake the whole programme exists to undo.

Shadow mode records the saliency statistics and the robustness metrics on every run, per candidate, alongside which candidate the run kept, and lets none of it influence selection. From the moment it lands, a run that was going to happen anyway becomes a sample of *(statistics, chosen arm, outcome)* at no extra GPU cost.

This is why Phase 3 sits before Phase 4 rather than inside it.

New `src/bnnr/training/shadow.py`; output is `shadow_records.jsonl` in the run directory.

## Four properties that make the records usable

**Raw statistics, never a regime.** Writing a regime would need thresholds, and the thresholds are exactly what these records exist to calibrate. A record that already assumed an answer would be useless for finding it. There is a test asserting no record carries `regime` or `recommended`.

**Every candidate, not only the winner.** Each record carries `selected`. A calibration set with only winning arms cannot answer "would the other choice have been better", which is the question the whole exercise turns on.

**Absent is not zero.** A metric the run did not measure records as `null`. No measurement and a measurement of zero are different facts, and a calibration set that confuses them is worse than one missing rows. Same reason a run with no maps contributes nothing rather than a zeroed record that would read as *perfectly uniform attention*.

**The sample size travels with the statistics.** The probe set is a sample, and a statistic without its sample size cannot be weighted against another run's.

## It really is free

The statistics come from maps the XAI probe already produced. The runner stashes them on the trainer; the loop reads them where the candidate, the iteration and the metrics are all in scope. No XAI signature changes, no extra pass runs.

The stash is **cleared after each read**, so a candidate whose probe produced nothing cannot silently inherit the previous candidate's attention — that would be a corrupt calibration row rather than a missing one.

`perturbation_shift` is deliberately **not** computed. It needs a second explainer pass, and shadow mode's entire claim is that it costs nothing; paying for it silently on every run would break that claim. There is a test pinning it to `None`.

## The load-bearing claim, tested where it matters

"Selection behaviour is provably unchanged" is worth nothing if tested on a configuration where shadow mode does no work. `TestARealRunProducesTheRecordsFile` runs the same trainer twice **with XAI enabled**, recording and not, and asserts:

- the recording run's file is non-empty and the other's does not exist;
- both reach the same `best_path` and the same `best_metrics`.

## Defaults

`shadow_mode` defaults to `true` because it is free, and does nothing when `xai_enabled` is `false` since there are no maps to read. JSONL rather than JSON so a run killed halfway still leaves every record it had already written.

## Test plan

- `pytest -q` -> **1521 passed, 19 skipped** (30 new).
- `ruff check src tests` clean; `mypy` clean on both touched modules.
- Coverage: the recorder's fields and null handling; the selection flag including that it leaves other iterations alone; writing, the stable filename, the empty case, directory creation; map aggregation including empty and wrong-rank inputs; the config default; and ten end-to-end assertions across two real runs.

## Docs

`docs/configuration.md` gains a `Shadow mode` section; `docs/artifacts.md` documents `shadow_records.jsonl` key by key; `docs/diagnosis.md` links to it from the thresholds section.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #411
