### PR TITLE
fix(selection): scale candidate differences by measurement noise, not by spread

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,18 @@ The statistic is the **mean** paired difference, not the median. At sample level
 
 The test runs only when per-sample predictions were cached for both the candidate and the baseline. Without them the raw metric comparison stands, so a caller that never cached predictions behaves exactly as before.
 
+### How the composite scales candidate differences
+
+When `xai_selection_weight > 0` (deprecated, see below), the metric term is scaled by the **binomial standard error** `sqrt(p(1-p)/n)` of the selection metric, where `n` is the validation sample count.
+
+It used to be min-max normalised across the candidates. That stretches whatever spread the candidates happened to have across the full `[0, 1]` range, so a spread of 0.2 pp and a spread of 20 pp both produce a metric term running 0 to 1, and the blending weight means something different in every iteration. On a saturated metric it was applied to scatter rather than to signal.
+
+A normalised difference of `1.0` now means "one standard error better than the weakest candidate", in every iteration. A sub-noise spread produces a term well below 1; a spread of several standard errors exceeds 1 and dominates, which is correct because that difference is real.
+
+The unit falls back to the observed spread when the sample size is unknown or the metric is not a proportion (a loss, say), since the binomial form claims nothing there.
+
+**Standard deviation across the candidates is deliberately not used.** Three points is a poor estimator of anything, and on the runs this was written for it would have been an estimator of the very noise it was supposed to divide out.
+
 ### Deprecated XAI selection knobs
 
 `xai_selection_weight` and `xai_pruning_threshold` are **deprecated as of 0.x**. Both keep working and both emit a `DeprecationWarning` when you set them to a non-zero value.

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -780,6 +780,7 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
             xai_scores_by_candidate if candidates else None,
             per_sample_correct=candidate_correct,
             baseline_correct=trainer._baseline_correct,
+            n_val=_val_sample_count(trainer),
         )
         selected_name = selection.best
         trainer._last_selection = selection
@@ -1059,3 +1060,22 @@ def _record_shadow(
         stats=stats,
         metrics=metrics,
     )
+
+
+def _val_sample_count(trainer: BNNRTrainer) -> int | None:
+    """How many validation samples the selection metric was measured on.
+
+    The noise unit the selector scales differences by is the binomial standard
+    error, which needs this. Preferring the cached label vector over
+    ``len(dataset)`` because it is what the metric was actually computed over:
+    a drop_last loader or a dataset without ``__len__`` would make the two
+    disagree, and the smaller honest number is the right one.
+    """
+    labels = trainer._last_eval_labels
+    if labels is not None and labels.size:
+        return int(labels.size)
+    dataset = getattr(trainer.val_loader, "dataset", None)
+    try:
+        return len(dataset) if dataset is not None else None
+    except TypeError:
+        return None

--- a/src/bnnr/training/selection.py
+++ b/src/bnnr/training/selection.py
@@ -19,6 +19,7 @@ return, and is now a thin adapter over the registry.
 from __future__ import annotations
 
 import hashlib
+import math
 import random
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
@@ -105,6 +106,7 @@ class CandidateSelector(Protocol):
         *,
         diagnosis: Diagnosis | None = None,
         baseline_correct: Any | None = None,
