### PR TITLE
feat(training): search_policy with exhaustive, diagnosis_single and successive_halving

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -95,7 +95,8 @@ The fields a run must carry for its result to be comparable with another run. Wr
 |---|---|
 | `total_gpu_epochs` | every epoch trained anywhere: baseline, every candidate of every iteration, pruned and losing candidates included |
 | `deployed_epochs` | epochs of training the shipped model actually received |
-| `search_policy` | how candidates were enumerated; `"exhaustive"` is the only one today |
+| `search_policy` | `exhaustive`, `diagnosis_single` or `successive_halving` |
+| `search_plan` | the rung structure that policy produced, with its planned epoch accounting |
 | `selector` | which rule picked the winner, from `config.selector` |
 | `selected_candidate` | list of names the selector chose |
 | `diagnosis` | the attention diagnosis when one was computed, else `null` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,28 @@ seed: 42
 
 Both are gated the same way: whatever a selector picks is discarded unless it beat the baseline on `selection_metric`. That gate is deliberately shared, so a comparison between two selectors is a comparison of their ranking rules and nothing else. A selector that skipped it would look better purely by accepting runs the others reject.
 
+### Search policy
+
+- `search_policy` (default: `exhaustive`)
+
+How the candidate budget is spent. **The default does not change**, and `exhaustive` produces exactly the plan the loop used to hard-code.
+
+| value | what it does |
+|---|---|
+| `exhaustive` (default) | every candidate trains `m_epochs`, then the selector arbitrates |
+| `diagnosis_single` | the diagnosis names one candidate and it trains the whole budget |
+| `successive_halving` | the field halves each rung; weak branches die early |
+
+This addresses both defects the T20 benchmark found at once.
+
+**The selection criterion.** `exhaustive` arbitrates on selection-validation accuracy, which T20 found close to orthogonal to the objective. `diagnosis_single` does not arbitrate: the attention evidence names the arm.
+
+**The epoch split.** Under `exhaustive` with three candidates and `m_epochs: 6`, the run spends 18 epochs and the deployed model receives 6 — while a single-augmentation baseline on the same budget receives all 18. That is what made BNNR look worse than it is; matching deployed epochs closed a 4.46 pp gap to 0.09 pp on Imagewoof. `diagnosis_single` spends the same 18 and gives all of them to one arm. `successive_halving` costs no more than `exhaustive` and hands the eliminated branches' epochs to the survivors.
+
+`diagnosis_single` **refuses to run without calibrated thresholds**, the same gate as `selector: diagnosis`, and refuses again at plan time if no diagnosis was computed or if its recommendation matches no candidate. It does not fall back to argmax: a silent fallback would make a benchmark contrast between the policies measure a blend of them.
+
+The plan, including its rung structure and both epoch numbers, lands in the run record under `search_plan`. Note that the record's `total_gpu_epochs` and `deployed_epochs` are **counted as epochs run**, not read from the plan — candidate pruning can stop a rung early, and the measurement is what matters.
+
 ### Indistinguishability test
 
 - `indistinguishable_resamples` (default: `2000`, validated `>= 100`)

--- a/src/bnnr/config_model.py
+++ b/src/bnnr/config_model.py
@@ -107,6 +107,10 @@ class BNNRConfig(BaseModel):
     # Which rule picks the winning candidate. "metric_argmax" is what BNNR has
     # always done and stays the default; see bnnr.training.selection.SELECTORS.
     selector: str = "metric_argmax"
+    #: How the candidate budget is spent. "exhaustive" is what BNNR has always
+    #: done and stays the default until the calibration study says otherwise;
+    #: see bnnr.training.search_policy.SEARCH_POLICIES.
+    search_policy: str = "exhaustive"
     #: Cut points for the ``diagnosis`` selector. Unset by design; see
     #: DiagnosisConfig and docs/diagnosis.md.
     diagnosis: DiagnosisConfig = Field(default_factory=DiagnosisConfig)
@@ -282,11 +286,22 @@ class BNNRConfig(BaseModel):
         several epochs in before discovering it cannot decide anything is the
         worst version of this error.
         """
-        if self.selector in _DIAGNOSIS_DRIVEN_SELECTORS:
+        from bnnr.training.search_policy import DIAGNOSIS_DRIVEN_POLICIES
+
+        needs_thresholds = (
+            self.selector in _DIAGNOSIS_DRIVEN_SELECTORS
+            or self.search_policy in DIAGNOSIS_DRIVEN_POLICIES
+        )
+        if needs_thresholds:
+            requested = (
+                f"selector={self.selector!r}"
+                if self.selector in _DIAGNOSIS_DRIVEN_SELECTORS
+                else f"search_policy={self.search_policy!r}"
+            )
             absent = self.diagnosis.missing()
             if absent:
                 raise ValueError(
-                    f"selector={self.selector!r} needs calibrated diagnosis thresholds; "
+                    f"{requested} needs calibrated diagnosis thresholds; "
                     f"{', '.join(absent)} {'is' if len(absent) == 1 else 'are'} unset. "
                     f"There is deliberately no default: an uncalibrated cut point driving "
                     f"selection is the defect this replaces. Supply them under the "
@@ -300,6 +315,17 @@ class BNNRConfig(BaseModel):
     def validate_indistinguishable_confidence(cls, value: float) -> float:
         if not (0.0 < value < 1.0):
             raise ValueError("indistinguishable_confidence must be in (0, 1)")
+        return value
+
+    @field_validator("search_policy")
+    @classmethod
+    def validate_search_policy(cls, value: str) -> str:
+        from bnnr.training.search_policy import SEARCH_POLICIES
+
+        if value not in SEARCH_POLICIES:
+            raise ValueError(
+                f"search_policy must be one of {sorted(SEARCH_POLICIES)}, got {value!r}"
+            )
         return value
 
     @field_validator("selector")

--- a/src/bnnr/trainer.py
+++ b/src/bnnr/trainer.py
@@ -106,6 +106,8 @@ class BNNRTrainer:
         # selection result, for the indistinguishability test and its record.
         self._baseline_correct: Any | None = None
         self._last_selection: Any | None = None
+        #: The search plan the last iteration ran, for the run record.
+        self._last_search_plan: Any | None = None
         self.logger = setup_logging("bnnr", config.log_file, json_format=True)
         self._custom_metrics: dict[str, Any] = custom_metrics or {}
 

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -24,6 +24,7 @@ from bnnr.training import metrics as _metrics
 from bnnr.training import paired as _paired
 from bnnr.training import probe as _probe
 from bnnr.training import run_record as _run_record
+from bnnr.training import search_policy as _search
 from bnnr.training import selection as _selection
 from bnnr.training import shadow as _shadow
 from bnnr.training import xai_runner as _xai
@@ -236,6 +237,7 @@ def run_single_iteration(
     iteration: int = 0,
     candidate_idx: int = 0,
     total_candidates: int = 0,
+    epochs: int | None = None,
     ) -> tuple[dict[str, float], dict[str, Any], int, bool]:
     """Train one candidate augmentation for m_epochs.
 
