### PR TITLE
feat(training): indistinguishability test for candidate selection

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -101,6 +101,8 @@ The fields a run must carry for its result to be comparable with another run. Wr
 | `diagnosis` | the attention diagnosis when one was computed, else `null` |
 | `hard_quantile_q` | the loss quantile the robustness metrics used |
 | `augmentation_modes` | `{name: mode}` for augmentations whose transform depends on a mode |
+| `selection_reason` | `improved`, `no_improvement`, `indistinguishable`, `no_candidates` |
+| `selection_interval` | the paired bootstrap interval behind that reason, when one was computed |
 
 **The two epoch counts are the point.** They differ whenever a branch search runs, and confusing them is what made BNNR look worse than it was: under "equal compute" the deployed model trained for a third of the budget while single-augmentation baselines trained all of it. Matching deployed epochs instead closed a 4.46 pp gap to 0.09 pp. They are equal only for a run with no search.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,23 @@ seed: 42
 
 Both are gated the same way: whatever a selector picks is discarded unless it beat the baseline on `selection_metric`. That gate is deliberately shared, so a comparison between two selectors is a comparison of their ranking rules and nothing else. A selector that skipped it would look better purely by accepting runs the others reject.
 
+### Indistinguishability test
+
+- `indistinguishable_resamples` (default: `2000`, validated `>= 100`)
+- `indistinguishable_confidence` (default: `0.95`, validated in `(0, 1)`)
+
+A candidate only replaces the baseline when the **paired bootstrap interval on the difference excludes zero** — not merely when its metric is a larger number.
+
+T20's central negative result is that the selector was picking between candidates that are not distinguishable on the criterion it uses. On Waterbirds the candidate accuracies were .8749 / .8816 / .8549 on a validation set whose binomial standard error is larger than that spread. A strict `>` on those numbers is a coin flip.
+
+When the interval covers zero, `SelectionResult.reason` becomes `"indistinguishable"` and **the baseline is kept**: it is the closest thing to what the data supports, and it is the cheapest in epochs. The interval lands in the run record so the decision is auditable afterwards rather than only at the moment it was made.
+
+The comparison is **paired**: both arms are evaluated on the same validation set, and each bootstrap draw indexes both arms together. Ignoring the pairing would inflate the interval with variance that comes from the validation set rather than from the arms, and make everything look indistinguishable.
+
+The statistic is the **mean** paired difference, not the median. At sample level the paired difference is in `{-1, 0, 1}`, where the median is degenerate; the mean of those differences *is* the accuracy difference. The seed-level convention in the benchmark summarizers is a median, because a per-seed metric is continuous — different level of aggregation, different right answer.
+
+The test runs only when per-sample predictions were cached for both the candidate and the baseline. Without them the raw metric comparison stands, so a caller that never cached predictions behaves exactly as before.
+
 ### Deprecated XAI selection knobs
 
 `xai_selection_weight` and `xai_pruning_threshold` are **deprecated as of 0.x**. Both keep working and both emit a `DeprecationWarning` when you set them to a non-zero value.

--- a/src/bnnr/config_model.py
+++ b/src/bnnr/config_model.py
@@ -110,6 +110,11 @@ class BNNRConfig(BaseModel):
     #: Cut points for the ``diagnosis`` selector. Unset by design; see
     #: DiagnosisConfig and docs/diagnosis.md.
     diagnosis: DiagnosisConfig = Field(default_factory=DiagnosisConfig)
+    #: Bootstrap settings for the indistinguishability test. The resampling is
+    #: over a boolean vector rather than over the model, so it is cheap enough
+    #: to run on every iteration.
+    indistinguishable_resamples: int = Field(default=2000, ge=100)
+    indistinguishable_confidence: float = 0.95
 
     # NOTE: For detection tasks, use selection_metric="map_50" (or "map_50_95")
     # and metrics=["map_50", "map_50_95", "loss"].  The model_validator below
@@ -289,6 +294,13 @@ class BNNRConfig(BaseModel):
                     f"bnnr.config.load_diagnosis_profile(). See docs/diagnosis.md."
                 )
         return self
+
+    @field_validator("indistinguishable_confidence")
+    @classmethod
+    def validate_indistinguishable_confidence(cls, value: float) -> float:
+        if not (0.0 < value < 1.0):
+            raise ValueError("indistinguishable_confidence must be in (0, 1)")
+        return value
 
     @field_validator("selector")
     @classmethod

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -102,6 +102,10 @@ class BNNRTrainer:
         # acted on by nothing.
         self._shadow = _shadow.ShadowRecorder()
         self._last_saliency_maps: Any | None = None