+        n_val: int | None = None,
     ) -> SelectionResult:
         """Pick from *candidates*, or select nothing.
 
@@ -124,6 +126,50 @@ def _resolved_values(candidates: list[CandidateReport], metric: str) -> dict[str
         if value is not None:
             resolved[candidate.name] = value
     return resolved
+
+
+def _noise_unit(values: dict[str, float], n_val: int | None) -> float:
+    """The resolution of the selection metric, for scaling candidate differences.
+
+    Min-max normalisation used to go here, and it is what T20 found fault with.
+    It stretches whatever spread the candidates happened to have across the full
+    [0, 1] range, so a spread of 0.2 pp and a spread of 20 pp both produce a
+    metric term running from 0 to 1. The blending weight therefore means
+    something different in every iteration, and on a saturated metric it is
+    applied to scatter rather than to signal.
+
+    The unit here is the binomial standard error ``sqrt(p(1-p)/n)`` of the
+    selection metric, which is the actual resolution of the number being
+    compared. A normalised difference of 1.0 now means "one standard error
+    better than the weakest candidate" in every iteration, and a sub-noise
+    spread produces a term well below 1 instead of a near-1.0 one.
+
+    ``p`` is the mean across candidates rather than a per-candidate value: the
+    candidates differ by fractions of a point, so the choice barely moves the
+    unit, and one shared unit keeps the scores on a common scale.
+
+    **Standard deviation across the candidates is deliberately not used.** Three
+    points is a poor estimator of anything, and on the run T20 examined it would
+    have been an estimator of the noise it was supposed to divide out.
+
+    Falls back to the observed spread when the sample size is unknown or the
+    metric is not a proportion, since the binomial form claims nothing there.
+    """
+    spread = max(values.values()) - min(values.values())
+    fallback = spread if spread > 0 else 1.0
+
+    if not n_val or n_val < 1:
+        return fallback
+    mean_p = sum(values.values()) / len(values)
+    if not 0.0 <= mean_p <= 1.0:
+        # Not a proportion (a loss, say); the binomial standard error is not
+        # defined for it and pretending otherwise would be worse than min-max.
+        return fallback
+
+    unit = math.sqrt(max(mean_p * (1.0 - mean_p), 0.0) / n_val)
+    # A metric saturated at exactly 0 or 1 has zero binomial variance, which
+    # would divide by zero. The observed spread is the honest answer there.
+    return unit if unit > 1e-12 else fallback
 
 
 def _improved(value: float, baseline_value: float, mode: str) -> bool:
@@ -208,6 +254,7 @@ class MetricArgmaxSelector:
         *,
         diagnosis: Diagnosis | None = None,
         baseline_correct: Any | None = None,
+        n_val: int | None = None,
     ) -> SelectionResult:
         del diagnosis  # this selector decides on the metric alone
         metric = config.selection_metric
@@ -227,12 +274,13 @@ class MetricArgmaxSelector:
             )
 
         lo, hi = min(values.values()), max(values.values())
-        span = hi - lo if hi != lo else 1.0
+        unit = _noise_unit(values, n_val)
         xai_by_name = {c.name: (c.xai_score or 0.0) for c in candidates}
 
         scores = {}
         for name, value in values.items():
-            normalised = (value - lo) / span if mode == "max" else (hi - value) / span
+            delta = (value - lo) if mode == "max" else (hi - value)
+            normalised = delta / unit
             scores[name] = (1.0 - weight) * normalised + weight * xai_by_name.get(name, 0.0)
 
         best_name = max(scores, key=lambda name: scores[name])
@@ -261,8 +309,9 @@ class RandomSelector:
         *,
         diagnosis: Diagnosis | None = None,
         baseline_correct: Any | None = None,
+        n_val: int | None = None,
     ) -> SelectionResult:
-        del diagnosis  # a random arm reads nothing
+        del diagnosis, n_val  # a random arm reads nothing
         values = _resolved_values(candidates, config.selection_metric)
         if not values:
             return SelectionResult((), self.name, "no_candidates", {})
@@ -311,7 +360,9 @@ class DiagnosisSelector:
         *,
         diagnosis: Diagnosis | None = None,
         baseline_correct: Any | None = None,
+        n_val: int | None = None,
     ) -> SelectionResult:
+        del n_val  # the diagnosis decides the family, not a scaled metric
         values = _resolved_values(candidates, config.selection_metric)
         if not values:
             return SelectionResult((), self.name, "no_candidates", {})
@@ -378,6 +429,7 @@ def run_selector(
     diagnosis: Diagnosis | None = None,
     per_sample_correct: dict[str, Any] | None = None,
     baseline_correct: Any | None = None,
+    n_val: int | None = None,
 ) -> SelectionResult:
     """Build the candidate reports and run the configured selector over them."""
     candidates = [
@@ -399,4 +451,5 @@ def run_selector(
         config,
         diagnosis=diagnosis,
         baseline_correct=baseline_correct,
+        n_val=n_val,
     )

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -388,3 +388,88 @@ class TestDiagnosisSelector:
                 self.RESULTS, self.BASELINE, config, diagnosis=_diagnosis(("icd",))
             ).best
             assert without == with_diag
+
+
+# ---------------------------------------------------------------------------
+# The noise-scaled unit (FIX-2-2)
+# ---------------------------------------------------------------------------
+
+
+class TestNoiseScaledUnit:
+    """Min-max stretched any spread across [0, 1]; the unit is now measured."""
+
+    BASELINE = {"accuracy": 0.50}
+
+    def _scores(self, accuracies: dict[str, float], *, n_val: int | None, weight: float = 0.5):
+        return run_selector(
+            {name: {"accuracy": acc} for name, acc in accuracies.items()},
+            self.BASELINE,
+            _config(xai_selection_weight=weight),
+            {name: 0.0 for name in accuracies},
+            n_val=n_val,
+        ).scores
+
+    def test_a_sub_noise_spread_no_longer_reaches_one(self) -> None:
+        """A 0.2 pp spread on 1000 samples is ~0.19 standard errors. Under
+        min-max the best candidate's metric term was exactly 1.0 regardless."""
+        scores = self._scores({"a": 0.8700, "b": 0.8720, "c": 0.8710}, n_val=1000)
+        # weight 0.5 and xai 0.0, so the metric term is score * 2.
+        assert max(scores.values()) * 2 < 0.3
+
+    def test_a_spread_of_several_standard_errors_is_treated_as_real(self) -> None:
+        """The T20 candidate accuracies are 2.5 SE apart at n=1000, which is a
+        resolved difference. Scaling by noise must not flatten those."""
+        scores = self._scores({"a": 0.8749, "b": 0.8816, "c": 0.8549}, n_val=1000)
+        assert max(scores.values()) * 2 > 2.0
+
+    def test_a_large_spread_still_saturates_the_metric_term(self) -> None:
+        """Differences of many standard errors should dominate, and do."""
+        scores = self._scores({"a": 0.50, "b": 0.90}, n_val=1000)
+        assert max(scores.values()) * 2 > 1.0
+
+    def test_the_same_spread_means_the_same_thing_at_two_sample_sizes(self) -> None:
+        """Min-max could not tell these apart; a noise unit must."""
+        small = self._scores({"a": 0.80, "b": 0.82}, n_val=100)
+        large = self._scores({"a": 0.80, "b": 0.82}, n_val=10000)
+        assert max(large.values()) > max(small.values())
+
+    def test_the_ranking_is_unchanged(self) -> None:
+        """Scaling changes what a difference means, not which is bigger."""
+        scores = self._scores({"a": 0.80, "b": 0.86, "c": 0.83}, n_val=500)
+        assert max(scores, key=lambda k: scores[k]) == "b"
+
+    def test_an_unknown_sample_size_falls_back_to_the_spread(self) -> None:
+        """No n means no binomial claim; the old behaviour stands."""
+        scores = self._scores({"a": 0.80, "b": 0.90}, n_val=None)
+        assert max(scores.values()) * 2 == pytest.approx(1.0)
+
+    def test_a_non_proportion_metric_falls_back(self) -> None:
+        """A loss is not a proportion and the binomial form says nothing."""
+        result = run_selector(
+            {"a": {"loss": 2.5}, "b": {"loss": 1.0}},
+            {"loss": 3.0},
+            _config(selection_metric="loss", selection_mode="min", xai_selection_weight=0.5),
+            {"a": 0.0, "b": 0.0},
+            n_val=500,
+        )
+        assert max(result.scores.values()) * 2 == pytest.approx(1.0)
+
+    def test_identical_candidates_do_not_divide_by_zero(self) -> None:
+        scores = self._scores({"a": 0.85, "b": 0.85}, n_val=500)
+        assert all(v == pytest.approx(0.0) for v in scores.values())
+
+    def test_a_saturated_metric_does_not_divide_by_zero(self) -> None:
+        """p = 1.0 has zero binomial variance; the spread is the honest unit."""
+        scores = self._scores({"a": 1.0, "b": 1.0}, n_val=500)
+        assert all(v == pytest.approx(0.0) for v in scores.values())
+
+    def test_the_plain_argmax_path_is_untouched(self) -> None:
+        """Scaling only enters the composite; weight 0 must be unaffected."""
+        result = run_selector(
+            {"a": {"accuracy": 0.8749}, "b": {"accuracy": 0.8816}},
+            self.BASELINE,
+            _config(),
+            n_val=1000,
+        )
+        assert result.best == "b"
+        assert result.scores == {"a": 0.8749, "b": 0.8816}