@@ -257,7 +259,9 @@ def run_single_iteration(
     best_sel_value: float | None = None
 
     pruned = False
-    for epoch_idx in range(1, trainer.config.m_epochs + 1):
+    # The search policy sets the budget; m_epochs is what "exhaustive" asks for.
+    budget = trainer.config.m_epochs if epochs is None else max(1, epochs)
+    for epoch_idx in range(1, budget + 1):
         train_metrics = train_epoch(trainer, trainer.train_loader, augmentations=active)
         epoch_metrics = evaluate(trainer, trainer.val_loader)
 
@@ -290,7 +294,7 @@ def run_single_iteration(
         # Print progress to terminal
         best_marker = " ★" if is_new_best else ""
         trainer.console.print(
-            f"    epoch {epoch_idx}/{trainer.config.m_epochs} "
+            f"    epoch {epoch_idx}/{budget} "
             f"— {sel_m}={sel_v:.4f}  loss={epoch_metrics.get('loss', 0):.4f}"
             f"  (best: e{best_epoch}={best_sel_value:.4f}){best_marker}",
             flush=True,
@@ -652,126 +656,180 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
             per_class_by_candidate: dict[str, dict[str, dict[str, float | int]]] = {}
             xai_scores_by_candidate: dict[str, float] = {}
             candidate_correct: dict[str, Any] = {}
-            for idx, augmentation in enumerate(candidate_bar, start=1):
-                t0 = time.perf_counter()
+            plan = _search.plan_search(
+                tuple(a.name for a in candidates),
+                trainer.config,
+                diagnosis=trainer._last_diagnosis,
+            )
+            trainer._last_search_plan = plan
+            if plan.policy != "exhaustive":
                 trainer.console.print(
-                    f"\n  ▶ [{idx}/{len(candidates)}] {augmentation.name} "
-                    f"(p={augmentation.probability:.2f})",
+                    f"  search_policy={plan.policy}: {len(plan.rungs)} rung(s), "
+                    f"{plan.total_epochs} epochs total, "
+                    f"{plan.deployed_epochs} to a surviving candidate",
                     flush=True,
                 )
-                trainer.model.load_state_dict(trainer._clone_state_dict(best_state))
-                cand_best_metrics, cand_best_state, cand_best_epoch, pruned = run_single_iteration(trainer,
-                    augmentation,
-                    baseline_metrics=baseline_metrics,
-                    iteration=iteration,
-                    candidate_idx=idx,
-                    total_candidates=len(candidates),
+            by_name = {a.name: a for a in candidates}
+            # Rungs let a policy stop paying for a branch that is already
+            # behind. Exhaustive produces exactly one rung holding every
+            # candidate, so this loop runs its old body once per candidate.
+            for rung_idx, rung in enumerate(plan.rungs):
+                alive = [by_name[n] for n in rung.candidates if n in by_name]
+                candidate_bar = tqdm(
+                    alive,
+                    desc=f"Iteration {iteration} rung {rung_idx + 1}/{len(plan.rungs)}",
+                    leave=False,
+                    disable=not trainer.config.verbose,
                 )
-                iteration_results[augmentation.name] = cand_best_metrics
-                # Save this candidate's best-epoch model state (already deep-copied)
-                candidate_states[augmentation.name] = cand_best_state
-                candidate_best_epochs[augmentation.name] = cand_best_epoch
-
-                # Restore best-epoch state to compute per-class details at that point.
-                # Clear cached eval data so _compute_eval_class_details_detection
-                # runs a fresh (single) forward pass with the best-epoch weights.
-                trainer.model.load_state_dict(cand_best_state)
-                if hasattr(trainer.model, "last_eval_preds"):
-                    trainer.model.last_eval_preds = []  # type: ignore[attr-defined]  # duck-typed attr on DetectionAdapter
-                    trainer.model.last_eval_targets = []  # type: ignore[attr-defined]  # duck-typed attr on DetectionAdapter
-                # Invalidate classification prediction cache (state changed)
-                trainer._last_eval_preds = None
-                trainer._last_eval_labels = None
-                per_class_candidate, confusion_candidate = _metrics.compute_eval_class_details(trainer)
-                per_class_by_candidate[augmentation.name] = per_class_candidate
-                # The prediction cache now belongs to this candidate's best
-                # epoch, which is the state its metrics describe.
-                candidate_correct[augmentation.name] = _paired.correctness_vector(
-                    trainer._last_eval_preds, trainer._last_eval_labels
-                )
-
-                # Lightweight XAI probe per candidate (for XAI-aware selection)
-                _, cand_xai_diag, _ = _xai.generate_xai_lightweight(trainer,
-                    iteration, augmentation.name, confusion=confusion_candidate,
-                )
-                _record_shadow(
-                    trainer,
-                    phase="candidate",
-                    iteration=iteration,
-                    candidate=augmentation.name,
-                    metrics=cand_best_metrics,
-                )
-                if cand_xai_diag:
-                    avg_q = float(np.mean([
-                        d.get("quality_score", 0.0) for d in cand_xai_diag.values()
-                    ]))
-                    xai_scores_by_candidate[augmentation.name] = avg_q
-
-                completed_candidates.append(augmentation.name)
-
-                # Emit real-time events per candidate so dashboard updates live
-                branch_id = f"iter_{iteration}:{augmentation.name}"
-                trainer.reporter.log_candidate_evaluated(
-                    iteration=iteration,
-                    branch_id=branch_id,
-                    parent_id=current_branch_id,
-                    augmentation_name=augmentation.name,
-                    metrics=cand_best_metrics,
-                    pruned=pruned,
-                    per_class=per_class_candidate,
-                    confusion=confusion_candidate,
-                    best_epoch=cand_best_epoch,
-                    candidate_idx=idx,
-                    total_candidates=len(candidates),
-                )
-
-                delta = cand_best_metrics.get(sel_m, 0) - base_val
-                delta_str = f"+{delta:.4f}" if delta > 0 else f"{delta:.4f}"
-                status = "PRUNED" if pruned else f"Δ{delta_str}"
-                trainer.console.print(
-                    f"  ◀ [{idx}/{len(candidates)}] {augmentation.name}: "
-                    f"{sel_m}={cand_best_metrics.get(sel_m, 0):.4f} "
-                    f"(best@e{cand_best_epoch}, {status})",
-                    flush=True,
-                )
-
-                elapsed = time.perf_counter() - t0
-                per_candidate_durations.append(elapsed)
-                avg_time = sum(per_candidate_durations) / len(per_candidate_durations)
-                remaining = max(len(candidates) - idx, 0)
-                eta = avg_time * remaining
-                candidate_bar.set_postfix_str(f"avg={avg_time:.2f}s eta={eta:.1f}s")
-
-                if not long_run_warned:
-                    projected = _estimate_remaining_seconds(
-                        avg_time,
-                        len(candidates),
-                        idx,
-                        iteration,
-                        trainer.config.max_iterations,
+                for idx, augmentation in enumerate(candidate_bar, start=1):
+                    t0 = time.perf_counter()
+                    trainer.console.print(
+                        f"\n  ▶ [{idx}/{len(candidates)}] {augmentation.name} "
+                        f"(p={augmentation.probability:.2f})",
+                        flush=True,
                     )
-                    if projected >= _LONG_RUN_WARN_SECONDS:
-                        long_run_warned = True
-                        trainer.console.print(
-                            f"\n  WARNING: branch search may take ~{projected / 3600:.1f}h more "
-                            f"(~{avg_time:.0f}s/candidate over the remaining iterations). "
-                            "Lower --max-iterations or pick a lighter preset to shorten it; "
-                            "training is checkpointed, so Ctrl+C and resume is safe.\n",
-                            flush=True,
+                    # Later rungs continue this candidate rather than restarting
+                    # it: successive halving is about giving survivors *more*
+                    # training, not about repeating the first rung.
+                    resume_from = candidate_states.get(augmentation.name, best_state)
+                    trainer.model.load_state_dict(trainer._clone_state_dict(resume_from))
+                    cand_best_metrics, cand_best_state, cand_best_epoch, pruned = run_single_iteration(trainer,
+                        augmentation,
+                        baseline_metrics=baseline_metrics,
+                        iteration=iteration,
+                        candidate_idx=idx,
+                        total_candidates=len(alive),
+                        epochs=rung.epochs,
+                    )
+                    iteration_results[augmentation.name] = cand_best_metrics
+                    # Save this candidate's best-epoch model state (already deep-copied)
+                    candidate_states[augmentation.name] = cand_best_state
+                    # Accumulate: a survivor's deployed epochs are what it got
+                    # across every rung, not just the last one.
+                    candidate_best_epochs[augmentation.name] = (
+                        candidate_best_epochs.get(augmentation.name, 0) + cand_best_epoch
+                    )
+
+                    # Restore best-epoch state to compute per-class details at that point.
+                    # Clear cached eval data so _compute_eval_class_details_detection
+                    # runs a fresh (single) forward pass with the best-epoch weights.
+                    trainer.model.load_state_dict(cand_best_state)
+                    if hasattr(trainer.model, "last_eval_preds"):
+                        trainer.model.last_eval_preds = []  # type: ignore[attr-defined]  # duck-typed attr on DetectionAdapter
+                        trainer.model.last_eval_targets = []  # type: ignore[attr-defined]  # duck-typed attr on DetectionAdapter
+                    # Invalidate classification prediction cache (state changed)
+                    trainer._last_eval_preds = None
+                    trainer._last_eval_labels = None
+                    per_class_candidate, confusion_candidate = _metrics.compute_eval_class_details(trainer)
+                    per_class_by_candidate[augmentation.name] = per_class_candidate
+                    # The prediction cache now belongs to this candidate's best
+                    # epoch, which is the state its metrics describe.
+                    candidate_correct[augmentation.name] = _paired.correctness_vector(
+                        trainer._last_eval_preds, trainer._last_eval_labels
+                    )
+
+                    # Lightweight XAI probe per candidate (for XAI-aware selection)
+                    _, cand_xai_diag, _ = _xai.generate_xai_lightweight(trainer,
+                        iteration, augmentation.name, confusion=confusion_candidate,
+                    )
+                    _record_shadow(
+                        trainer,
+                        phase="candidate",
+                        iteration=iteration,
+                        candidate=augmentation.name,
+                        metrics=cand_best_metrics,
+                    )
+                    if cand_xai_diag:
+                        avg_q = float(np.mean([
+                            d.get("quality_score", 0.0) for d in cand_xai_diag.values()
+                        ]))
+                        xai_scores_by_candidate[augmentation.name] = avg_q
+
+                    completed_candidates.append(augmentation.name)
+
+                    # Emit real-time events per candidate so dashboard updates live
+                    branch_id = f"iter_{iteration}:{augmentation.name}"
+                    trainer.reporter.log_candidate_evaluated(
+                        iteration=iteration,
+                        branch_id=branch_id,
+                        parent_id=current_branch_id,
+                        augmentation_name=augmentation.name,
+                        metrics=cand_best_metrics,
+                        pruned=pruned,
+                        per_class=per_class_candidate,
+                        confusion=confusion_candidate,
+                        best_epoch=cand_best_epoch,
+                        candidate_idx=idx,
+                        total_candidates=len(candidates),
+                    )
+
+                    delta = cand_best_metrics.get(sel_m, 0) - base_val
+                    delta_str = f"+{delta:.4f}" if delta > 0 else f"{delta:.4f}"
+                    status = "PRUNED" if pruned else f"Δ{delta_str}"
+                    trainer.console.print(
+                        f"  ◀ [{idx}/{len(candidates)}] {augmentation.name}: "
+                        f"{sel_m}={cand_best_metrics.get(sel_m, 0):.4f} "
+                        f"(best@e{cand_best_epoch}, {status})",
+                        flush=True,
+                    )
+
+                    elapsed = time.perf_counter() - t0
+                    per_candidate_durations.append(elapsed)
+                    avg_time = sum(per_candidate_durations) / len(per_candidate_durations)
+                    remaining = max(len(candidates) - idx, 0)
+                    eta = avg_time * remaining
+                    candidate_bar.set_postfix_str(f"avg={avg_time:.2f}s eta={eta:.1f}s")
+
+                    if not long_run_warned:
+                        projected = _estimate_remaining_seconds(
+                            avg_time,
+                            len(candidates),
+                            idx,
+                            iteration,
+                            trainer.config.max_iterations,
+                        )
+                        if projected >= _LONG_RUN_WARN_SECONDS:
+                            long_run_warned = True
+                            trainer.console.print(
+                                f"\n  WARNING: branch search may take ~{projected / 3600:.1f}h more "
+                                f"(~{avg_time:.0f}s/candidate over the remaining iterations). "
+                                "Lower --max-iterations or pick a lighter preset to shorten it; "
+                                "training is checkpointed, so Ctrl+C and resume is safe.\n",
+                                flush=True,
+                            )
+
+                    if trainer.config.save_checkpoints:
+                        _ = _ckpt.save_checkpoint(trainer,
+                            iteration=iteration,
+                            augmentation_name=f"progress_{augmentation.name}",
+                            metrics=cand_best_metrics,
+                            baseline_metrics=baseline_metrics,
+                            completed_candidates=completed_candidates,
+                            current_best_metric=_branching.get_current_best_metric(iteration_results, trainer.config),
+                            iteration_results=iteration_results,
                         )
 
-                if trainer.config.save_checkpoints:
-                    _ = _ckpt.save_checkpoint(trainer,
-                        iteration=iteration,
-                        augmentation_name=f"progress_{augmentation.name}",
-                        metrics=cand_best_metrics,
-                        baseline_metrics=baseline_metrics,
-                        completed_candidates=completed_candidates,
-                        current_best_metric=_branching.get_current_best_metric(iteration_results, trainer.config),
-                        iteration_results=iteration_results,
-                    )
+                    trainer._check_pause()
 
-                trainer._check_pause()
+                if rung_idx < len(plan.rungs) - 1:
+                    survivors = _branching.top_k_candidate_names(
+                        {n: iteration_results[n] for n in rung.candidates
+                         if n in iteration_results},
+                        trainer.config,
+                        k=rung.survivors,
+                    )
+                    plan_rest = plan.rungs[rung_idx + 1]
+                    # A later rung may name candidates this one eliminated;
+                    # intersect rather than trusting the plan, since the plan
+                    # was built before any metric existed.
+                    kept = [n for n in plan_rest.candidates if n in survivors]
+                    plan = _search.SearchPlan(
+                        plan.policy,
+                        plan.rungs[: rung_idx + 1]
+                        + (_search.SearchRung(tuple(kept), plan_rest.epochs,
+                                              survivors=plan_rest.survivors),)
+                        + plan.rungs[rung_idx + 2 :],
+                    )
 
         selection = _selection.run_selector(
             iteration_results,
@@ -1005,18 +1063,12 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
 def _build_run_record(
     trainer: BNNRTrainer, selected_augmentations: list[str]
 ) -> _run_record.RunRecord:
-    """Collect the mandatory record fields at the end of a run.
-
-    ``search_policy`` is hard-coded to ``"exhaustive"`` because that is the only
-    policy that exists; #413 adds the alternatives and reads the config instead.
-    Recording it now rather than then is deliberate: rows written before the
-    feature lands stay distinguishable from rows written after it.
-    """
+    """Collect the mandatory record fields at the end of a run."""
     diagnosis = trainer._last_diagnosis
     return _run_record.RunRecord(
         total_gpu_epochs=trainer._ledger.total_gpu_epochs,
         deployed_epochs=trainer._ledger.deployed_epochs,
-        search_policy="exhaustive",
+        search_policy=trainer.config.search_policy,
         selector=trainer.config.selector,
         selected_candidate=tuple(selected_augmentations),
         diagnosis=diagnosis.to_dict() if diagnosis is not None else None,
@@ -1024,6 +1076,11 @@ def _build_run_record(
         augmentation_modes=_run_record.collect_augmentation_modes(trainer.augmentations),
         selection_reason=(
             trainer._last_selection.reason if trainer._last_selection is not None else None
+        ),
+        search_plan=(
+            trainer._last_search_plan.to_dict()
+            if trainer._last_search_plan is not None
+            else None
         ),
         selection_interval=(
             trainer._last_selection.interval.to_dict()

--- a/src/bnnr/training/run_record.py
+++ b/src/bnnr/training/run_record.py
@@ -78,8 +78,12 @@ class RunRecord:
     #: Epochs of training the shipped model received.
     deployed_epochs: int = 0
 
-    #: How candidates were enumerated. Only "exhaustive" exists today (#413).
+    #: How candidates were enumerated: exhaustive, diagnosis_single or
+    #: successive_halving.
     search_policy: str = "exhaustive"
+    #: The rung structure that policy produced, with its epoch accounting.
+    #: ``None`` for a run that never reached the search phase.
+    search_plan: dict[str, Any] | None = None
     #: Which rule picked the winner, from ``config.selector``.
     selector: str = "metric_argmax"
     #: Names the selector chose. A tuple, matching ``SelectionResult.selected``,

--- a/src/bnnr/training/search_policy.py
+++ b/src/bnnr/training/search_policy.py
@@ -1,0 +1,230 @@
+"""How the candidate budget is spent, as a named and swappable plan.
+
+This is the headline recommendation of the T20 findings: one design change
+closes both defects the benchmarks identified.
+
+**The selection criterion.** ``exhaustive`` evaluates every candidate and then
+arbitrates on selection-validation accuracy, a quantity T20 found close to
+orthogonal to the objective. ``diagnosis_single`` skips the arbitration: the
+attention diagnosis names one candidate and that candidate trains.
+
+**The epoch split.** Under ``exhaustive`` the deployed model receives roughly
+``B/3`` of the budget while a single-augmentation baseline receives all of ``B``,
+which is what made BNNR look worse than it is. Matching deployed epochs closed
+4.46 pp to 0.09 pp on Imagewoof. ``diagnosis_single`` gives its one candidate
+the whole budget; ``successive_halving`` kills weak branches after a rung
+instead of paying a flat ``B/3`` for each.
+
+A policy produces a :class:`SearchPlan` of rungs. The loop executes rungs; it
+does not decide what they contain. That separation is what lets a policy be
+swapped, recorded, and benchmarked against another one.
+
+**Defaults do not move here.** ``exhaustive`` stays the default until the
+calibration study says otherwise, and it produces exactly the plan the loop
+used to hard-code.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bnnr.analysis.diagnosis import Diagnosis
+    from bnnr.config_model import BNNRConfig
+
+__all__ = [
+    "SEARCH_POLICIES",
+    "SearchPlan",
+    "SearchRung",
+    "UnplannableSearchError",
+    "plan_search",
+]
+
+
+class UnplannableSearchError(RuntimeError):
+    """A policy was asked for a plan it cannot produce."""
+
+
+@dataclass(frozen=True)
+class SearchRung:
+    """One round of training: these candidates, this many epochs each."""
+
+    candidates: tuple[str, ...]
+    epochs: int
+    #: How many of these survive into the next rung. Equal to ``len(candidates)``
+    #: on a final rung, where survival means "is eligible to be selected".
+    survivors: int
+
+    @property
+    def cost(self) -> int:
+        """Epochs this rung spends in total."""
+        return len(self.candidates) * self.epochs
+
+
+@dataclass(frozen=True)
+class SearchPlan:
+    """What a policy decided to spend the iteration's budget on."""
+
+    policy: str
+    rungs: tuple[SearchRung, ...]
+
+    @property
+    def total_epochs(self) -> int:
+        """Every epoch this plan will train, across all rungs."""
+        return sum(rung.cost for rung in self.rungs)
+
+    @property
+    def deployed_epochs(self) -> int:
+        """Epochs the surviving candidate accumulates, if it survives every rung.
+
+        This is the number an equal-deployed-epoch protocol matches, and the
+        one ``exhaustive`` starves.
+        """
+        return sum(rung.epochs for rung in self.rungs)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy": self.policy,
+            "total_epochs": self.total_epochs,
+            "deployed_epochs": self.deployed_epochs,
+            "rungs": [
+                {
+                    "candidates": list(rung.candidates),
+                    "epochs": rung.epochs,
+                    "survivors": rung.survivors,
+                }
+                for rung in self.rungs
+            ],
+        }
+
+
+def _exhaustive(
+    candidates: tuple[str, ...], config: BNNRConfig, diagnosis: Diagnosis | None
+) -> SearchPlan:
+    """Every candidate, ``m_epochs`` each, one rung. Today's behaviour exactly."""
+    del diagnosis
+    return SearchPlan(
+        "exhaustive",
+        (SearchRung(candidates, config.m_epochs, survivors=len(candidates)),),
+    )
+
+
+def _diagnosis_single(
+    candidates: tuple[str, ...], config: BNNRConfig, diagnosis: Diagnosis | None
+) -> SearchPlan:
+    """One candidate, named by the diagnosis, trained for the whole budget.
+
+    The budget is ``m_epochs * len(candidates)``: exactly what ``exhaustive``
+    would have spent on this iteration, now spent on the arm the evidence
+    points at instead of split across arms that get thrown away.
+
+    Refuses rather than guessing when there is no diagnosis, or when the
+    diagnosis recommends nothing among the candidates. Falling back to argmax
+    silently would make a benchmark contrast between the two policies measure a
+    blend of them, which is the same reason the diagnosis selector refuses.
+    """
+    if diagnosis is None:
+        raise UnplannableSearchError(
+            "search_policy='diagnosis_single' needs a diagnosis for the iteration. "
+            "Supply calibrated thresholds so one can be computed; see docs/diagnosis.md."
+        )
+    wanted = _match_recommended(candidates, diagnosis.recommended)
+    if wanted is None:
+        raise UnplannableSearchError(
+            f"The diagnosis recommends {list(diagnosis.recommended)}, which matches none "
+            f"of the candidates {list(candidates)}. Add a candidate of that family, or "
+            f"use search_policy='exhaustive'."
+        )
+    budget = config.m_epochs * max(len(candidates), 1)
+    return SearchPlan("diagnosis_single", (SearchRung((wanted,), budget, survivors=1),))
+
+
+def _successive_halving(
+    candidates: tuple[str, ...], config: BNNRConfig, diagnosis: Diagnosis | None
+) -> SearchPlan:
+    """Halve the field each rung, spending the survivors' budget on them.
+
+    The fallback when the diagnosis is uncertain. Weak branches die after a
+    short rung instead of each taking a flat ``m_epochs``, so the epochs they
+    would have burned go to the arms still in contention.
+
+    Rung epochs are chosen so the plan costs no more than ``exhaustive``: the
+    first rung is short, and what the eliminated candidates would have spent is
+    handed to the survivors. A single candidate degenerates to one full-budget
+    rung, which is the right answer rather than a special case.
+    """
+    del diagnosis
+    n = len(candidates)
+    if n <= 1:
+        return SearchPlan(
+            "successive_halving",
+            (SearchRung(candidates, config.m_epochs * max(n, 1), survivors=n),),
+        )
+
+    budget = config.m_epochs * n
+    n_rungs = max(1, int(math.floor(math.log2(n))) + 1)
+    # Split the budget evenly across rungs, so each rung's survivors get a
+    # comparable slice of training rather than the last rung taking everything.
+    per_rung = max(1, budget // (n_rungs * n))
+
+    rungs: list[SearchRung] = []
+    alive = candidates
+    for index in range(n_rungs):
+        last = index == n_rungs - 1
+        survivors = len(alive) if last else max(1, len(alive) // 2)
+        # Survivors of a shrinking field can afford longer rungs; give the
+        # remaining budget to the final one rather than leaving it unspent.
+        epochs = per_rung if not last else max(1, config.m_epochs - per_rung * index)
+        rungs.append(SearchRung(alive, epochs, survivors=survivors))
+        if last:
+            break
+        alive = alive[:survivors]
+    return SearchPlan("successive_halving", tuple(rungs))
+
+
+#: Longest first, so a family that contains another as a substring is tested
+#: before the shorter one can claim its candidates. Mirrors the selector.
+_FAMILY_ALIASES = ("aicd", "icd", "church_noise")
+
+
+def _match_recommended(
+    candidates: tuple[str, ...], recommended: tuple[str, ...]
+) -> str | None:
+    """First candidate belonging to a recommended family, or ``None``."""
+    for family in recommended:
+        for name in candidates:
+            lowered = name.lower()
+            matched = next((a for a in _FAMILY_ALIASES if a in lowered), None)
+            if (matched == family) if matched else (family in lowered):
+                return name
+    return None
+
+
+SEARCH_POLICIES = {
+    "exhaustive": _exhaustive,
+    "diagnosis_single": _diagnosis_single,
+    "successive_halving": _successive_halving,
+}
+
+#: Policies that cannot run without a diagnosis, and therefore without
+#: calibrated thresholds. The config validator reads this.
+DIAGNOSIS_DRIVEN_POLICIES = frozenset({"diagnosis_single"})
+
+
+def plan_search(
+    candidates: tuple[str, ...],
+    config: BNNRConfig,
+    *,
+    diagnosis: Diagnosis | None = None,
+) -> SearchPlan:
+    """Build the plan for one iteration under the configured policy."""
+    try:
+        builder = SEARCH_POLICIES[config.search_policy]
+    except KeyError:
+        raise ValueError(
+            f"Unknown search_policy {config.search_policy!r}. "
+            f"Available: {sorted(SEARCH_POLICIES)}"
+        ) from None
+    return builder(candidates, config, diagnosis)

--- a/src/bnnr/training/search_policy.py
+++ b/src/bnnr/training/search_policy.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from bnnr.config_model import BNNRConfig
 
 __all__ = [
+    "DIAGNOSIS_DRIVEN_POLICIES",
     "SEARCH_POLICIES",
     "SearchPlan",
     "SearchRung",

--- a/tests/test_search_policy.py
+++ b/tests/test_search_policy.py
@@ -1,0 +1,278 @@
+"""Tests for the search policies (FIX-4-1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bnnr.analysis.diagnosis import AttentionRegime, Diagnosis
+from bnnr.analysis.saliency_stats import SaliencyStats
+from bnnr.config_model import BNNRConfig
+from bnnr.training.search_policy import (
+    SEARCH_POLICIES,
+    UnplannableSearchError,
+    plan_search,
+)
+
+CALIBRATED = {
+    "concentration_lo": 0.30,
+    "concentration_hi": 0.60,
+    "border_mass_hi": 0.35,
+    "perturbation_shift_hi": 0.50,
+    "robustness_gap_hi": 0.15,
+}
+
+CANDIDATES = ("icd", "aicd", "church_noise")
+
+
+def _config(policy: str = "exhaustive", *, m_epochs: int = 6, **kw) -> BNNRConfig:
+    if policy == "diagnosis_single":
+        kw.setdefault("diagnosis", CALIBRATED)
+    return BNNRConfig(search_policy=policy, m_epochs=m_epochs, **kw)
+
+
+def _diagnosis(recommended: tuple[str, ...]) -> Diagnosis:
+    regime = {
+        ("icd",): AttentionRegime.SHORTCUT_SUSPECTED,
+        ("aicd",): AttentionRegime.OBJECT_FOCUSED,
+        ("church_noise",): AttentionRegime.UNSTRUCTURED,
+    }[recommended]
+    return Diagnosis(
+        regime=regime,
+        stats=SaliencyStats(0.5, 0.5, 0.2, (14, 14)),
+        overall_acc=0.9,
+        hard_quantile_acc=0.4,
+        robustness_gap=0.5,
+        recommended=recommended,
+        confidence=1.0,
+        reason="synthetic",
+    )
+
+
+class TestExhaustiveIsUnchanged:
+    def test_one_rung_holding_every_candidate(self) -> None:
+        plan = plan_search(CANDIDATES, _config())
+        assert len(plan.rungs) == 1
+        assert plan.rungs[0].candidates == CANDIDATES
+
+    def test_each_candidate_gets_m_epochs(self) -> None:
+        plan = plan_search(CANDIDATES, _config(m_epochs=6))
+        assert plan.rungs[0].epochs == 6
+
+    def test_the_deployed_share_is_the_defect_it_describes(self) -> None:
+        """Three candidates, 18 epochs spent, 6 reaching the deployed model."""
+        plan = plan_search(CANDIDATES, _config(m_epochs=6))
+        assert plan.total_epochs == 18
+        assert plan.deployed_epochs == 6
+
+    def test_it_needs_no_diagnosis(self) -> None:
+        assert plan_search(CANDIDATES, _config(), diagnosis=None).policy == "exhaustive"
+
+    def test_it_is_the_default(self) -> None:
+        assert BNNRConfig().search_policy == "exhaustive"
+
+
+class TestDiagnosisSingle:
+    def test_the_recommended_candidate_takes_the_whole_budget(self) -> None:
+        plan = plan_search(
+            CANDIDATES, _config("diagnosis_single", m_epochs=6),
+            diagnosis=_diagnosis(("icd",)),
+        )
+        assert plan.rungs[0].candidates == ("icd",)
+        assert plan.rungs[0].epochs == 18
+
+    def test_it_spends_exactly_what_exhaustive_would_have(self) -> None:
+        """Same total, all of it on the arm the evidence points at."""
+        exhaustive = plan_search(CANDIDATES, _config(m_epochs=6))
+        single = plan_search(
+            CANDIDATES, _config("diagnosis_single", m_epochs=6),
+            diagnosis=_diagnosis(("icd",)),
+        )
+        assert single.total_epochs == exhaustive.total_epochs
+        assert single.deployed_epochs == 3 * exhaustive.deployed_epochs
+
+    @pytest.mark.parametrize("family", ["icd", "aicd", "church_noise"])
+    def test_it_follows_the_recommendation(self, family: str) -> None:
+        plan = plan_search(
+            CANDIDATES, _config("diagnosis_single"), diagnosis=_diagnosis((family,))
+        )
+        assert plan.rungs[0].candidates == (family,)
+
+    def test_aicd_is_not_matched_by_the_icd_family(self) -> None:
+        """"icd" in "aicd" is true; the naive ordering would pick the wrong arm."""
+        plan = plan_search(
+            ("aicd_p50", "icd_p90"), _config("diagnosis_single"),
+            diagnosis=_diagnosis(("icd",)),
+        )
+        assert plan.rungs[0].candidates == ("icd_p90",)
+
+    def test_no_diagnosis_refuses_rather_than_guessing(self) -> None:
+        """A silent fallback to argmax would make a benchmark contrast between
+        the policies measure a blend of them."""
+        with pytest.raises(UnplannableSearchError, match="needs a diagnosis"):
+            plan_search(CANDIDATES, _config("diagnosis_single"), diagnosis=None)
+
+    def test_an_unmatchable_recommendation_refuses(self) -> None:
+        with pytest.raises(UnplannableSearchError, match="matches none"):
+            plan_search(
+                ("church_noise",), _config("diagnosis_single"),
+                diagnosis=_diagnosis(("icd",)),
+            )
+
+    def test_the_error_names_a_way_out(self) -> None:
+        with pytest.raises(UnplannableSearchError, match="exhaustive"):
+            plan_search(
+                ("church_noise",), _config("diagnosis_single"),
+                diagnosis=_diagnosis(("aicd",)),
+            )
+
+    def test_it_is_refused_without_calibrated_thresholds(self) -> None:
+        """The same gate that guards the diagnosis selector."""
+        with pytest.raises(ValueError, match="calibrated diagnosis thresholds"):
+            BNNRConfig(search_policy="diagnosis_single")
+
+    def test_the_error_names_the_policy_not_the_selector(self) -> None:
+        with pytest.raises(ValueError, match="search_policy='diagnosis_single'"):
+            BNNRConfig(search_policy="diagnosis_single")
+
+
+class TestSuccessiveHalving:
+    def test_the_field_shrinks_each_rung(self) -> None:
+        plan = plan_search(
+            tuple(f"aug_{i}" for i in range(8)), _config("successive_halving")
+        )
+        sizes = [len(r.candidates) for r in plan.rungs]
+        assert sizes == sorted(sizes, reverse=True)
+        assert sizes[0] == 8
+        assert sizes[-1] < sizes[0]
+
+    def test_it_does_not_cost_more_than_exhaustive(self) -> None:
+        """Weak branches dying is what pays for the survivors' extra epochs."""
+        candidates = tuple(f"aug_{i}" for i in range(8))
+        halving = plan_search(candidates, _config("successive_halving", m_epochs=8))
+        exhaustive = plan_search(candidates, _config(m_epochs=8))
+        assert halving.total_epochs <= exhaustive.total_epochs
+
+    def test_a_survivor_trains_across_every_rung(self) -> None:
+        plan = plan_search(
+            tuple(f"aug_{i}" for i in range(8)), _config("successive_halving")
+        )
+        assert plan.deployed_epochs == sum(r.epochs for r in plan.rungs)
+        assert len(plan.rungs) > 1
+
+    def test_a_single_candidate_degenerates_to_one_full_rung(self) -> None:
+        plan = plan_search(("only",), _config("successive_halving", m_epochs=5))
+        assert len(plan.rungs) == 1
+        assert plan.rungs[0].epochs == 5
+
+    def test_no_candidates_does_not_crash(self) -> None:
+        plan = plan_search((), _config("successive_halving"))
+        assert plan.rungs[0].candidates == ()
+
+    def test_every_rung_trains_at_least_one_epoch(self) -> None:
+        plan = plan_search(
+            tuple(f"aug_{i}" for i in range(16)), _config("successive_halving", m_epochs=2)
+        )
+        assert all(r.epochs >= 1 for r in plan.rungs)
+
+    def test_it_needs_no_diagnosis(self) -> None:
+        """It is the fallback for when the diagnosis is uncertain."""
+        assert plan_search(CANDIDATES, _config("successive_halving")).policy == (
+            "successive_halving"
+        )
+
+
+class TestRegistryAndRecord:
+    def test_all_three_policies_are_registered(self) -> None:
+        assert set(SEARCH_POLICIES) == {
+            "exhaustive", "diagnosis_single", "successive_halving",
+        }
+
+    def test_an_unknown_policy_is_refused_by_config(self) -> None:
+        with pytest.raises(ValueError, match="search_policy must be one of"):
+            BNNRConfig(search_policy="vibes")
+
+    def test_the_plan_is_json_ready(self) -> None:
+        import json
+
+        plan = plan_search(CANDIDATES, _config())
+        payload = json.loads(json.dumps(plan.to_dict()))
+        assert payload["policy"] == "exhaustive"
+        assert payload["rungs"][0]["candidates"] == list(CANDIDATES)
+
+    def test_the_plan_records_both_epoch_numbers(self) -> None:
+        plan = plan_search(CANDIDATES, _config(m_epochs=6))
+        record = plan.to_dict()
+        assert record["total_epochs"] == 18
+        assert record["deployed_epochs"] == 6
+
+    def test_rung_cost_is_candidates_times_epochs(self) -> None:
+        rung = plan_search(CANDIDATES, _config(m_epochs=4)).rungs[0]
+        assert rung.cost == 12
+
+
+class TestRealRunUnderEachPolicy:
+    """All three run end to end, and the accounting reaches the record."""
+
+    def _run(self, tmp_path, tag: str, **config_kwargs):
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, TensorDataset
+
+        from bnnr.adapter import SimpleTorchAdapter
+        from bnnr.augmentations import BasicAugmentation, ChurchNoise
+        from bnnr.reporting import Reporter
+        from bnnr.trainer import BNNRTrainer
+
+        torch.manual_seed(0)
+        model = nn.Sequential(
+            nn.Conv2d(3, 4, 3, padding=1), nn.ReLU(),
+            nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(4, 2),
+        )
+        adapter = SimpleTorchAdapter(
+            model=model,
+            criterion=nn.CrossEntropyLoss(),
+            optimizer=torch.optim.SGD(model.parameters(), lr=0.01),
+            device="cpu",
+        )
+        images = torch.rand(8, 3, 8, 8)
+        labels = torch.randint(0, 2, (8,))
+        loader = DataLoader(TensorDataset(images, labels), batch_size=4)
+        config = BNNRConfig(
+            m_epochs=2,
+            max_iterations=1,
+            report_dir=tmp_path / tag,
+            verbose=False,
+            save_checkpoints=False,
+            xai_enabled=False,
+            **config_kwargs,
+        )
+        trainer = BNNRTrainer(
+            model=adapter,
+            train_loader=loader,
+            val_loader=loader,
+            augmentations=[
+                BasicAugmentation(probability=1.0, random_state=0),
+                ChurchNoise(probability=1.0, random_state=0),
+            ],
+            config=config,
+            reporter=Reporter(tmp_path / tag, save_html=False),
+        )
+        return trainer.run()
+
+    def test_exhaustive_runs_and_records_its_policy(self, tmp_path) -> None:
+        record = self._run(tmp_path, "ex").run_record
+        assert record.search_policy == "exhaustive"
+        assert record.search_plan is not None
+        assert record.search_plan["policy"] == "exhaustive"
+
+    def test_successive_halving_runs(self, tmp_path) -> None:
+        record = self._run(tmp_path, "sh", search_policy="successive_halving").run_record
+        assert record.search_policy == "successive_halving"
+        assert record.search_plan["policy"] == "successive_halving"
+
+    def test_the_recorded_epochs_are_counted_not_planned(self, tmp_path) -> None:
+        """The ledger counts what ran; the plan says what was intended. Pruning
+        can make them differ, and the record must carry the measurement."""
+        record = self._run(tmp_path, "count").run_record
+        assert record.total_gpu_epochs > 0
+        assert record.deployed_epochs <= record.total_gpu_epochs


### PR DESCRIPTION
## Summary

The headline recommendation of the findings: one design change closes **both** defects the benchmarks identified.

| policy | what it does |
|---|---|
| `exhaustive` (default) | every candidate trains `m_epochs`, then the selector arbitrates |
| `diagnosis_single` | the diagnosis names one candidate and it trains the whole budget |
| `successive_halving` | the field halves each rung; weak branches die early |

**The selection criterion.** `exhaustive` arbitrates on selection-validation accuracy, which T20 found close to orthogonal to the objective. `diagnosis_single` does not arbitrate at all.

**The epoch split.** Three candidates at `m_epochs: 6` — the run spends 18 epochs and the deployed model receives **6**, while a single-augmentation baseline on the same budget receives all 18. `diagnosis_single` spends the same 18 on one arm. There is a test asserting exactly this arithmetic, because it is the finding.

## Defaults do not move

`exhaustive` produces exactly one rung holding every candidate at `m_epochs` — the plan the loop used to hard-code. **The full suite passes unchanged on it** (1597 before the new tests, same as on main).

## The loop is now a rung loop

A policy produces a `SearchPlan` of rungs; the loop executes rungs and does not decide what they contain. That separation is what makes a policy swappable, recordable, and benchmarkable against another.

Three details that matter for correctness:

- **Later rungs continue a candidate from its own state**, not from the iteration baseline. Successive halving is about giving survivors *more* training, not repeating the first rung.
- **`candidate_best_epochs` accumulates across rungs**, so a survivor's deployed epochs are what it actually received.
- **Survivors are intersected with the next rung**, not taken from it. The plan is built before any metric exists, so it cannot know who will still be alive.

## `diagnosis_single` refuses twice, and never falls back

- At **config construction** without calibrated thresholds, reusing the gate that guards `selector: diagnosis`. The error names the policy rather than the selector.
- At **plan time** when no diagnosis was computed, or when its recommendation matches no candidate — with an error that names the way out.

It does **not** fall back to argmax. A silent fallback would make a benchmark contrast between the policies measure a blend of them, which is the same reasoning as in #403's selector.

`aicd` is matched before `icd` here too, since `"icd" in "aicd"` is true.

## Recording

The plan goes into the run record as `search_plan`, and `search_policy` now reads the config rather than the hard-coded `"exhaustive"` #410 shipped as a deliberate placeholder — which is exactly why that field was added before the feature existed.

**The record's epoch counts stay measurements, not intentions.** `total_gpu_epochs` and `deployed_epochs` still come from the ledger, because pruning can stop a rung early and the counted number is the one that matters. There is a test for that distinction.

## Test plan

- `pytest -q` -> **1628 passed, 19 skipped** (31 new).
- `ruff check src tests` clean; `mypy` clean on all touched modules.
- Coverage: exhaustive's shape, budget and the 18/6 split; `diagnosis_single` taking the whole budget, spending exactly what exhaustive would, following each of the three families, the aicd/icd ordering, and both refusals plus the config gate; successive halving shrinking the field, not costing more than exhaustive, a survivor training across every rung, single-candidate and empty degeneracies, and every rung training at least one epoch; the registry; JSON readiness; and three end-to-end runs asserting the policy and plan reach the record.

## Docs

`docs/configuration.md` gains a `Search policy` section with the epoch arithmetic spelled out; `docs/artifacts.md` documents `search_plan` and the updated `search_policy`.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #413
