### PR TITLE
fix(config): deprecate the guessed XAI knobs and stop double-counting accuracy

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,22 @@ seed: 42
 
 Both are gated the same way: whatever a selector picks is discarded unless it beat the baseline on `selection_metric`. That gate is deliberately shared, so a comparison between two selectors is a comparison of their ranking rules and nothing else. A selector that skipped it would look better purely by accepting runs the others reject.
 
+### Deprecated XAI selection knobs
+
+`xai_selection_weight` and `xai_pruning_threshold` are **deprecated as of 0.x**. Both keep working and both emit a `DeprecationWarning` when you set them to a non-zero value.
+
+Both are built on `compute_xai_quality_score`, a hand-weighted scalar whose component weights were chosen by hand and never calibrated against an outcome. The T20 benchmark traced its null result to exactly this path.
+
+There were two separate defects:
+
+**Accuracy was counted twice.** The quality score carried accuracy at 25 %, and `select_best_path` then blended that score against the normalised selection metric — which is accuracy. The effective accuracy weight of the composite was a number nobody chose, and the two copies were not even the same quantity: one min-max normalised across candidates, the other the raw probe-set fraction. Accuracy is no longer part of the weighted sum; it remains in the breakdown as an observation.
+
+**The score encodes a prior.** It rewards high Gini and penalises `edge_ratio` unconditionally, so it hard-codes "concentrated, central saliency is good". That is precisely the question [the diagnosis](diagnosis.md) answers per case — and for a Waterbirds-like model the built-in prior points the wrong way, since a model reading background context has diffuse, border-heavy attention and needs ICD, which this score ranks last.
+
+**Preset change.** `xai_full` and `xai_adaptive` shipped `xai_selection_weight` of 0.1 and 0.15. Both are now `0.0`. Everything those presets are actually for — XAI reporting, dual XAI, adaptive ICD thresholds — is unchanged. Set the field yourself if you want the old behaviour.
+
+`xai_pruning_threshold` keeps its preset values, since dropping a candidate is recoverable in a way that selecting the wrong one is not.
+
 ### Shadow mode
 
 - `shadow_mode` (default: `true`)

--- a/src/bnnr/config.py
+++ b/src/bnnr/config.py
@@ -215,7 +215,10 @@ _XAI_PRESETS: dict[str, dict[str, Any]] = {
         "xai_enabled": True,
         "xai_method": "opticam",
         "dual_xai_report": True,
-        "xai_selection_weight": 0.1,
+        # Was 0.1. Zeroed in 0.x: it steered selection with a weight nobody
+        # measured, which is the path T20 traced its null result to. The XAI
+        # reporting this preset is actually for is unaffected.
+        "xai_selection_weight": 0.0,
         "xai_pruning_threshold": 0.15,
         "adaptive_icd_threshold": True,
     },
@@ -223,7 +226,8 @@ _XAI_PRESETS: dict[str, dict[str, Any]] = {
         "xai_enabled": True,
         "xai_method": "opticam",
         "dual_xai_report": False,
-        "xai_selection_weight": 0.15,
+        # Was 0.15, zeroed for the same reason as xai_full.
+        "xai_selection_weight": 0.0,
         "xai_pruning_threshold": 0.2,
         "adaptive_icd_threshold": True,
     },
@@ -259,12 +263,22 @@ def apply_xai_preset(config: BNNRConfig, preset: str) -> BNNRConfig:
 
     * ``"xai_light"`` – XAI enabled with defaults (no influence on
       training decisions).  Good for dashboards and reports.
-    * ``"xai_full"`` – All XAI features activated: composite selection
-      (10 % weight), XAI-based pruning, adaptive ICD thresholds, and
-      dual XAI report.
-    * ``"xai_adaptive"`` – XAI actively guides training: higher
-      composite selection weight (15 %), stricter pruning, and adaptive
-      ICD thresholds.
+    * ``"xai_full"`` – All XAI reporting activated: XAI-based pruning,
+      adaptive ICD thresholds, and dual XAI report. Composite selection
+      is **off** as of 0.x; see the note below.
+    * ``"xai_adaptive"`` – Stricter XAI-based pruning and adaptive ICD
+      thresholds. Composite selection is **off** as of 0.x.
+
+    .. note::
+       ``xai_full`` and ``xai_adaptive`` used to ship
+       ``xai_selection_weight`` of 0.1 and 0.15. Both are now 0.0. Those
+       weights blended a hand-weighted saliency scalar into candidate
+       selection, and T20 traced its null result to that path. Set the field
+       yourself if you want the old behaviour; it still works and warns.
+
+       ``xai_pruning_threshold`` is deprecated but left at its preset values,
+       since removing a candidate is reversible in a way that selecting the
+       wrong one is not.
 
     Parameters
     ----------

