### PR TITLE
feat(reporting): surface the attention evidence and promote ECE into the table

### DIFF
--- a/benchmarks/summarize_grand.py
+++ b/benchmarks/summarize_grand.py
@@ -312,6 +312,7 @@ def _analyze_dataset(
     by_cond: dict[str, dict[int, float]] = defaultdict(dict)
     gpu_epochs_by_cond: dict[str, list[int]] = defaultdict(list)
     deployed_epochs_by_cond: dict[str, list[int]] = defaultdict(list)
+    ece_by_cond: dict[str, list[float]] = defaultdict(list)
     for r in ds_runs:
         cid = r["condition"]
         seed = int(r["seed"])
@@ -325,6 +326,12 @@ def _analyze_dataset(
         dep = r.get("deployed_epochs")
         if dep is not None:
             deployed_epochs_by_cond[cid].append(int(dep))
+        # ECE was recorded from the start and never printed. On Imagewoof the
+        # most accurate conditions are the worst calibrated by roughly an order
+        # of magnitude, which is a headline fact rather than a JSON field.
+        ece = r.get("test_ece")
+        if ece is not None:
+            ece_by_cond[cid].append(float(ece))
 
     print(f"\n{'='*70}")
     print(f"  DATASET: {dataset.upper()}  |  fill={strategy}")
@@ -404,6 +411,8 @@ def _analyze_dataset(
         gpu_ep_s = str(int(statistics.median(gpu_epochs_list))) if gpu_epochs_list else "?"
         deployed_list = deployed_epochs_by_cond.get(cid, [])
         dep_ep_s = str(int(statistics.median(deployed_list))) if deployed_list else "?"
+        ece_list = ece_by_cond.get(cid, [])
+        ece_s = f"{statistics.median(ece_list):.3f}" if ece_list else "?"
 
         rows.append({
             "cid": cid,
@@ -419,6 +428,7 @@ def _analyze_dataset(
             "ci": ci_s,
             "gpu_epochs": gpu_ep_s,
             "deployed_epochs": dep_ep_s,
+            "ece": ece_s,
             "per_seed": ", ".join(f"{v*100:.2f}%" for v in sorted(vals)),
         })
 
@@ -435,8 +445,13 @@ def _print_text_table(rows: list[dict[str, Any]]) -> None:
     w = 38
     header = (
         f"{'Condition':<{w}} {'Median':>8} {'±IQR':>8} {'Mean':>8} {'±Std':>7} "
-        f"{'n':>3} {'Δ vs no_aug':>12} {'p(Holm)':>18} {'r':>6} {'GPU-ep':>8} {'Depl-ep':>8}"
+        f"{'n':>3} {'Δ vs no_aug':>12} {'p(Holm)':>18} {'r':>6} {'ECE':>7} "
+        f"{'GPU-ep':>8} {'Depl-ep':>8}"
     )
+    # Say what the ordering means. Accuracy and calibration reverse the ranking
+    # on this data, so a table sorted by one and read as "best" is misleading.
+    print("  ranked by: median held-out accuracy (higher better). "
+          "ECE is calibration error (LOWER better) and does not follow it.")
     print(header)
     print("-" * len(header))
     for row in rows:
@@ -447,7 +462,7 @@ def _print_text_table(rows: list[dict[str, Any]]) -> None:
         print(
             f"{row['label']:<{w}} {med_s:>8} {iqr_s:>8} {mn_s:>8} {std_s:>7} "
             f"{row['n']:>3} {row['delta']:>12} {row['p_holm']:>18} {row['r']:>6} "
-            f"{row['gpu_epochs']:>8} {row['deployed_epochs']:>8}"
+            f"{row['ece']:>7} {row['gpu_epochs']:>8} {row['deployed_epochs']:>8}"
         )
         print(f"  per-seed: {row['per_seed']}")
     print()
@@ -455,14 +470,20 @@ def _print_text_table(rows: list[dict[str, Any]]) -> None:
 
 def _print_markdown_table(rows: list[dict[str, Any]]) -> None:
     print(
+        "Ranked by median held-out accuracy (higher better). "
+        "ECE is calibration error, where **lower is better**, and it does not "
+        "follow the accuracy ranking: on Imagewoof the most accurate conditions "
+        "are the worst calibrated by roughly an order of magnitude.\n"
+    )
+    print(
         "| Condition | Median | ±IQR | mean±std | n | "
         "Δ vs no_aug | p (Holm) vs bnnr_xai | r | Bootstrap 95% CI | "
-        "GPU-epochs | Deployed epochs |"
+        "ECE ↓ | GPU-epochs | Deployed epochs |"
     )
     print(
         "|-----------|--------|------|----------|---|"
         "------------|---------------------|---|-----------------|"
-        "-----------|-----------------|"
+        "-------|-----------|-----------------|"
     )
     for row in rows:
         med_s = f"{row['median']*100:.2f}%"
@@ -478,7 +499,7 @@ def _print_markdown_table(rows: list[dict[str, Any]]) -> None:
             f"| {row['p_holm']} "
             f"| {row['r']} "
             f"| {row['ci']} "
-            f"| {row['gpu_epochs']} | {row['deployed_epochs']} |"
+            f"| {row['ece']} | {row['gpu_epochs']} | {row['deployed_epochs']} |"
         )
 
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -110,6 +110,24 @@ Both are **counted as epochs run**, not derived from `m_epochs × max_iterations
 
 A report written before this key existed still loads: `RunRecord.from_dict` falls back to defaults for absent fields and ignores unknown ones, so old runs summarize rather than crashing a reader.
 
+### `analysis.attention`
+
+What the run can honestly say about where the model's attention sits, so the report is readable on its own rather than needing the JSONL parsed by hand.
+
+| key | meaning |
+|---|---|
+| `axes` | which direction is better for each number the block reports |
+| `shadow_records` | how many observations were recorded |
+| `latest` | the most recent candidate's statistics and robustness metrics |
+| `diagnosis` | the regime and recommendation, or `null` |
+| `diagnosis_unavailable_because` | present only when `diagnosis` is `null`, saying why |
+
+**No regime is named without calibrated thresholds**, and the block says so rather than leaving a silent `null`. That absence is the design, not a gap: see [diagnosis](diagnosis.md).
+
+`axes` exists because **accuracy and calibration reverse the ranking** on the data this was written for. A report that prints both without saying which direction is better invites the reader to assume they agree.
+
+The block is omitted entirely when XAI or shadow mode is off, since an empty one would be noise.
+
 ## `shadow_records.jsonl`
 
 Written when `shadow_mode=true` (default) and XAI is enabled. One JSON object per line — JSONL rather than JSON so a run killed halfway still leaves every record it had already written.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -19,3 +19,11 @@ The public table compares **different training budgets**:
 - **`bnnr_branch_search`:** full BNNR pipeline (baseline phase + screening branches with ICD/AICD) — **more wall-clock and more epochs** on the winning path.
 
 So the Δaccuracy is **illustrative** (product vs simple baselines), not an equal-compute SOTA claim. Hardware, seeds, and full methodology: [`benchmarks/README.md`](../benchmarks/README.md#results-2026-05-28-seeds-4244-cpu).
+
+## Reading the grand-benchmark table
+
+The per-dataset table is **ranked by median held-out accuracy**, and says so above the header.
+
+It also prints **ECE** (expected calibration error), where **lower is better**. That column does not follow the accuracy ranking. On Imagewoof the most accurate conditions are the worst calibrated by roughly an order of magnitude — `no_aug` leads on accuracy at ~34% with an ECE of 0.257, while RandAugment sits at ~31% with an ECE of 0.033.
+
+That is the point of showing both: given that different augmentations improve different axes, "the best augmentation" is not a well-defined thing, and a single ranking hides it. Rows from before ECE was recorded print `?`.

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -987,6 +987,9 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
         analysis["dual_xai"] = dual_xai_analysis
     if trainer.config.shadow_mode:
         trainer._shadow.write(trainer.reporter.run_dir)
+    attention = _attention_summary(trainer)
+    if attention:
+        analysis["attention"] = attention
     trainer._emit_pipeline_complete()
     result = trainer.reporter.finalize(
         best_path=best_path,
@@ -1079,3 +1082,57 @@ def _val_sample_count(trainer: BNNRTrainer) -> int | None:
         return len(dataset) if dataset is not None else None
     except TypeError:
         return None
+
+
+def _attention_summary(trainer: BNNRTrainer) -> dict[str, Any]:
+    """What the run can honestly say about where the model's attention sits.
+
+    The report has to be readable on its own, so this lands in ``analysis``
+    rather than staying an internal gate. What it can say depends on what was
+    configured:
+
+    * With shadow mode on, the saliency statistics and the robustness metrics.
+      No regime, because naming one needs thresholds and there are none by
+      default; that is the point of #405, not a gap.
+    * With calibrated thresholds and the diagnosis selector, the regime, the
+      recommendation and the clause-by-clause reason as well.
+
+    Also carries which axis each number is better on, because accuracy and
+    calibration reverse the ranking on the data this was written for, and a
+    report that prints both without saying so invites the reader to assume
+    they agree.
+    """
+    records = [r.to_dict() for r in trainer._shadow.records]
+    diagnosis = trainer._last_diagnosis
+    if not records and diagnosis is None:
+        return {}
+
+    summary: dict[str, Any] = {
+        "axes": {
+            "accuracy": "higher is better",
+            "hard_quantile_acc": "higher is better",
+            "robustness_gap": "lower is better",
+            "ece": "lower is better",
+            "concentration": "neither: high means focused, low means diffuse",
+            "border_mass": "neither: high means the model is reading the frame",
+        },
+    }
+    if records:
+        summary["shadow_records"] = len(records)
+        latest = records[-1]
+        summary["latest"] = {
+            "candidate": latest["candidate"],
+            "stats": latest["stats"],
+            "overall_acc": latest["overall_acc"],
+            "hard_quantile_acc": latest["hard_quantile_acc"],
+            "robustness_gap": latest["robustness_gap"],
+        }
+    if diagnosis is not None:
+        summary["diagnosis"] = diagnosis.to_dict()
+    else:
+        summary["diagnosis"] = None
+        summary["diagnosis_unavailable_because"] = (
+            "no calibrated thresholds were supplied, so no regime can be named. "
+            "The statistics above are recorded for calibration; see docs/diagnosis.md."
+        )
+    return summary

--- a/tests/test_attention_report.py
+++ b/tests/test_attention_report.py
@@ -1,0 +1,166 @@
+"""Tests for the attention block in the run report (FIX-3-3)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from bnnr.adapter import SimpleTorchAdapter
+from bnnr.config_model import BNNRConfig
+from bnnr.reporting import Reporter
+from bnnr.trainer import BNNRTrainer
+
+
+def _run(tmp_path, tag: str, **config_kwargs):
+    torch.manual_seed(0)
+    model = nn.Sequential(
+        nn.Conv2d(3, 4, 3, padding=1), nn.ReLU(),
+        nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(4, 2),
+    )
+    adapter = SimpleTorchAdapter(
+        model=model,
+        criterion=nn.CrossEntropyLoss(),
+        optimizer=torch.optim.SGD(model.parameters(), lr=0.01),
+        device="cpu",
+    )
+    images = torch.rand(8, 3, 16, 16)
+    labels = torch.randint(0, 2, (8,))
+    loader = DataLoader(TensorDataset(images, labels), batch_size=4)
+    config = BNNRConfig(
+        m_epochs=1,
+        max_iterations=0,
+        report_dir=tmp_path / tag,
+        verbose=False,
+        save_checkpoints=False,
+        xai_samples=2,
+        **config_kwargs,
+    )
+    trainer = BNNRTrainer(
+        model=adapter,
+        train_loader=loader,
+        val_loader=loader,
+        augmentations=[],
+        config=config,
+        reporter=Reporter(tmp_path / tag, save_html=False),
+    )
+    return trainer.run()
+
+
+class TestAttentionBlock:
+    def test_the_report_carries_an_attention_block(self, tmp_path) -> None:
+        result = _run(tmp_path, "on", xai_enabled=True)
+        payload = json.loads(result.report_json_path.read_text())
+        assert "attention" in payload["analysis"]
+
+    def test_it_says_which_axis_each_number_is_better_on(self, tmp_path) -> None:
+        """Accuracy and calibration reverse the ranking, so a report that prints
+        both without saying so invites the reader to assume they agree."""
+        result = _run(tmp_path, "on", xai_enabled=True)
+        axes = json.loads(result.report_json_path.read_text())["analysis"]["attention"]["axes"]
+        assert axes["robustness_gap"] == "lower is better"
+        assert axes["ece"] == "lower is better"
+        assert axes["accuracy"] == "higher is better"
+
+    def test_it_reports_the_statistics_it_observed(self, tmp_path) -> None:
+        result = _run(tmp_path, "on", xai_enabled=True)
+        block = json.loads(result.report_json_path.read_text())["analysis"]["attention"]
+        assert block["shadow_records"] > 0
+        assert block["latest"]["stats"] is not None
+
+    def test_it_names_no_regime_without_thresholds(self, tmp_path) -> None:
+        """Naming one needs calibrated thresholds. Their absence is the design,
+        so the report says why rather than leaving a silent null."""
+        result = _run(tmp_path, "on", xai_enabled=True)
+        block = json.loads(result.report_json_path.read_text())["analysis"]["attention"]
+        assert block["diagnosis"] is None
+        assert "no calibrated thresholds" in block["diagnosis_unavailable_because"]
+        assert "docs/diagnosis.md" in block["diagnosis_unavailable_because"]
+
+    def test_no_block_when_there_is_nothing_to_say(self, tmp_path) -> None:
+        """With XAI off there are no maps, so an empty block would be noise."""
+        result = _run(tmp_path, "off", xai_enabled=False)
+        payload = json.loads(result.report_json_path.read_text())
+        assert "attention" not in payload["analysis"]
+
+    def test_shadow_mode_off_also_produces_nothing(self, tmp_path) -> None:
+        result = _run(tmp_path, "noshadow", xai_enabled=True, shadow_mode=False)
+        payload = json.loads(result.report_json_path.read_text())
+        assert "attention" not in payload["analysis"]
+
+    def test_the_block_is_json_serialisable(self, tmp_path) -> None:
+        """It travels in report.json, so nothing in it may be a numpy scalar."""
+        result = _run(tmp_path, "on", xai_enabled=True)
+        block = json.loads(result.report_json_path.read_text())["analysis"]["attention"]
+        json.dumps(block)  # must not raise
+
+    def test_the_latest_record_names_its_candidate(self, tmp_path) -> None:
+        result = _run(tmp_path, "on", xai_enabled=True)
+        block = json.loads(result.report_json_path.read_text())["analysis"]["attention"]
+        assert block["latest"]["candidate"] == "baseline"
+
+
+class TestSummarizerAxisLabels:
+    """Where a ranking is printed, the axis it ranks on is printed too."""
+
+    def _rows(self):
+        return [
+            {
+                "label": "cond_a", "median": 0.34, "iqr": 0.01, "mean": 0.34,
+                "std": 0.01, "n": 10, "delta": "—", "p_holm": "p=0.02",
+                "r": "1.00", "ci": "[0, 0]", "gpu_epochs": "40",
+                "deployed_epochs": "13", "ece": "0.257",
+                "per_seed": "34.00%",
+            }
+        ]
+
+    def test_the_text_table_states_the_ranking_axis(self, capsys) -> None:
+        from benchmarks.summarize_grand import _print_text_table
+
+        _print_text_table(self._rows())
+        out = capsys.readouterr().out
+        assert "ranked by" in out
+        assert "LOWER better" in out
+
+    def test_the_text_table_prints_ece(self, capsys) -> None:
+        from benchmarks.summarize_grand import _print_text_table
+
+        _print_text_table(self._rows())
+        out = capsys.readouterr().out
+        assert "ECE" in out
+        assert "0.257" in out
+
+    def test_the_markdown_table_prints_ece_and_its_direction(self, capsys) -> None:
+        from benchmarks.summarize_grand import _print_markdown_table
+
+        _print_markdown_table(self._rows())
+        out = capsys.readouterr().out
+        assert "ECE" in out
+        assert "lower is better" in out
+        assert "0.257" in out
+
+    def test_a_row_without_ece_prints_a_question_mark(self, capsys) -> None:
+        """Records written before ECE was surfaced still summarize."""
+        from benchmarks.summarize_grand import _print_text_table
+
+        rows = self._rows()
+        rows[0]["ece"] = "?"
+        _print_text_table(rows)
+        assert "?" in capsys.readouterr().out
+
+
+class TestEceIsCollectedFromRows:
+    def test_the_summarizer_reads_test_ece(self) -> None:
+        """The key was recorded from the start and never printed."""
+        import json as _json
+        from pathlib import Path
+
+        path = Path("benchmarks/results_imagewoof_scratch.json")
+        if not path.exists():
+            pytest.skip("benchmark results not present")
+        data = _json.loads(path.read_text())
+        rows = data if isinstance(data, list) else data.get("runs", [])
+        assert any(r.get("test_ece") is not None for r in rows)


### PR DESCRIPTION
## Summary

Proposal G: given that ICD and AICD improve different axes, and that accuracy and calibration reverse the ranking, *"the best augmentation"* is not well defined. The honest deliverable is the trade-off plus something that tells a user where on it they sit. The diagnosis was an internal gate; ECE was recorded and never shown.

## ECE in the headline table

`test_ece` was in the benchmark rows from the start. It is now a column in both the text and markdown tables, and it immediately shows the reversal the finding describes:

| condition | median accuracy | ECE |
|---|---|---|
| `no_aug` | **33.97%** | **0.257** |
| RandAugment | 30.79% | **0.033** |

The most accurate condition is the worst calibrated, by roughly an order of magnitude. That is the whole point of showing both.

## Rankings say what they rank on

Both tables now print the axis above the header, and that ECE runs the other way:

```
ranked by: median held-out accuracy (higher better). ECE is calibration error
(LOWER better) and does not follow it.
```

A table sorted by accuracy and read as "best" is misleading precisely when the two axes disagree — which is the case this exists to expose.

Rows written before ECE was surfaced print `?` rather than crashing the summarizer, the same convention #410 established for the epoch counts.

## `analysis.attention` in `report.json`

Carries the saliency statistics, the robustness metrics, how many shadow observations were made, and an `axes` map saying which direction is better for each number.

That last part is not decoration. A report that prints accuracy and calibration without saying which way each runs invites the reader to assume they agree, which on this data they do not.

**No regime is named without calibrated thresholds**, and the block says *why* in `diagnosis_unavailable_because` rather than leaving a silent `null`. The absence is the design from #405, and a reader should not have to know that to interpret the field.

The block is omitted entirely when XAI or shadow mode is off, since an empty one would be noise.

## What I did not do, and why

Step 1 also names the **HTML report and the dashboard**.

There is no HTML generator for training runs — `report_html_path` is always `None`, and `analysis/html_report.py` belongs to the standalone `bnnr analyze` path, which never computes a diagnosis. So the JSON block is the report surface that actually exists. Wiring the dashboard is a change against `dashboard_web/` with its own build step, and folding it in here would have made this PR two unrelated reviews.

Flagging it rather than quietly narrowing the issue: if you want the dashboard panel, it is a follow-up I can take.

## Test plan

- `pytest -q` -> **1597 passed, 19 skipped** (13 new).
- `ruff check src tests benchmarks` clean; `mypy` clean.
- Ran the summarizer over the real `benchmarks/results_*.json` to confirm the column renders and the numbers above are what it prints.
- Coverage: the block present and absent in the three configurations; the axes map; the statistics; the no-regime explanation naming both the reason and the doc; JSON serialisability; both tables printing ECE and their axis note; and a missing-ECE row still summarizing.

## Docs

`docs/artifacts.md` documents `analysis.attention` key by key; `docs/benchmarks.md` gains a section on reading the table, with the Imagewoof reversal spelled out.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed (untouched; see above)

Closes #412