### PR DESCRIPTION
## Summary

The composite path normalised the selection metric min-max across candidates:

```python
m_range = max_m - min_m if max_m != min_m else 1.0
norm_m = (val - min_m) / m_range
```

That stretches whatever spread the candidates happened to have across the full `[0, 1]` range. A spread of 0.2 pp and a spread of 20 pp both produce a metric term running 0 to 1, so the blending weight means something different in every iteration, and on a saturated metric it is applied to scatter rather than to signal.

The unit is now the **binomial standard error** `sqrt(p(1-p)/n)` of the selection metric — the actual resolution of the number being compared. A normalised difference of `1.0` means *"one standard error better than the weakest candidate"*, in every iteration.

## What the numbers actually do

| spread | n | in noise units |
|---|---|---|
| 0.2 pp | 1000 | 0.19 → well under 1, the xai term gets a say |
| 2.67 pp | 1000 | 2.51 → over 1, the metric dominates |

Both are correct. The issue's "Done when" asks that a sub-noise spread stop producing a near-1.0 normalised difference, and it does. The second row matters too: a difference of several standard errors is **real**, and scaling by noise must not flatten it. There is a test for each.

**A note on the issue text:** it says "on Waterbirds that spread is around 0.2 pp" and then quotes accuracies of .8749 / .8816 / .8549, which is a 2.67 pp spread. Those are two different claims. I wrote a test for each rather than picking one, and my first attempt asserted the wrong thing about the quoted numbers before I checked the arithmetic.