--- a/src/bnnr/config_model.py
+++ b/src/bnnr/config_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -9,6 +10,19 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 if TYPE_CHECKING:
     from bnnr.analysis.diagnosis import DiagnosisThresholds
+
+#: Knobs whose value came from nobody's measurement, with what to do instead.
+#: They keep working; the warning exists so a run that depends on one says so.
+_DEPRECATED_XAI_KNOBS = {
+    "xai_selection_weight": (
+        "Use selector='diagnosis' with calibrated thresholds to let attention "
+        "decide, or leave it at 0.0 to select on the metric alone."
+    ),
+    "xai_pruning_threshold": (
+        "Use candidate_pruning_relative_threshold, which prunes on the metric "
+        "being optimised rather than on a hand-weighted saliency scalar."
+    ),
+}
 
 #: Selectors that cannot run without calibrated thresholds. A diagnosis-driven
 #: search policy (#413) joins this set rather than growing a second check.
@@ -224,6 +238,35 @@ class BNNRConfig(BaseModel):
         if value <= 0:
             raise ValueError("detection_xai_* controls must be > 0")
         return value
+
+    @model_validator(mode="after")
+    def warn_on_uncalibrated_xai_knobs(self) -> BNNRConfig:
+        """Warn when a run is steered by a weight nobody measured.
+
+        Both knobs are built on ``compute_xai_quality_score``, a hand-weighted
+        scalar whose components were chosen by hand and never calibrated
+        against an outcome. T20 traced its null result to exactly this path.
+        They keep working, since we stay in 0.x, but a run that relies on them
+        should say so out loud.
+
+        The warning fires only when the field was explicitly supplied.
+        ``model_fields_set`` is what makes that distinguishable from the
+        default, so a user who never touched the knob is never nagged about it.
+        """
+        for field, replacement in _DEPRECATED_XAI_KNOBS.items():
+            if field not in self.model_fields_set:
+                continue
+            value = getattr(self, field)
+            if not value:
+                continue
+            warnings.warn(
+                f"{field}={value} is deprecated: it is built on an uncalibrated "
+                f"hand-weighted quality score, which is what T20 traced its null "
+                f"result to. {replacement} See docs/diagnosis.md.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_diagnosis_is_calibrated(self) -> BNNRConfig:

--- a/src/bnnr/xai_analysis.py
+++ b/src/bnnr/xai_analysis.py
@@ -324,29 +324,49 @@ def compute_xai_quality_score(
     stats: list[dict[str, float]],
     correct_flags: list[bool],
 ) -> tuple[float, dict[str, float]]:
-    """Compute a 0–1 quality score from saliency statistics and accuracy.
+    """Compute a 0–1 score describing the *shape* of the saliency maps.
 
-    Higher score = better-focused model with higher accuracy.
+    Higher score = more concentrated, more coherent, less border-heavy, more
+    consistent across samples.
 
-    **6-component formula** (v2):
+    **5-component formula** (v3):
 
     =============================  ======  ================================
     Component                      Weight  Source
     =============================  ======  ================================
-    accuracy                       25 %    fraction of correct predictions
-    focus (Gini coefficient)       20 %    higher Gini → sharper focus
-    coverage                       15 %    moderate (5–30 %) is ideal
-    spatial coherence              15 %    single blob preferred
-    edge ratio (inverted)          10 %    penalise border attention
-    cross-sample consistency       15 %    low CV of entropy across samples
+    focus (Gini coefficient)       26.7 %  higher Gini → sharper focus
+    coverage                       20 %    moderate (5–30 %) is ideal
+    spatial coherence              20 %    single blob preferred
+    edge ratio (inverted)          13.3 %  penalise border attention
+    cross-sample consistency       20 %    low CV of entropy across samples
     =============================  ======  ================================
+
+    **Accuracy was removed from the weighted sum in v3.** It used to carry 25 %,
+    and ``select_best_path`` then blended this score against the normalised
+    selection metric, which is accuracy. Accuracy was therefore counted twice,
+    at an effective weight nobody chose, and the two copies were not even the
+    same quantity: one min-max normalised across candidates, the other the raw
+    probe-set fraction. The weights above are the surviving five renormalised
+    to sum to 1, so the score keeps its ``[0, 1]`` range.
+
+    ``accuracy`` stays in ``breakdown`` as an observation, because the dashboard
+    displays it, but nothing multiplies it any more.
+
+    **This score encodes a prior: "concentrated, central saliency is good."**
+    It rewards high Gini and penalises ``edge_ratio`` unconditionally. That is
+    exactly the question :mod:`bnnr.analysis.diagnosis` decides per case, and
+    for a Waterbirds-like model the built-in prior points the wrong way: a
+    model reading background context has *diffuse, border-heavy* attention and
+    needs ICD, which this score would rank last. Prefer the diagnosis where the
+    answer matters; this remains a display statistic.
 
     Returns
     -------
     score : float
-        Scalar quality score in ``[0, 1]``.
+        Scalar shape score in ``[0, 1]``.
     breakdown : dict[str, float]
-        Per-component sub-scores (each 0–1) for dashboard display.
+        Per-component sub-scores (each 0–1) for dashboard display, plus the
+        observed ``accuracy``, which is no longer weighted into the score.
     """
     if not stats:
         return 0.0, {}
@@ -391,6 +411,7 @@ def compute_xai_quality_score(
         consistency_score = 0.5
 
     breakdown = {
+        # Observed, not weighted: see the docstring on the v3 change.
         "accuracy": round(accuracy, 4),
         "focus": round(focus_score, 4),
         "coverage": round(coverage_score, 4),
@@ -399,13 +420,15 @@ def compute_xai_quality_score(
         "consistency": round(consistency_score, 4),
     }
 
+    # The v2 weights without accuracy summed to 0.75, so each is divided by
+    # that to keep the score on [0, 1]. Written as the division rather than as
+    # rounded constants so the provenance of every number stays visible.
     score = (
-        accuracy * 0.25
-        + focus_score * 0.20
-        + coverage_score * 0.15
-        + coherence_score * 0.15
-        + edge_score * 0.10
-        + consistency_score * 0.15
+        focus_score * (0.20 / 0.75)
+        + coverage_score * (0.15 / 0.75)
+        + coherence_score * (0.15 / 0.75)
+        + edge_score * (0.10 / 0.75)
+        + consistency_score * (0.15 / 0.75)
     )
     return round(min(1.0, max(0.0, score)), 4), breakdown
 

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -224,7 +224,8 @@ class TestXaiPresets:
         new_cfg = apply_xai_preset(cfg, "xai_full")
         assert new_cfg.xai_enabled is True
         assert new_cfg.dual_xai_report is True
-        assert new_cfg.xai_selection_weight == 0.1
+        # Zeroed in 0.x; the preset used to ship 0.1. See FIX-2-4.
+        assert new_cfg.xai_selection_weight == 0.0
 
     def test_apply_xai_preset_preserves_other_fields(self):
         from bnnr.config import apply_xai_preset

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,7 +133,9 @@ def test_apply_xai_preset_full() -> None:
     result = apply_xai_preset(cfg, "xai_full")
     assert result.xai_enabled is True
     assert result.dual_xai_report is True
-    assert result.xai_selection_weight == 0.1
+    # Zeroed in 0.x: the preset used to ship 0.1, steering selection with a
+    # weight nobody measured. See FIX-2-4.
+    assert result.xai_selection_weight == 0.0
     assert result.xai_pruning_threshold == 0.15
     assert result.adaptive_icd_threshold is True
     # Non-XAI fields preserved
@@ -145,7 +147,8 @@ def test_apply_xai_preset_adaptive() -> None:
     cfg = BNNRConfig(device="cpu")
     result = apply_xai_preset(cfg, "xai_adaptive")
     assert result.xai_enabled is True
-    assert result.xai_selection_weight == 0.15
+    # Zeroed in 0.x; the preset used to ship 0.15. See FIX-2-4.
+    assert result.xai_selection_weight == 0.0
     assert result.xai_pruning_threshold == 0.2
     assert result.adaptive_icd_threshold is True
 

--- a/tests/test_deprecated_xai_knobs.py
+++ b/tests/test_deprecated_xai_knobs.py
@@ -1,0 +1,136 @@
+"""Tests for the deprecated XAI selection knobs (FIX-2-4)."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from bnnr.config import apply_xai_preset, get_xai_preset, list_xai_presets
+from bnnr.config_model import BNNRConfig
+from bnnr.xai_analysis import compute_xai_quality_score
+
+
+def _stats(n: int = 4, **overrides: float) -> list[dict[str, float]]:
+    base = {
+        "gini": 0.5,
+        "coverage": 0.15,
+        "spatial_coherence": 0.8,
+        "edge_ratio": 0.1,
+        "entropy": 5.0,
+    }
+    base.update(overrides)
+    return [dict(base) for _ in range(n)]
+
+
+class TestDeprecationWarnings:
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("xai_selection_weight", 0.1), ("xai_pruning_threshold", 0.15)],
+    )
+    def test_setting_a_deprecated_knob_warns(self, field: str, value: float) -> None:
+        with pytest.warns(DeprecationWarning, match=field):
+            BNNRConfig(**{field: value})
+
+    def test_the_warning_names_what_to_use_instead(self) -> None:
+        with pytest.warns(DeprecationWarning, match="selector='diagnosis'"):
+            BNNRConfig(xai_selection_weight=0.1)
+
+    def test_the_pruning_warning_names_the_metric_based_knob(self) -> None:
+        with pytest.warns(DeprecationWarning, match="candidate_pruning_relative_threshold"):
+            BNNRConfig(xai_pruning_threshold=0.2)
+
+    def test_not_setting_the_field_does_not_warn(self) -> None:
+        """A user who never touched the knob is never nagged about it."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            BNNRConfig()
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("xai_selection_weight", 0.0), ("xai_pruning_threshold", 0.0)],
+    )
+    def test_explicitly_disabling_does_not_warn(self, field: str, value: float) -> None:
+        """Setting it to zero is turning the feature off, not relying on it."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            BNNRConfig(**{field: value})
+
+    def test_the_knob_still_works(self) -> None:
+        """We stay in 0.x: deprecated is not removed."""
+        with pytest.warns(DeprecationWarning):
+            config = BNNRConfig(xai_selection_weight=0.3)
+        assert config.xai_selection_weight == pytest.approx(0.3)
+
+
+class TestPresetsShipNoSelectionWeight:
+    @pytest.mark.parametrize("preset", ["xai_light", "xai_full", "xai_adaptive"])
+    def test_no_preset_ships_an_uncalibrated_selection_weight(self, preset: str) -> None:
+        assert get_xai_preset(preset)["xai_selection_weight"] == 0.0
+
+    @pytest.mark.parametrize("preset", ["xai_light", "xai_full", "xai_adaptive"])
+    def test_applying_a_preset_leaves_selection_on_the_metric(self, preset: str) -> None:
+        config = apply_xai_preset(BNNRConfig(), preset)
+        assert config.xai_selection_weight == 0.0
+
+    def test_every_preset_is_covered_by_these_tests(self) -> None:
+        """So a preset added later cannot quietly reintroduce a weight."""
+        assert set(list_xai_presets()) == {"xai_light", "xai_full", "xai_adaptive"}
+
+    def test_the_reporting_features_are_untouched(self) -> None:
+        """Zeroing the weight must not turn off what the preset is for."""
+        config = apply_xai_preset(BNNRConfig(), "xai_full")
+        assert config.xai_enabled is True
+        assert config.dual_xai_report is True
+        assert config.adaptive_icd_threshold is True
+
+
+class TestAccuracyIsNoLongerDoubleCounted:
+    def test_accuracy_does_not_move_the_score(self) -> None:
+        """It used to carry 25 %, and select_best_path then blended the score
+        against the normalised selection metric, which is accuracy."""
+        all_wrong, _ = compute_xai_quality_score(_stats(), [False] * 4)
+        all_right, _ = compute_xai_quality_score(_stats(), [True] * 4)
+        assert all_wrong == pytest.approx(all_right)
+
+    def test_accuracy_is_still_reported_in_the_breakdown(self) -> None:
+        """The dashboard displays it; nothing multiplies it."""
+        _, breakdown = compute_xai_quality_score(_stats(), [True, True, False, False])
+        assert breakdown["accuracy"] == pytest.approx(0.5)
+
+    def test_the_score_still_spans_zero_to_one(self) -> None:
+        worst, _ = compute_xai_quality_score(
+            _stats(gini=0.0, coverage=0.9, spatial_coherence=0.0, edge_ratio=0.5),
+            [True] * 4,
+        )
+        best, _ = compute_xai_quality_score(
+            _stats(gini=1.0, coverage=0.15, spatial_coherence=1.0, edge_ratio=0.0),
+            [True] * 4,
+        )
+        assert 0.0 <= worst < best <= 1.0
+
+    def test_a_perfect_shape_scores_one(self) -> None:
+        """The surviving weights are renormalised, so the top of the range is
+        still reachable rather than capped at 0.75."""
+        score, _ = compute_xai_quality_score(
+            _stats(gini=1.0, coverage=0.15, spatial_coherence=1.0, edge_ratio=0.0),
+            [True] * 4,
+        )
+        assert score == pytest.approx(1.0, abs=0.01)
+
+    def test_saliency_shape_still_moves_the_score(self) -> None:
+        """Removing accuracy must not make the score constant."""
+        diffuse, _ = compute_xai_quality_score(_stats(gini=0.1), [True] * 4)
+        sharp, _ = compute_xai_quality_score(_stats(gini=0.9), [True] * 4)
+        assert sharp > diffuse
+
+    def test_empty_stats_still_score_zero(self) -> None:
+        score, breakdown = compute_xai_quality_score([], [])
+        assert score == 0.0
+        assert breakdown == {}
+
+    def test_the_breakdown_keeps_every_component(self) -> None:
+        _, breakdown = compute_xai_quality_score(_stats(), [True] * 4)
+        assert set(breakdown) == {
+            "accuracy", "focus", "coverage", "coherence", "edge", "consistency",
+        }