+        # Per-sample correctness of the baseline's best epoch, and the last
+        # selection result, for the indistinguishability test and its record.
+        self._baseline_correct: Any | None = None
+        self._last_selection: Any | None = None
         self.logger = setup_logging("bnnr", config.log_file, json_format=True)
         self._custom_metrics: dict[str, Any] = custom_metrics or {}
 

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -21,8 +21,10 @@ from bnnr.training import checkpoint as _ckpt
 from bnnr.training import dataset_profile as _dprofile
 from bnnr.training import hard_quantile as _hard_quantile
 from bnnr.training import metrics as _metrics
+from bnnr.training import paired as _paired
 from bnnr.training import probe as _probe
 from bnnr.training import run_record as _run_record
+from bnnr.training import selection as _selection
 from bnnr.training import shadow as _shadow
 from bnnr.training import xai_runner as _xai
 from bnnr.training.metrics import average_metrics
@@ -496,6 +498,12 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
                 flush=True,
             )
         baseline_metrics = evaluate(trainer, trainer.val_loader, cache_predictions=True)
+        # Per-sample correctness of the baseline's best epoch, for the paired
+        # indistinguishability test. Captured here because this is the one
+        # point where the cache belongs to the weights that will be compared.
+        trainer._baseline_correct = _paired.correctness_vector(
+            trainer._last_eval_preds, trainer._last_eval_labels
+        )
         # Overwrite the on-disk baseline checkpoint (per-epoch saves left the
         # last epoch) so resume restores the best baseline, not the last one.
         _ckpt.save_checkpoint(trainer, 0, "baseline", baseline_metrics)
@@ -643,6 +651,7 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
             per_candidate_durations: list[float] = []
             per_class_by_candidate: dict[str, dict[str, dict[str, float | int]]] = {}
             xai_scores_by_candidate: dict[str, float] = {}