## Decisions

**`p` is the mean across candidates**, not per-candidate. They differ by fractions of a point so it barely moves the unit, and one shared unit keeps the scores on a common scale.

**Standard deviation across the candidates is deliberately not used**, and the code says why in a comment as the issue asks: three points is a poor estimator of anything, and on the runs this was written for it would have been an estimator of the very noise it was supposed to divide out.

**Fallbacks.** The observed spread is used when `n` is unknown, when the metric is not a proportion (a loss — the binomial form claims nothing there), and when a saturated metric gives the unit zero variance. Each has a test.

**`n` comes from the cached label vector**, not `len(dataset)`: that is what the metric was actually computed over, and a `drop_last` loader would make the two disagree. The smaller honest number is the right one.

## Scope

The composite path stays behaviourally reachable, as the issue requires — #409 deprecates the weight but does not remove it. The **plain argmax path is untouched**, with a test asserting its scores are still the raw metric values.

## Test plan

- `pytest -q` -> **1584 passed, 19 skipped** (10 new).
- `ruff check src tests` clean; `mypy` clean on both touched modules.
- Coverage: the sub-noise spread staying low; a several-SE spread still dominating; the same spread meaning more at a larger `n`; the ranking unchanged; the three fallbacks (unknown `n`, non-proportion metric, saturated metric); identical candidates not dividing by zero; and the plain argmax path untouched.

## Docs

`docs/configuration.md` gains a section on how the composite scales differences, what a normalised `1.0` now means, the fallbacks, and why the candidate standard deviation was rejected.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #407