### PR DESCRIPTION
## Summary

`xai_selection_weight` is the knob T20 blames for the null result, but the whole path is built from numbers nobody measured. `compute_xai_quality_score` is a hand-weighted 6-component scalar with hard-coded bins, and both `xai_selection_weight` and `xai_pruning_threshold` act on its output.

Two separate defects, fixed separately.

## Defect 1: accuracy was counted twice

The quality score carried `accuracy` at 25 %. `select_best_path` then blended that score against the normalised selection metric — which is accuracy.

So the effective accuracy weight of the composite was a number nobody chose. Worse, the two copies were not even the same quantity: one min-max normalised across candidates, the other the raw probe-set fraction.

**Fix:** accuracy is out of the weighted sum. The surviving five weights are renormalised by dividing by `0.75`, written as the division rather than as rounded constants so the provenance of every number stays visible. The score keeps its `[0, 1]` range with the top still reachable — there is a test that a perfect shape still scores 1.0 rather than being capped at 0.75.

`accuracy` stays in `breakdown` as an observation, because the dashboard displays it, but nothing multiplies it. A test asserts that flipping every prediction from wrong to right does not move the score.

## Defect 2: the score encodes a prior

It rewards high Gini and penalises `edge_ratio` unconditionally, hard-coding *"concentrated, central saliency is good"*.

