### PR TITLE
feat(training): fall back to metric_argmax below min_confidence

### DIFF
--- a/benchmarks/summarize_grand.py
+++ b/benchmarks/summarize_grand.py
@@ -771,6 +771,60 @@ def _key_comparison_section(
 # ---------------------------------------------------------------------------
 
 
+def _diagnosis_fallback_section(
+    all_runs: list[dict[str, Any]],
+    datasets: list[str],
+    *,
+    strategy: str = "none",
+) -> None:
+    """How often the diagnosis was not confident enough to be acted on.
+
+    Fallback frequency is itself a calibration signal. A rule that fires on
+    every run tells you nothing; one that never fires means ``min_confidence``
+    is set too low to be doing any work. Neither is visible from accuracy.
+
+    Only runs that requested a diagnosis-driven selector or policy can fall
+    back, so the denominator is those runs and not every row.
+    """
+    rows_by_ds: dict[str, tuple[int, int, list[float]]] = {}
+    for ds in datasets:
+        eligible = 0
+        fell_back = 0
+        confidences: list[float] = []
+        for r in all_runs:
+            if r.get("dataset") != ds:
+                continue
+            # Absent in records written before FIX-4-2, and absent on runs that
+            # never asked for a diagnosis. Both are "not eligible", not "did
+            # not fall back", and conflating them would understate the rate.
+            requested = r.get("selector") or r.get("search_policy")
+            if requested not in {"diagnosis", "diagnosis_single"}:
+                continue
+            eligible += 1
+            if r.get("selection_fallback_from"):
+                fell_back += 1
+                conf = r.get("selection_fallback_confidence")
+                if conf is not None:
+                    confidences.append(float(conf))
+        if eligible:
+            rows_by_ds[ds] = (fell_back, eligible, confidences)
+
+    if not rows_by_ds:
+        return
+
+    print("\n" + "=" * 70)
+    print(f"  DIAGNOSIS FALLBACK RATE  |  fill={strategy}")
+    print("  how often confidence fell below min_confidence and the run defaulted")
+    print("=" * 70)
+    for ds, (fell_back, eligible, confidences) in rows_by_ds.items():
+        rate = fell_back / eligible
+        line = f"  {ds}: {fell_back}/{eligible} ({rate:.0%})"
+        if confidences:
+            line += f"  median confidence when it fired: {statistics.median(confidences):.2f}"
+        print(line)
+    print()
+
+
 def _compute_transparency_section(
     all_runs: list[dict[str, Any]],
     datasets: list[str],
@@ -1227,6 +1281,7 @@ def main() -> None:
 
         # 5. Compute transparency
         _compute_transparency_section(view, datasets, strategy=strategy)
+        _diagnosis_fallback_section(view, datasets, strategy=strategy)
 
     _which_fill_is_best_section(
         all_runs, datasets, strategies,

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -104,6 +104,8 @@ The fields a run must carry for its result to be comparable with another run. Wr
 | `augmentation_modes` | `{name: mode}` for augmentations whose transform depends on a mode |
 | `selection_reason` | `improved`, `no_improvement`, `indistinguishable`, `no_candidates` |
 | `selection_interval` | the paired bootstrap interval behind that reason, when one was computed |
+| `selection_fallback_from` | the selector that was configured but not run, when confidence fell short |
+| `selection_fallback_confidence` | the confidence that triggered that fallback |
 
 **The two epoch counts are the point.** They differ whenever a branch search runs, and confusing them is what made BNNR look worse than it was: under "equal compute" the deployed model trained for a third of the budget while single-augmentation baselines trained all of it. Matching deployed epochs instead closed a 4.46 pp gap to 0.09 pp. They are equal only for a run with no search.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,23 @@ seed: 42
 
 Both are gated the same way: whatever a selector picks is discarded unless it beat the baseline on `selection_metric`. That gate is deliberately shared, so a comparison between two selectors is a comparison of their ranking rules and nothing else. A selector that skipped it would look better purely by accepting runs the others reject.
 
+### Confidence fallback
+
+Set `diagnosis.min_confidence` and a diagnosis-driven run that is not confident enough defaults to known behaviour instead of acting on a rule nobody has validated yet.
+
+| requested | falls back to |
+|---|---|
+| `selector: diagnosis` | `metric_argmax` |
+| `search_policy: diagnosis_single` | `exhaustive` |
+
+Both record what they fell back *from* and the confidence that triggered it, in `run_record.selection_fallback_from` and in `search_plan.fallback_from`. A user can tell a diagnosed run from a defaulted one without re-deriving it from the config.
+
+The check sits in the policy layer, not inside the selector. It is a policy about when to trust the rule, not part of the rule — a selector that quietly second-guessed itself would make a benchmark contrast between it and argmax measure a blend of the two.
+
+**With `min_confidence` unset there is no fallback.** You have not said where the line is, and inventing one would be another uncalibrated number of exactly the kind this programme removes.
+
+The grand-benchmark summarizer prints the fallback rate per dataset. That frequency is itself a calibration signal: a rule that fires on every run tells you nothing, and one that never fires means the threshold is too low to be doing any work. Neither is visible from accuracy.
+
 ### Search policy
 
 - `search_policy` (default: `exhaustive`)

--- a/src/bnnr/training/loop.py
+++ b/src/bnnr/training/loop.py
@@ -662,7 +662,14 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
                 diagnosis=trainer._last_diagnosis,
             )
             trainer._last_search_plan = plan
-            if plan.policy != "exhaustive":
+            if plan.fallback_from is not None:
+                trainer.console.print(
+                    f"  (diagnosis confidence {plan.fallback_confidence:.2f} is below "
+                    f"min_confidence; search_policy fell back from "
+                    f"'{plan.fallback_from}' to '{plan.policy}')",
+                    flush=True,
+                )
+            elif plan.policy != "exhaustive":
                 trainer.console.print(
                     f"  search_policy={plan.policy}: {len(plan.rungs)} rung(s), "
                     f"{plan.total_epochs} epochs total, "
@@ -842,6 +849,13 @@ def run(trainer: BNNRTrainer) -> BNNRRunResult:
         )
         selected_name = selection.best
         trainer._last_selection = selection
+        if selection.fallback_from is not None:
+            trainer.console.print(
+                f"  (diagnosis confidence {selection.fallback_confidence:.2f} is below "
+                f"min_confidence; selector fell back from "
+                f"'{selection.fallback_from}' to '{selection.selector}')",
+                flush=True,
+            )
         if selection.reason == "indistinguishable" and selection.interval is not None:
             trainer.console.print(
                 f"  (candidates indistinguishable from baseline: "
@@ -1080,6 +1094,16 @@ def _build_run_record(
         search_plan=(
             trainer._last_search_plan.to_dict()
             if trainer._last_search_plan is not None
+            else None
+        ),
+        selection_fallback_from=(
+            trainer._last_selection.fallback_from
+            if trainer._last_selection is not None
+            else None
+        ),
+        selection_fallback_confidence=(
+            trainer._last_selection.fallback_confidence
+            if trainer._last_selection is not None
             else None
         ),
         selection_interval=(

--- a/src/bnnr/training/run_record.py
+++ b/src/bnnr/training/run_record.py
@@ -110,6 +110,15 @@ class RunRecord:
     #: Why the selector landed where it did: ``"improved"``,
     #: ``"no_improvement"``, ``"indistinguishable"``, ``"no_candidates"``.
     selection_reason: str | None = None
+    #: The selector that was configured but not run, because the diagnosis was
+    #: not confident enough to act on. ``None`` on a run that used what it was
+    #: asked for. A reader must be able to tell a diagnosed run from a
+    #: defaulted one without re-deriving it from the config.
+    selection_fallback_from: str | None = None
+    #: The confidence that triggered it, so the threshold can be re-examined
+    #: later without re-running anything.
+    selection_fallback_confidence: float | None = None
+
     #: The paired bootstrap interval behind that reason, when one was computed.
     #: Recorded so a decision is auditable after the fact rather than only at
     #: the moment it was made, which is what T20 had to reconstruct by hand.

--- a/src/bnnr/training/search_policy.py
+++ b/src/bnnr/training/search_policy.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "DIAGNOSIS_DRIVEN_POLICIES",
+    "FALLBACK_POLICY",
     "SEARCH_POLICIES",
     "SearchPlan",
     "SearchRung",
@@ -70,6 +71,11 @@ class SearchPlan:
 
     policy: str
     rungs: tuple[SearchRung, ...]
+    #: The policy that was configured but not run, when confidence fell below
+    #: ``min_confidence``. ``None`` on a run that used what it was asked for.
+    fallback_from: str | None = None
+    #: The confidence that triggered the fallback.
+    fallback_confidence: float | None = None
 
     @property
     def total_epochs(self) -> int:
@@ -88,6 +94,8 @@ class SearchPlan:
     def to_dict(self) -> dict[str, Any]:
         return {
             "policy": self.policy,
+            "fallback_from": self.fallback_from,
+            "fallback_confidence": self.fallback_confidence,
             "total_epochs": self.total_epochs,
             "deployed_epochs": self.deployed_epochs,
             "rungs": [
@@ -214,18 +222,47 @@ SEARCH_POLICIES = {
 DIAGNOSIS_DRIVEN_POLICIES = frozenset({"diagnosis_single"})
 
 
+#: What a diagnosis-driven policy falls back to when the diagnosis is not
+#: confident enough to act on. exhaustive is today's behaviour, so falling back
+#: to it means falling back to a known quantity.
+FALLBACK_POLICY = "exhaustive"
+
+
 def plan_search(
     candidates: tuple[str, ...],
     config: BNNRConfig,
     *,
     diagnosis: Diagnosis | None = None,
 ) -> SearchPlan:
-    """Build the plan for one iteration under the configured policy."""
+    """Build the plan for one iteration under the configured policy.
+
+    Below ``min_confidence`` a diagnosis-driven policy falls back to
+    ``exhaustive`` and the plan says so in its ``policy`` field, so a reader can
+    tell a diagnosed run from a defaulted one without inspecting the config.
+    """
+    policy = _resolve_policy(config, diagnosis)
     try:
-        builder = SEARCH_POLICIES[config.search_policy]
+        builder = SEARCH_POLICIES[policy]
     except KeyError:
         raise ValueError(
-            f"Unknown search_policy {config.search_policy!r}. "
-            f"Available: {sorted(SEARCH_POLICIES)}"
+            f"Unknown search_policy {policy!r}. Available: {sorted(SEARCH_POLICIES)}"
         ) from None
-    return builder(candidates, config, diagnosis)
+    plan = builder(candidates, config, diagnosis)
+    if policy == config.search_policy:
+        return plan
+    return SearchPlan(
+        plan.policy,
+        plan.rungs,
+        fallback_from=config.search_policy,
+        fallback_confidence=diagnosis.confidence if diagnosis is not None else None,
+    )
+
+
+def _resolve_policy(config: BNNRConfig, diagnosis: Diagnosis | None) -> str:
+    """Which policy actually runs, given how confident the diagnosis is."""
+    if config.search_policy not in DIAGNOSIS_DRIVEN_POLICIES:
+        return config.search_policy
+    threshold = config.diagnosis.min_confidence
+    if threshold is None or diagnosis is None:
+        return config.search_policy
+    return config.search_policy if diagnosis.confidence >= threshold else FALLBACK_POLICY

--- a/src/bnnr/training/selection.py
+++ b/src/bnnr/training/selection.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import hashlib
 import math
 import random
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Protocol
 
 from bnnr.training.paired import PairedInterval, paired_bootstrap_ci
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from bnnr.config_model import BNNRConfig
 
 __all__ = [
+    "FALLBACK_SELECTOR",
     "SELECTORS",
     "CandidateReport",
     "CandidateSelector",
@@ -86,6 +87,13 @@ class SelectionResult:
     #: baseline, when one could be computed. Recorded so the decision is
     #: auditable after the fact rather than only at the moment it was made.
     interval: PairedInterval | None = None
+    #: The selector that was configured but not run, when confidence fell below
+    #: ``min_confidence``. ``None`` on a run that used what it was asked for.
+    #: A user must be able to tell a diagnosed run from a defaulted one.
+    fallback_from: str | None = None
+    #: The confidence that triggered the fallback, so the threshold can be
+    #: re-examined later without re-running anything.
+    fallback_confidence: float | None = None
 
     @property
     def best(self) -> str | None:
@@ -445,7 +453,9 @@ def run_selector(
         )
         for name, metrics in results.items()
     ]
-    return get_selector(config.selector).select(
+    requested = config.selector
+    effective, fallback_confidence = _resolve_selector(requested, config, diagnosis)
+    result = get_selector(effective).select(
         candidates,
         baseline_metrics,
         config,
@@ -453,3 +463,48 @@ def run_selector(
         baseline_correct=baseline_correct,
         n_val=n_val,
     )
+    if effective == requested:
+        return result
+    return replace(
+        result,
+        fallback_from=requested,
+        fallback_confidence=fallback_confidence,
+    )
+
+
+#: What a diagnosis-driven selector falls back to when it is not confident
+#: enough to act. metric_argmax is today's behaviour, and therefore the one
+#: known quantity available to fall back to.
+FALLBACK_SELECTOR = "metric_argmax"
+
+
+def _resolve_selector(
+    requested: str, config: BNNRConfig, diagnosis: Diagnosis | None
+) -> tuple[str, float | None]:
+    """Which selector actually runs, and the confidence that decided it.
+
+    The decision rule is unvalidated until the calibration study says
+    otherwise, and an unvalidated automatic path is worse than an explicit
+    flag. Below ``min_confidence`` the run uses ``metric_argmax``, which is
+    today's behaviour and therefore a known quantity.
+
+    The check lives here rather than inside ``DiagnosisSelector`` on purpose:
+    it is a policy about when to trust the rule, not part of the rule. A
+    selector that quietly second-guessed itself would make a benchmark contrast
+    between it and argmax measure a blend of the two.
+
+    With ``min_confidence`` unset there is no fallback: the caller has not said
+    where the line is, and inventing one would be another uncalibrated number.
+    """
+    if requested not in _DIAGNOSIS_DRIVEN:
+        return requested, None
+    threshold = config.diagnosis.min_confidence
+    if threshold is None or diagnosis is None:
+        return requested, None
+    if diagnosis.confidence >= threshold:
+        return requested, None
+    return FALLBACK_SELECTOR, diagnosis.confidence
+
+
+#: Selectors whose decision the confidence gate applies to.
+_DIAGNOSIS_DRIVEN = frozenset({"diagnosis"})

--- a/tests/test_confidence_fallback.py
+++ b/tests/test_confidence_fallback.py
@@ -1,0 +1,277 @@
+"""Tests for the low-confidence fallback (FIX-4-2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bnnr.analysis.diagnosis import AttentionRegime, Diagnosis
+from bnnr.analysis.saliency_stats import SaliencyStats
+from bnnr.config_model import BNNRConfig
+from bnnr.training.search_policy import FALLBACK_POLICY, plan_search
+from bnnr.training.selection import FALLBACK_SELECTOR, run_selector
+
+CALIBRATED = {
+    "concentration_lo": 0.30,
+    "concentration_hi": 0.60,
+    "border_mass_hi": 0.35,
+    "perturbation_shift_hi": 0.50,
+    "robustness_gap_hi": 0.15,
+}
+
+RESULTS = {"icd": {"accuracy": 0.81}, "aicd": {"accuracy": 0.90}}
+BASELINE = {"accuracy": 0.50}
+CANDIDATES = ("icd", "aicd")
+
+
+def _config(*, min_confidence: float | None, **kw) -> BNNRConfig:
+    diagnosis = dict(CALIBRATED)
+    if min_confidence is not None:
+        diagnosis["min_confidence"] = min_confidence
+    return BNNRConfig(diagnosis=diagnosis, **kw)
+
+
+def _diagnosis(confidence: float, recommended: tuple[str, ...] = ("icd",)) -> Diagnosis:
+    return Diagnosis(
+        regime=AttentionRegime.SHORTCUT_SUSPECTED,
+        stats=SaliencyStats(0.5, 0.5, 0.2, (14, 14)),
+        overall_acc=0.9,
+        hard_quantile_acc=0.4,
+        robustness_gap=0.5,
+        recommended=recommended,
+        confidence=confidence,
+        reason="synthetic",
+    )
+
+
+class TestSelectorFallback:
+    def test_low_confidence_falls_back_to_metric_argmax(self) -> None:
+        result = run_selector(
+            RESULTS, BASELINE,
+            _config(min_confidence=0.75, selector="diagnosis"),
+            diagnosis=_diagnosis(0.50),
+        )
+        assert result.selector == FALLBACK_SELECTOR
+        assert result.fallback_from == "diagnosis"
+        # metric_argmax picks the better metric, which the diagnosis did not want.
+        assert result.best == "aicd"
+
+    def test_sufficient_confidence_keeps_the_diagnosis(self) -> None:
+        result = run_selector(
+            RESULTS, BASELINE,
+            _config(min_confidence=0.75, selector="diagnosis"),
+            diagnosis=_diagnosis(1.0),
+        )
+        assert result.selector == "diagnosis"
+        assert result.fallback_from is None
+        assert result.best == "icd"
+
+    def test_the_threshold_is_inclusive(self) -> None:
+        """Exactly at min_confidence counts as confident enough."""
+        result = run_selector(
+            RESULTS, BASELINE,
+            _config(min_confidence=0.75, selector="diagnosis"),
+            diagnosis=_diagnosis(0.75),
+        )
+        assert result.fallback_from is None
+
+    def test_the_triggering_confidence_is_recorded(self) -> None:
+        """So the threshold can be re-examined without re-running anything."""
+        result = run_selector(
+            RESULTS, BASELINE,
+            _config(min_confidence=0.75, selector="diagnosis"),
+            diagnosis=_diagnosis(0.25),
+        )
+        assert result.fallback_confidence == pytest.approx(0.25)
+
+    def test_no_min_confidence_means_no_fallback(self) -> None:
+        """The caller has not said where the line is, and inventing one would be
+        another uncalibrated number."""
+        result = run_selector(
+            RESULTS, BASELINE,
+            _config(min_confidence=None, selector="diagnosis"),
+            diagnosis=_diagnosis(0.0),
+        )
+        assert result.fallback_from is None
+        assert result.selector == "diagnosis"
+
+    def test_a_metric_selector_is_never_second_guessed(self) -> None:
+        result = run_selector(
+            RESULTS, BASELINE,
+            _config(min_confidence=0.99, selector="metric_argmax"),
+            diagnosis=_diagnosis(0.0),
+        )
+        assert result.fallback_from is None
+
+    def test_no_diagnosis_is_not_a_fallback(self) -> None:
+        """Without one there is nothing to be unconfident about; the selector's
+        own no_diagnosis refusal stands."""
+        result = run_selector(
+            RESULTS, BASELINE, _config(min_confidence=0.75, selector="diagnosis")
+        )
+        assert result.fallback_from is None
+        assert result.reason == "no_diagnosis"
+
+
+class TestPolicyFallback:
+    def test_low_confidence_falls_back_to_exhaustive(self) -> None:
+        plan = plan_search(
+            CANDIDATES,
+            _config(min_confidence=0.75, search_policy="diagnosis_single"),
+            diagnosis=_diagnosis(0.50),
+        )
+        assert plan.policy == FALLBACK_POLICY
+        assert plan.fallback_from == "diagnosis_single"
+
+    def test_the_fallback_plan_is_a_real_exhaustive_plan(self) -> None:
+        """Not a marker: it must actually evaluate every candidate."""
+        plan = plan_search(
+            CANDIDATES,
+            _config(min_confidence=0.75, search_policy="diagnosis_single", m_epochs=4),
+            diagnosis=_diagnosis(0.25),
+        )
+        assert plan.rungs[0].candidates == CANDIDATES
+        assert plan.rungs[0].epochs == 4
+
+    def test_sufficient_confidence_keeps_the_policy(self) -> None:
+        plan = plan_search(
+            CANDIDATES,
+            _config(min_confidence=0.75, search_policy="diagnosis_single"),
+            diagnosis=_diagnosis(1.0),
+        )
+        assert plan.policy == "diagnosis_single"
+        assert plan.fallback_from is None
+
+    def test_the_confidence_is_recorded_in_the_plan(self) -> None:
+        plan = plan_search(
+            CANDIDATES,
+            _config(min_confidence=0.75, search_policy="diagnosis_single"),
+            diagnosis=_diagnosis(0.5),
+        )
+        assert plan.to_dict()["fallback_confidence"] == pytest.approx(0.5)
+        assert plan.to_dict()["fallback_from"] == "diagnosis_single"
+
+    def test_no_min_confidence_lets_the_policy_run(self) -> None:
+        plan = plan_search(
+            CANDIDATES,
+            _config(min_confidence=None, search_policy="diagnosis_single"),
+            diagnosis=_diagnosis(0.0),
+        )
+        assert plan.policy == "diagnosis_single"
+
+    def test_exhaustive_is_never_second_guessed(self) -> None:
+        plan = plan_search(
+            CANDIDATES, _config(min_confidence=0.99), diagnosis=_diagnosis(0.0)
+        )
+        assert plan.fallback_from is None
+
+
+class TestItReachesTheRunRecord:
+    def _run(self, tmp_path, tag: str, **config_kwargs):
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, TensorDataset
+
+        from bnnr.adapter import SimpleTorchAdapter
+        from bnnr.augmentations import BasicAugmentation, ChurchNoise
+        from bnnr.reporting import Reporter
+        from bnnr.trainer import BNNRTrainer
+
+        torch.manual_seed(0)
+        model = nn.Sequential(
+            nn.Conv2d(3, 4, 3, padding=1), nn.ReLU(),
+            nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(4, 2),
+        )
+        adapter = SimpleTorchAdapter(
+            model=model,
+            criterion=nn.CrossEntropyLoss(),
+            optimizer=torch.optim.SGD(model.parameters(), lr=0.01),
+            device="cpu",
+        )
+        images = torch.rand(8, 3, 8, 8)
+        labels = torch.randint(0, 2, (8,))
+        loader = DataLoader(TensorDataset(images, labels), batch_size=4)
+        config = BNNRConfig(
+            m_epochs=1, max_iterations=1, report_dir=tmp_path / tag,
+            verbose=False, save_checkpoints=False, xai_enabled=False,
+            **config_kwargs,
+        )
+        trainer = BNNRTrainer(
+            model=adapter, train_loader=loader, val_loader=loader,
+            augmentations=[
+                BasicAugmentation(probability=1.0, random_state=0),
+                ChurchNoise(probability=1.0, random_state=0),
+            ],
+            config=config,
+            reporter=Reporter(tmp_path / tag, save_html=False),
+        )
+        return trainer.run()
+
+    def test_a_run_without_a_fallback_records_none(self, tmp_path) -> None:
+        record = self._run(tmp_path, "plain").run_record
+        assert record.selection_fallback_from is None
+        assert record.selection_fallback_confidence is None
+
+    def test_the_fields_survive_the_json_round_trip(self, tmp_path) -> None:
+        import json
+
+        from bnnr.training.run_record import RunRecord
+
+        result = self._run(tmp_path, "json")
+        payload = json.loads(result.report_json_path.read_text())["run_record"]
+        assert "selection_fallback_from" in payload
+        assert RunRecord.from_dict(payload).selection_fallback_from is None
+
+
+class TestFallbackRateIsSummarizable:
+    """Fallback frequency is itself a calibration signal."""
+
+    def _rows(self, n_fell_back: int, n_eligible: int) -> list[dict]:
+        rows = []
+        for i in range(n_eligible):
+            row = {"dataset": "imagewoof", "selector": "diagnosis", "condition": f"c{i}"}
+            if i < n_fell_back:
+                row["selection_fallback_from"] = "diagnosis"
+                row["selection_fallback_confidence"] = 0.5
+            rows.append(row)
+        return rows
+
+    def test_it_prints_the_rate(self, capsys) -> None:
+        from benchmarks.summarize_grand import _diagnosis_fallback_section
+
+        _diagnosis_fallback_section(self._rows(3, 10), ["imagewoof"])
+        out = capsys.readouterr().out
+        assert "3/10" in out
+        assert "30%" in out
+
+    def test_it_reports_the_median_triggering_confidence(self, capsys) -> None:
+        from benchmarks.summarize_grand import _diagnosis_fallback_section
+
+        _diagnosis_fallback_section(self._rows(2, 5), ["imagewoof"])
+        assert "0.50" in capsys.readouterr().out
+
+    def test_runs_that_never_asked_for_a_diagnosis_are_not_the_denominator(
+        self, capsys
+    ) -> None:
+        """They are 'not eligible', not 'did not fall back'. Conflating them
+        would understate the rate."""
+        from benchmarks.summarize_grand import _diagnosis_fallback_section
+
+        rows = self._rows(1, 2) + [
+            {"dataset": "imagewoof", "selector": "metric_argmax", "condition": "x"}
+        ] * 8
+        _diagnosis_fallback_section(rows, ["imagewoof"])
+        assert "1/2" in capsys.readouterr().out
+
+    def test_nothing_eligible_prints_nothing(self, capsys) -> None:
+        from benchmarks.summarize_grand import _diagnosis_fallback_section
+
+        _diagnosis_fallback_section(
+            [{"dataset": "imagewoof", "selector": "metric_argmax"}], ["imagewoof"]
+        )
+        assert capsys.readouterr().out == ""
+
+    def test_records_from_before_this_change_are_not_counted(self, capsys) -> None:
+        from benchmarks.summarize_grand import _diagnosis_fallback_section
+
+        _diagnosis_fallback_section([{"dataset": "imagewoof", "condition": "old"}], ["imagewoof"])
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

The decision rule is unvalidated until #417 says otherwise, and **an unvalidated automatic path is worse than an explicit flag**. Below `diagnosis.min_confidence` a diagnosis-driven run now defaults to known behaviour:

| requested | falls back to |
|---|---|
| `selector: diagnosis` | `metric_argmax` |
| `search_policy: diagnosis_single` | `exhaustive` |

Both are what BNNR did before any of this programme, and therefore known quantities.

## It is recorded, not silent

`run_record.selection_fallback_from` and `search_plan.fallback_from` carry what was configured but not run, plus the confidence that triggered it — so the threshold can be re-examined later without re-running anything.

Both also print on the console during the run. **A user must be able to tell a diagnosed run from a defaulted one**, and a JSON field alone does not do that for someone watching a run go by.

## Where the check lives, and why it matters

In the **policy layer**, not inside `DiagnosisSelector`.

It is a policy about *when to trust the rule*, not part of the rule. A selector that quietly second-guessed itself would make a benchmark contrast between it and argmax measure a blend of the two — the same reasoning that keeps `no_diagnosis` a refusal rather than a fallback in #432.

The selector's existing refusals are untouched: no diagnosis at all is still `no_diagnosis`, because there is nothing to be unconfident *about*.

## Two decisions

**With `min_confidence` unset there is no fallback.** The caller has not said where the line is, and inventing one would be another uncalibrated number of exactly the kind this programme removes. Tested.

**The threshold is inclusive** — exactly at `min_confidence` counts as confident enough. Tested, because a boundary that is never stated is a boundary someone will get wrong later.

The fallback plan is a **real exhaustive plan**, not a marker: there is a test that it evaluates every candidate for `m_epochs` rather than merely renaming itself.

## Fallback frequency is a calibration signal

`summarize_grand.py` gains a section printing the rate per dataset with the median triggering confidence.

A rule that fires on every run tells you nothing. One that never fires means `min_confidence` is too low to be doing any work. **Neither is visible from accuracy**, which is why it needs its own line.

Runs that never requested a diagnosis are excluded from the denominator rather than counted as "did not fall back" — conflating those would understate the rate. Tested, along with records written before this change, which are also not counted.

## Test plan

- `pytest -q` -> **1719 passed, 19 skipped** (20 new).
- `ruff check src tests benchmarks` clean; `mypy` clean on all touched modules.
- Coverage: selector and policy fallback in both directions; the inclusive boundary; the recorded confidence; `min_confidence` unset; metric selectors never second-guessed; no-diagnosis not counted as a fallback; the fallback plan being real; run-record fields and their JSON round trip; and four cases on the summarizer including the denominator question.

## Docs

`docs/configuration.md` gains a `Confidence fallback` section; `docs/artifacts.md` documents the two new run-record keys.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #414