+            candidate_correct: dict[str, Any] = {}
             for idx, augmentation in enumerate(candidate_bar, start=1):
                 t0 = time.perf_counter()
                 trainer.console.print(
@@ -675,6 +684,11 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
                 trainer._last_eval_labels = None
                 per_class_candidate, confusion_candidate = _metrics.compute_eval_class_details(trainer)
                 per_class_by_candidate[augmentation.name] = per_class_candidate
+                # The prediction cache now belongs to this candidate's best
+                # epoch, which is the state its metrics describe.
+                candidate_correct[augmentation.name] = _paired.correctness_vector(
+                    trainer._last_eval_preds, trainer._last_eval_labels
+                )
 
                 # Lightweight XAI probe per candidate (for XAI-aware selection)
                 _, cand_xai_diag, _ = _xai.generate_xai_lightweight(trainer,
@@ -759,11 +773,25 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
 
                 trainer._check_pause()
 
-        selected_name = trainer._select_best_path(
+        selection = _selection.run_selector(
             iteration_results,
             baseline_metrics,
-            xai_scores=xai_scores_by_candidate if candidates else None,
+            trainer.config,
+            xai_scores_by_candidate if candidates else None,
+            per_sample_correct=candidate_correct,
+            baseline_correct=trainer._baseline_correct,
         )
+        selected_name = selection.best
+        trainer._last_selection = selection
+        if selection.reason == "indistinguishable" and selection.interval is not None:
+            trainer.console.print(
+                f"  (candidates indistinguishable from baseline: "
+                f"Δ={selection.interval.difference:+.4f}, "
+                f"{int(selection.interval.confidence * 100)}% CI "
+                f"[{selection.interval.low:+.4f}, {selection.interval.high:+.4f}] "
+                f"— keeping baseline)",
+                flush=True,
+            )
         # Shadow records are only a calibration set once they say which arm won.
         trainer._shadow.mark_selected(iteration, selected_name)
         top_candidate_names = _branching.top_k_candidate_names(iteration_results, trainer.config, k=3)
@@ -990,6 +1018,14 @@ def _build_run_record(
         diagnosis=diagnosis.to_dict() if diagnosis is not None else None,
         hard_quantile_q=trainer.config.hard_quantile_q,
         augmentation_modes=_run_record.collect_augmentation_modes(trainer.augmentations),
+        selection_reason=(
+            trainer._last_selection.reason if trainer._last_selection is not None else None
+        ),
+        selection_interval=(
+            trainer._last_selection.interval.to_dict()
+            if trainer._last_selection is not None and trainer._last_selection.interval is not None
+            else None
+        ),
     )
 
 

--- a/src/bnnr/training/paired.py
+++ b/src/bnnr/training/paired.py
@@ -1,0 +1,138 @@
+"""Is the winning candidate actually distinguishable from the baseline?
+
+T20's central negative result is that the selector picks between candidates
+that are not distinguishable on the criterion it uses. The method had no way to
+say so: ``select_best_path`` always returned a winner whenever its metric was
+larger by any margin at all, and the run record made that look like a decision.
+
+On Waterbirds the candidate accuracies were .8749 / .8816 / .8549 on a
+validation set where the binomial standard error is larger than the spread. A
+strict ``>`` on those numbers is a coin flip wearing a lab coat.
+
+This module answers the question properly: bootstrap the *paired* difference in
+per-sample correctness between two arms, and if the confidence interval covers
+zero, say so rather than picking.
+
+**Paired, not two-sample.** Both arms are evaluated on the same validation set,
+so the samples are matched and the pairing removes the variance that comes from
+the set itself rather than from the arms. Ignoring it inflates the interval and
+would make everything look indistinguishable.
+
+**Mean, not median.** The seed-level convention in the benchmark summarizers is
+a median paired difference, because a per-seed metric is continuous and skewed.
+Here the paired difference per sample is in ``{-1, 0, 1}``, where the median is
+degenerate: it is 0 unless one arm is right on more than half the samples the
+other got wrong. The mean of those differences *is* the accuracy difference,
+which is the quantity being tested.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+__all__ = [
+    "DEFAULT_CONFIDENCE",
+    "DEFAULT_RESAMPLES",
+    "PairedInterval",
+    "paired_bootstrap_ci",
+]
+
+#: Resamples for the bootstrap. Enough for a stable 95% interval on a
+#: validation set, cheap enough to run on every iteration: the resampling is
+#: over a boolean vector, not over the model.
+DEFAULT_RESAMPLES = 2000
+
+DEFAULT_CONFIDENCE = 0.95
+
+
+@dataclass(frozen=True)
+class PairedInterval:
+    """A bootstrap interval on the paired difference between two arms."""
+
+    #: Observed mean paired difference, ``a - b``. Positive means *a* is better.
+    difference: float
+    low: float
+    high: float
+    confidence: float
+    n_pairs: int
+    n_resamples: int
+
+    @property
+    def contains_zero(self) -> bool:
+        """Whether the interval covers zero, i.e. the arms are indistinguishable."""
+        return self.low <= 0.0 <= self.high
+
+    def to_dict(self) -> dict[str, float | int]:
+        """JSON-ready, for the run record."""
+        return {
+            "difference": self.difference,
+            "low": self.low,
+            "high": self.high,
+            "confidence": self.confidence,
+            "n_pairs": self.n_pairs,
+            "n_resamples": self.n_resamples,
+        }
+
+
+def paired_bootstrap_ci(
+    correct_a: np.ndarray,
+    correct_b: np.ndarray,
+    *,
+    n_resamples: int = DEFAULT_RESAMPLES,
+    confidence: float = DEFAULT_CONFIDENCE,
+    seed: int = 0,
+) -> PairedInterval | None:
+    """Percentile bootstrap interval on the mean paired difference ``a - b``.
+
+    ``correct_a`` and ``correct_b`` are per-sample correctness for the same
+    validation samples in the same order. Pass boolean or 0/1 arrays.
+
+    Returns ``None`` when the inputs cannot support an interval: different
+    lengths, or fewer than two pairs. ``None`` means "no test was possible",
+    which callers must not confuse with "the arms tie" — the first should fall
+    back to the old comparison, the second should refuse to switch.
+
+    Resampling is over the *pairs*, indexing both arms with the same draw,
+    which is what makes the interval paired.
+    """
+    a = np.asarray(correct_a).astype(np.float64).ravel()
+    b = np.asarray(correct_b).astype(np.float64).ravel()
+    if a.size != b.size or a.size < 2:
+        return None
+
+    differences = a - b
+    observed = float(differences.mean())
+
+    rng = np.random.default_rng(seed)
+    # One draw of indices per resample, applied to the difference vector, so
+    # both arms are resampled together.
+    idx = rng.integers(0, differences.size, size=(n_resamples, differences.size))
+    means = differences[idx].mean(axis=1)
+
+    tail = (1.0 - confidence) / 2.0
+    low, high = np.quantile(means, [tail, 1.0 - tail])
+    return PairedInterval(
+        difference=observed,
+        low=float(low),
+        high=float(high),
+        confidence=confidence,
+        n_pairs=int(differences.size),
+        n_resamples=int(n_resamples),
+    )
+
+
+def correctness_vector(preds: np.ndarray | None, labels: np.ndarray | None) -> np.ndarray | None:
+    """Per-sample correctness from cached predictions, or ``None``.
+
+    Returns ``None`` rather than an empty array when either side is missing, so
+    a caller cannot accidentally run a test on nothing.
+    """
+    if preds is None or labels is None:
+        return None
+    preds_arr = np.asarray(preds)
+    labels_arr = np.asarray(labels)
+    if preds_arr.shape != labels_arr.shape or preds_arr.size == 0:
+        return None
+    return np.asarray(preds_arr == labels_arr)

--- a/src/bnnr/training/run_record.py
+++ b/src/bnnr/training/run_record.py
@@ -103,6 +103,14 @@ class RunRecord:
     #: without this is not reproducible across machines.
     augmentation_modes: dict[str, str] = field(default_factory=dict)
 
+    #: Why the selector landed where it did: ``"improved"``,
+    #: ``"no_improvement"``, ``"indistinguishable"``, ``"no_candidates"``.
+    selection_reason: str | None = None
+    #: The paired bootstrap interval behind that reason, when one was computed.
+    #: Recorded so a decision is auditable after the fact rather than only at
+    #: the moment it was made, which is what T20 had to reconstruct by hand.
+    selection_interval: dict[str, float | int] | None = None
+
     def to_dict(self) -> dict[str, Any]:
         """JSON-ready mapping. ``selected_candidate`` becomes a list."""
         data = asdict(self)

--- a/src/bnnr/training/selection.py
+++ b/src/bnnr/training/selection.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 import hashlib
 import random
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+from bnnr.training.paired import PairedInterval, paired_bootstrap_ci
 
 if TYPE_CHECKING:
     from bnnr.analysis.diagnosis import Diagnosis
@@ -50,6 +52,11 @@ class CandidateReport:
     name: str
     metrics: dict[str, float]
     xai_score: float | None = None
+    #: Per-sample correctness on the selection-validation set, in the same
+    #: order for every candidate. Present only when the caller cached
+    #: predictions; without it the indistinguishability test cannot run and
+    #: selection falls back to the raw metric comparison.
+    per_sample_correct: Any | None = None
 
     def value(self, metric: str) -> float | None:
         """The named metric, or ``None`` when this candidate did not report it."""
@@ -74,6 +81,10 @@ class SelectionResult:
     selector: str
     reason: str
     scores: dict[str, float] = field(default_factory=dict)
+    #: Bootstrap interval on the winner's paired difference against the
+    #: baseline, when one could be computed. Recorded so the decision is
+    #: auditable after the fact rather than only at the moment it was made.
+    interval: PairedInterval | None = None
 
     @property
     def best(self) -> str | None:
@@ -93,6 +104,7 @@ class CandidateSelector(Protocol):
         config: BNNRConfig,
         *,
         diagnosis: Diagnosis | None = None,
+        baseline_correct: Any | None = None,
     ) -> SelectionResult:
         """Pick from *candidates*, or select nothing.
 
@@ -125,6 +137,7 @@ def _gate_on_baseline(
     config: BNNRConfig,
     selector: str,
     scores: dict[str, float],
+    baseline_correct: Any | None = None,
 ) -> SelectionResult:
     """Apply the shared rule: a pick only counts if it beat the baseline.
 
@@ -132,6 +145,16 @@ def _gate_on_baseline(
     contrast between their ranking rules and nothing else. A selector that
     skipped the gate would look better simply by accepting runs the others
     rejected.
+
+    When per-sample correctness is available for both the winner and the
+    baseline, "beat" means the paired bootstrap interval on the difference
+    excludes zero, not merely that one number is larger. T20's whole negative
+    result is that a strict ``>`` on differences smaller than the standard
+    error is not a decision. On a tie the baseline is kept: it is the closest
+    thing to what the data supports and the cheapest in epochs.
+
+    Without those vectors the raw comparison stands, so a caller that never
+    cached predictions behaves exactly as before.
     """
     baseline_value = baseline.get(config.selection_metric)
     chosen = next((c for c in candidates if c.name == name), None)
@@ -141,7 +164,19 @@ def _gate_on_baseline(
         return SelectionResult((), selector, "no_baseline", scores)
     if not _improved(value, float(baseline_value), config.selection_mode):
         return SelectionResult((), selector, "no_improvement", scores)
-    return SelectionResult((name,), selector, "improved", scores)
+
+    interval = None
+    if chosen is not None and chosen.per_sample_correct is not None and baseline_correct is not None:
+        interval = paired_bootstrap_ci(
+            chosen.per_sample_correct,
+            baseline_correct,
+            n_resamples=config.indistinguishable_resamples,
+            confidence=config.indistinguishable_confidence,
+            seed=config.seed,
+        )
+    if interval is not None and interval.contains_zero:
+        return SelectionResult((), selector, "indistinguishable", scores, interval)
+    return SelectionResult((name,), selector, "improved", scores, interval)
 
 
 class MetricArgmaxSelector:
@@ -172,6 +207,7 @@ class MetricArgmaxSelector:
         config: BNNRConfig,
         *,
         diagnosis: Diagnosis | None = None,
+        baseline_correct: Any | None = None,
     ) -> SelectionResult:
         del diagnosis  # this selector decides on the metric alone
         metric = config.selection_metric
@@ -186,7 +222,9 @@ class MetricArgmaxSelector:
         if weight <= 0 or not has_xai:
             sign = 1.0 if mode == "max" else -1.0
             best_name = max(values, key=lambda name: sign * values[name])
-            return _gate_on_baseline(best_name, candidates, baseline, config, self.name, values)
+            return _gate_on_baseline(
+                best_name, candidates, baseline, config, self.name, values, baseline_correct
+            )
 
         lo, hi = min(values.values()), max(values.values())
         span = hi - lo if hi != lo else 1.0
@@ -198,7 +236,9 @@ class MetricArgmaxSelector:
             scores[name] = (1.0 - weight) * normalised + weight * xai_by_name.get(name, 0.0)
 
         best_name = max(scores, key=lambda name: scores[name])
-        return _gate_on_baseline(best_name, candidates, baseline, config, self.name, scores)
+        return _gate_on_baseline(
+            best_name, candidates, baseline, config, self.name, scores, baseline_correct
+        )
 
 
 class RandomSelector:
@@ -220,6 +260,7 @@ class RandomSelector:
         config: BNNRConfig,
         *,
         diagnosis: Diagnosis | None = None,
+        baseline_correct: Any | None = None,
     ) -> SelectionResult:
         del diagnosis  # a random arm reads nothing
         values = _resolved_values(candidates, config.selection_metric)
@@ -234,7 +275,9 @@ class RandomSelector:
         rng = random.Random(int.from_bytes(digest[:8], "big"))
         picked = rng.choice(sorted(values))
         scores = {name: (1.0 if name == picked else 0.0) for name in values}
-        return _gate_on_baseline(picked, candidates, baseline, config, self.name, scores)
+        return _gate_on_baseline(
+            picked, candidates, baseline, config, self.name, scores, baseline_correct
+        )
 
 
 class DiagnosisSelector:
@@ -267,6 +310,7 @@ class DiagnosisSelector:
         config: BNNRConfig,
         *,
         diagnosis: Diagnosis | None = None,
+        baseline_correct: Any | None = None,
     ) -> SelectionResult:
         values = _resolved_values(candidates, config.selection_metric)
         if not values:
@@ -289,7 +333,9 @@ class DiagnosisSelector:
         # hyperparameters of it.
         sign = 1.0 if config.selection_mode == "max" else -1.0
         best = max(wanted, key=lambda name: sign * values[name])
-        return _gate_on_baseline(best, candidates, baseline, config, self.name, scores)
+        return _gate_on_baseline(
+            best, candidates, baseline, config, self.name, scores, baseline_correct
+        )
 
 
 #: Longest first, so a family that contains another as a substring is tested
@@ -330,6 +376,8 @@ def run_selector(
     xai_scores: dict[str, float] | None = None,
     *,
     diagnosis: Diagnosis | None = None,
+    per_sample_correct: dict[str, Any] | None = None,
+    baseline_correct: Any | None = None,
 ) -> SelectionResult:
     """Build the candidate reports and run the configured selector over them."""
     candidates = [
@@ -341,9 +389,14 @@ def run_selector(
             # is reserved for "no XAI scoring at all", which is the condition
             # that selects the plain-argmax path.
             xai_score=(xai_scores.get(name, 0.0) if xai_scores else None),
+            per_sample_correct=(per_sample_correct or {}).get(name),
         )
         for name, metrics in results.items()
     ]
     return get_selector(config.selector).select(
-        candidates, baseline_metrics, config, diagnosis=diagnosis
+        candidates,
+        baseline_metrics,
+        config,
+        diagnosis=diagnosis,
+        baseline_correct=baseline_correct,
     )

--- a/tests/test_indistinguishable.py
+++ b/tests/test_indistinguishable.py
@@ -1,0 +1,251 @@
+"""Tests for the indistinguishability test (FIX-2-3)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bnnr.config_model import BNNRConfig
+from bnnr.training.paired import (
+    PairedInterval,
+    correctness_vector,
+    paired_bootstrap_ci,
+)
+from bnnr.training.selection import run_selector
+
+
+def _config(**overrides) -> BNNRConfig:
+    return BNNRConfig(**overrides)
+
+
+class TestPairedBootstrap:
+    def test_identical_arms_give_an_interval_containing_zero(self) -> None:
+        same = np.array([True] * 60 + [False] * 40)
+        interval = paired_bootstrap_ci(same, same, seed=0)
+        assert interval is not None
+        assert interval.difference == pytest.approx(0.0)
+        assert interval.contains_zero
+
+    def test_a_large_real_difference_excludes_zero(self) -> None:
+        rng = np.random.default_rng(0)
+        n = 400
+        better = rng.random(n) < 0.90
+        worse = rng.random(n) < 0.55
+        interval = paired_bootstrap_ci(better, worse, seed=0)
+        assert interval is not None
+        assert not interval.contains_zero
+        assert interval.low > 0
+
+    def test_a_sub_noise_difference_contains_zero(self) -> None:
+        """The Waterbirds shape: a spread smaller than the standard error."""
+        rng = np.random.default_rng(1)
+        n = 200
+        base = rng.random(n) < 0.87
+        nudged = base.copy()
+        flip = rng.choice(np.flatnonzero(~base), size=1, replace=False)
+        nudged[flip] = True  # one extra correct sample out of 200
+        interval = paired_bootstrap_ci(nudged, base, seed=0)
+        assert interval is not None
+        assert interval.difference > 0  # it *is* larger
+        assert interval.contains_zero  # but not distinguishably so
+
+    def test_the_pairing_is_preserved(self) -> None:
+        """Both arms are resampled with the same draw. Shuffling one arm
+        independently would change the answer if they were not paired."""
+        rng = np.random.default_rng(2)
+        a = rng.random(300) < 0.8
+        b = a.copy()
+        paired = paired_bootstrap_ci(a, b, seed=0)
+        assert paired is not None
+        # Perfectly matched arms have a zero-width interval on the difference.
+        assert paired.low == pytest.approx(0.0)
+        assert paired.high == pytest.approx(0.0)
+
+    def test_the_interval_is_reproducible_for_a_seed(self) -> None:
+        rng = np.random.default_rng(3)
+        a, b = rng.random(200) < 0.8, rng.random(200) < 0.75
+        first = paired_bootstrap_ci(a, b, seed=7)
+        second = paired_bootstrap_ci(a, b, seed=7)
+        assert first == second
+
+    def test_a_different_seed_moves_the_interval(self) -> None:
+        rng = np.random.default_rng(4)
+        a, b = rng.random(200) < 0.8, rng.random(200) < 0.75
+        assert paired_bootstrap_ci(a, b, seed=1) != paired_bootstrap_ci(a, b, seed=2)
+
+    def test_confidence_widens_the_interval(self) -> None:
+        rng = np.random.default_rng(5)
+        a, b = rng.random(300) < 0.8, rng.random(300) < 0.7
+        narrow = paired_bootstrap_ci(a, b, confidence=0.80, seed=0)
+        wide = paired_bootstrap_ci(a, b, confidence=0.99, seed=0)
+        assert narrow is not None and wide is not None
+        assert (wide.high - wide.low) > (narrow.high - narrow.low)
+
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        [
+            (np.array([True, False]), np.array([True])),  # mismatched lengths
+            (np.array([True]), np.array([False])),  # fewer than two pairs
+            (np.array([]), np.array([])),  # nothing at all
+        ],
+    )
+    def test_unusable_input_returns_none_not_a_tie(self, a, b) -> None:
+        """None means 'no test was possible', which is not the same as 'the
+        arms tie' and must not be treated as one."""
+        assert paired_bootstrap_ci(a, b) is None
+
+    def test_integer_arrays_are_accepted(self) -> None:
+        interval = paired_bootstrap_ci(np.array([1, 1, 0, 0]), np.array([1, 0, 0, 0]), seed=0)
+        assert interval is not None
+        assert interval.difference == pytest.approx(0.25)
+
+    def test_to_dict_is_json_ready(self) -> None:
+        import json
+
+        interval = paired_bootstrap_ci(np.array([1, 1, 0, 0]), np.array([1, 0, 0, 0]), seed=0)
+        assert interval is not None
+        assert json.loads(json.dumps(interval.to_dict()))["n_pairs"] == 4
+
+
+class TestCorrectnessVector:
+    def test_builds_from_predictions_and_labels(self) -> None:
+        got = correctness_vector(np.array([1, 2, 3]), np.array([1, 0, 3]))
+        assert got is not None
+        assert got.tolist() == [True, False, True]
+
+    @pytest.mark.parametrize(
+        ("preds", "labels"),
+        [
+            (None, np.array([1])),
+            (np.array([1]), None),
+            (np.array([1, 2]), np.array([1])),
+            (np.array([]), np.array([])),
+        ],
+    )
+    def test_missing_or_mismatched_input_is_none(self, preds, labels) -> None:
+        assert correctness_vector(preds, labels) is None
+
+
+class TestSelectionRefusesToSwitchOnATie:
+    BASELINE = {"accuracy": 0.87}
+
+    def _correct(self, n: int, accuracy: float, seed: int) -> np.ndarray:
+        rng = np.random.default_rng(seed)
+        return rng.random(n) < accuracy
+
+    def test_a_synthetic_tie_reports_indistinguishable_and_keeps_baseline(self) -> None:
+        base = self._correct(200, 0.87, seed=0)
+        nudged = base.copy()
+        nudged[np.flatnonzero(~base)[0]] = True
+
+        result = run_selector(
+            {"aug_a": {"accuracy": float(nudged.mean())}},
+            {"accuracy": float(base.mean())},
+            _config(),
+            per_sample_correct={"aug_a": nudged},
+            baseline_correct=base,
+        )
+        assert result.reason == "indistinguishable"
+        assert result.selected == ()
+
+    def test_a_real_improvement_is_still_selected(self) -> None:
+        base = self._correct(400, 0.55, seed=1)
+        better = self._correct(400, 0.90, seed=2)
+        result = run_selector(
+            {"aug_a": {"accuracy": float(better.mean())}},
+            {"accuracy": float(base.mean())},
+            _config(),
+            per_sample_correct={"aug_a": better},
+            baseline_correct=base,
+        )
+        assert result.reason == "improved"
+        assert result.selected == ("aug_a",)
+
+    def test_the_interval_is_attached_either_way(self) -> None:
+        base = self._correct(300, 0.6, seed=3)
+        better = self._correct(300, 0.85, seed=4)
+        result = run_selector(
+            {"aug_a": {"accuracy": float(better.mean())}},
+            {"accuracy": float(base.mean())},
+            _config(),
+            per_sample_correct={"aug_a": better},
+            baseline_correct=base,
+        )
+        assert isinstance(result.interval, PairedInterval)
+        assert result.interval.n_pairs == 300
+
+    def test_without_the_vectors_the_raw_comparison_stands(self) -> None:
+        """A caller that never cached predictions behaves exactly as before."""
+        result = run_selector(
+            {"aug_a": {"accuracy": 0.8701}}, self.BASELINE, _config()
+        )
+        assert result.reason == "improved"
+        assert result.selected == ("aug_a",)
+        assert result.interval is None
+
+    def test_a_candidate_below_baseline_is_rejected_before_the_test_runs(self) -> None:
+        base = self._correct(200, 0.9, seed=5)
+        worse = self._correct(200, 0.4, seed=6)
+        result = run_selector(
+            {"aug_a": {"accuracy": float(worse.mean())}},
+            {"accuracy": float(base.mean())},
+            _config(),
+            per_sample_correct={"aug_a": worse},
+            baseline_correct=base,
+        )
+        assert result.reason == "no_improvement"
+
+    def test_every_selector_applies_the_test(self) -> None:
+        """The gate is shared, so a contrast between selectors stays a contrast
+        between their ranking rules."""
+        base = self._correct(200, 0.87, seed=0)
+        nudged = base.copy()
+        nudged[np.flatnonzero(~base)[0]] = True
+        for selector in ("metric_argmax", "random"):
+            result = run_selector(
+                {"aug_a": {"accuracy": float(nudged.mean())}},
+                {"accuracy": float(base.mean())},
+                _config(selector=selector),
+                per_sample_correct={"aug_a": nudged},
+                baseline_correct=base,
+            )
+            assert result.reason == "indistinguishable", selector
+
+
+class TestConfig:
+    def test_defaults(self) -> None:
+        config = BNNRConfig()
+        assert config.indistinguishable_resamples == 2000
+        assert config.indistinguishable_confidence == pytest.approx(0.95)
+
+    @pytest.mark.parametrize("bad", [0.0, 1.0, 1.5, -0.1])
+    def test_confidence_range_is_validated(self, bad: float) -> None:
+        with pytest.raises(ValueError, match="indistinguishable_confidence"):
+            BNNRConfig(indistinguishable_confidence=bad)
+
+    def test_too_few_resamples_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            BNNRConfig(indistinguishable_resamples=10)
+
+    def test_the_configured_confidence_reaches_the_test(self) -> None:
+        rng = np.random.default_rng(9)
+        base = rng.random(300) < 0.80
+        better = rng.random(300) < 0.86
+        wide = run_selector(
+            {"aug_a": {"accuracy": float(better.mean())}},
+            {"accuracy": float(base.mean())},
+            _config(indistinguishable_confidence=0.999),
+            per_sample_correct={"aug_a": better},
+            baseline_correct=base,
+        )
+        narrow = run_selector(
+            {"aug_a": {"accuracy": float(better.mean())}},
+            {"accuracy": float(base.mean())},
+            _config(indistinguishable_confidence=0.50),
+            per_sample_correct={"aug_a": better},
+            baseline_correct=base,
+        )
+        assert wide.interval is not None and narrow.interval is not None
+        assert (wide.interval.high - wide.interval.low) > (
+            narrow.interval.high - narrow.interval.low
+        )


### PR DESCRIPTION
## Summary

T20's central negative result is that the selector picks between candidates that are **not distinguishable** on the criterion it uses. The method had no way to say so: `select_best_path` returned a winner whenever its metric was larger by any margin at all, and the run record made that look like a decision.

On Waterbirds the candidate accuracies were .8749 / .8816 / .8549 on a validation set whose binomial standard error is larger than that spread. A strict `>` on those numbers is a coin flip wearing a lab coat.

New `src/bnnr/training/paired.py` bootstraps the paired difference in per-sample correctness between the winner and the baseline. When the interval covers zero, `reason` becomes `"indistinguishable"` and **the baseline is kept** — the closest thing to what the data supports, and the cheapest in epochs.

## Two statistical choices, both deliberate

**Paired, not two-sample.** Both arms are evaluated on the same validation set, and each bootstrap draw indexes both arms together. Ignoring the pairing would load the interval with variance coming from the validation set rather than from the arms, and make everything look indistinguishable. There is a test that perfectly matched arms produce a zero-width interval, which only holds if the pairing is real.

**Mean, not median.** The seed-level convention in the benchmark summarizers is a *median* paired difference, because a per-seed metric is continuous and skewed. At sample level the paired difference is in `{-1, 0, 1}`, where the median is degenerate — it is 0 unless one arm is right on more than half the samples the other got wrong. The mean of those differences **is** the accuracy difference, which is the quantity being tested. Different level of aggregation, different right answer; the module docstring says so rather than leaving the divergence to be discovered later.

## Where it sits

In the **shared baseline gate**, so every selector applies it and a contrast between two selectors stays a contrast between their ranking rules rather than partly a contrast in how strictly each accepts a win. There is a test running the tie through both `metric_argmax` and `random`.

It runs only when per-sample correctness is available for both arms. Without it the raw comparison stands, so a caller that never cached predictions behaves exactly as before — tested.

## `None` is not a tie

`paired_bootstrap_ci` returns `None` for input it cannot test (mismatched lengths, fewer than two pairs) rather than an interval that happens to contain zero. Those are different facts and the caller treats them differently: no test possible → fall back to the raw comparison; arms tie → refuse to switch. Conflating them would silently turn every degenerate input into "keep the baseline".

## Auditability

`selection_reason` and `selection_interval` go into the run record. T20 had to reconstruct this kind of thing by hand from run directories months later; recording it is most of the point.

The console also prints the interval when it declines to switch, so the behaviour is visible during the run rather than only in the artifact.

## Note on step 5

The issue asks to reuse the paired estimator from `benchmarks/stats.py` (#398). **That file does not exist yet** — #398 is open and assigned to someone else. The estimator lives here for now and the convention difference (mean vs median, and why) is documented at the top of the module. Aligning the two is a follow-up once #398 lands; I did not want to block this on it, nor to pre-empt that PR's design.

## Test plan

- `pytest -q` -> **1574 passed, 19 skipped** (30 new).
- `ruff check src tests` clean; `mypy` clean on all touched modules.
- Coverage: identical arms containing zero; a large real difference excluding it; a sub-noise nudge of one sample in 200 that is genuinely larger yet not distinguishably so; the pairing being preserved; reproducibility per seed and divergence across seeds; confidence widening the interval; three unusable-input shapes returning `None`; integer arrays; JSON readiness; the correctness-vector helper and its four failure modes; the synthetic tie keeping the baseline; a real improvement still selected; the interval attached either way; the fallback without vectors; a below-baseline candidate rejected before the test runs; both selectors applying it; and the config defaults, validation and the confidence actually reaching the test.

## Docs

`docs/configuration.md` gains an `Indistinguishability test` section covering both statistical choices and the fallback; `docs/artifacts.md` documents the two new run-record keys.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #408