That is exactly the question #403's diagnosis answers per case — and for a Waterbirds-like model the built-in prior points the wrong way: a model reading background context has **diffuse, border-heavy** attention and needs ICD, which this score ranks last. The docstring now says so and points at `bnnr.analysis.diagnosis`.

I did not try to fix the prior here. Removing it *is* the diagnosis, which already exists; this score stays as a display statistic with its bias written down.

## Deprecation

Both knobs emit a `DeprecationWarning` when set to a non-zero value, naming what to use instead. They keep working — we stay in 0.x.

The warning fires **only when the field was explicitly supplied**, via `model_fields_set`, so:
- a user who never touched the knob is never nagged;
- setting it to `0.0` is turning the feature off rather than relying on it, and does not warn.

Both cases are tested.

## Preset change

`xai_full` and `xai_adaptive` shipped `xai_selection_weight` of 0.1 and 0.15. **Both are now `0.0`.** Everything those presets are actually for — XAI reporting, dual XAI, adaptive ICD thresholds — is untouched, and there is a test asserting that.

This is a behaviour change for preset users, shipped as a 0.x minor per the issue's decision. Three existing tests asserted the old values and are updated with a comment saying why.

**`xai_pruning_threshold` keeps its preset values**, and this is a judgement call worth flagging: dropping a candidate is recoverable in a way that selecting the wrong one is not, so the two knobs did not warrant the same treatment. Say the word if you want both zeroed.

## Test plan

- `pytest -q` -> **1544 passed, 19 skipped** (23 new).
- `ruff check src tests` clean; `mypy` clean on all three touched modules.
- Coverage: both knobs warning when set and not warning when absent or zero; the warning naming its replacement; the knob still working; every preset shipping `0.0`, with a test that the preset list itself is what these tests cover so a preset added later cannot quietly reintroduce a weight; accuracy not moving the score; accuracy still in the breakdown; the range still spanning 0 to 1; a perfect shape scoring 1.0; saliency shape still moving the score; empty stats; the breakdown keeping every key.

## Docs

`docs/configuration.md` gains a `Deprecated XAI selection knobs` section: both defects, the preset change, and why the two knobs were treated differently.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #409
