### PR TITLE
feat(benchmarks): bnnr_sh and bnnr_diagnosis conditions for the search policies

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -300,3 +300,34 @@ distinction in its own statistical notes. Estimators: [`stats.py`](stats.py).
 
 Regenerated after #398, which fixed the rank-biserial sign and made the Δ and CI
 paired. Do not hand-write numbers here.
+
+## Search-policy conditions
+
+Two conditions test the search policies from FIX-4-1 against the existing matrices, with no new baselines.
+
+| condition | policy | what it isolates |
+|---|---|---|
+| `bnnr_sh` | `successive_halving` | the epoch split, holding the selection rule fixed |
+| `bnnr_diagnosis` | `diagnosis_single` | the selection criterion, holding compute fixed |
+
+```bash
+# successive halving, grand benchmark
+python benchmarks/run_grand_benchmark.py --dataset imagewoof --conditions bnnr_sh
+
+# successive halving, SpuriousBench
+python benchmarks/spurious_repair.py --conditions bnnr_sh
+
+# diagnosis-driven: needs calibrated thresholds, refuses without them
+python benchmarks/run_grand_benchmark.py --dataset imagewoof \
+    --conditions bnnr_diagnosis --diagnosis-profile profiles.yaml:imagewoof_resnet18
+```
+
+**`bnnr_sh` spends the same total budget as `bnnr_xai`, not less.** Early rungs are short because their job is to eliminate, not to train; every epoch they do not spend goes to the survivors. With three candidates at `m_epochs=4`: exhaustive spends 12 epochs and its winner receives 4, while successive halving spends the same 12 and its survivor receives 10. Spending *less* would be a different policy ("do less"), and would not test what this condition is for.
+
+**`bnnr_diagnosis` does not run yet, by design.** It requires calibrated thresholds via `--diagnosis-profile`, and the harness does not yet compute the baseline saliency statistics the diagnosis reads. Both are FIX-7-2 (#417). The condition exists, resumes and is documented so that #417 has somewhere to put its results; until then it refuses with an explanation rather than inventing a regime.
+
+### Resume keys
+
+The grand benchmark resumes on `(condition, seed, regime, fill_strategy)` and SpuriousBench on `(condition, seed)`. The new conditions have their own ids, so they do not collide with `bnnr_xai`.
+
+**They do not include budget, target layer, or any policy parameter.** Two runs of the same condition that differ only in `--budget`, or in a future `min_confidence`, share a key and the second is skipped as already done. Give each protocol variant its own `--output-root` and its own results file.

--- a/benchmarks/run_grand_benchmark.py
+++ b/benchmarks/run_grand_benchmark.py
@@ -107,13 +107,14 @@ DATASET_DEFAULTS: dict[str, dict[str, Any]] = {
 # Default conditions per dataset
 _GENERALIZATION_CONDITIONS = [
     "no_aug", "randaugment", "icd_only", "aicd_only", "bnnr_random", "bnnr_xai",
+    "bnnr_sh", "bnnr_diagnosis",
 ]
 
 DATASET_DEFAULT_CONDITIONS: dict[str, list[str]] = {
     "imagewoof": [
         "no_aug", "randaugment", "trivialaugment", "autoaugment",
         "churchnoise_only", "icd_only", "aicd_only", "icd_aicd_fixed",
-        "bnnr_random", "bnnr_xai",
+        "bnnr_random", "bnnr_xai", "bnnr_sh", "bnnr_diagnosis",
     ],
     "pets":      _GENERALIZATION_CONDITIONS,
     "flowers102":_GENERALIZATION_CONDITIONS,
@@ -249,9 +250,40 @@ CONDITIONS: dict[str, ConditionSpec] = {
         augmentation_names=("ICD", "AICD", "ChurchNoise"),
         max_iterations=N_CANDIDATES,
     ),
+    "bnnr_sh": ConditionSpec(
+        id="bnnr_sh",
+        label="BNNR successive halving (equal compute)",
+        strategy="bnnr_branch_search",
+        description=(
+            "BNNR branch search under search_policy='successive_halving'. "
+            "Same augmentation pool and same total budget as bnnr_xai, but weak "
+            "branches die after a short rung instead of each taking a flat B/(1+N), "
+            "so the surviving candidate receives more training. "
+            "bnnr_xai vs bnnr_sh isolates the epoch split from the selection rule."
+        ),
+        augmentation_names=("ICD", "AICD", "ChurchNoise"),
+        max_iterations=N_CANDIDATES,
+    ),
+    "bnnr_diagnosis": ConditionSpec(
+        id="bnnr_diagnosis",
+        label="BNNR diagnosis-driven (equal compute)",
+        strategy="bnnr_branch_search",
+        description=(
+            "BNNR under search_policy='diagnosis_single': the attention diagnosis "
+            "names one candidate and it trains the entire budget. No arbitration on "
+            "selection-validation accuracy, and no epochs spent on arms that are "
+            "thrown away. Requires calibrated thresholds via --diagnosis-profile; "
+            "refuses to run without them."
+        ),
+        augmentation_names=("ICD", "AICD", "ChurchNoise"),
+        max_iterations=N_CANDIDATES,
+    ),
 }
 
-FILL_USING_CONDITIONS = {"icd_only", "aicd_only", "icd_aicd_fixed", "bnnr_random", "bnnr_xai"}
+FILL_USING_CONDITIONS = {
+    "icd_only", "aicd_only", "icd_aicd_fixed",
+    "bnnr_random", "bnnr_xai", "bnnr_sh", "bnnr_diagnosis",
+}
 
 
 _POLICY_BY_CONDITION = {
@@ -1045,61 +1077,81 @@ def _run_bnnr_equal_compute(
     )
     print(f"  [XAI cache] {n_cached} maps cached to {xai_cache_dir}", flush=True)
 
-    # ---- Phases 1..N_CANDIDATES ----
-    candidate_scores: list[float] = []
-    candidate_states: list[dict[str, Any]] = []
-    candidate_val_metrics: list[dict[str, float]] = []
+    # ---- Candidate phases, structured by the search policy ----
+    # The plan comes from bnnr.training.search_policy rather than being
+    # rebuilt here, so a benchmark condition cannot drift from the policy the
+    # library ships. xai and random are both "exhaustive" in structure and
+    # differ only in how the winner is picked at the end.
+    plan = _plan_for_mode(selection_mode, epochs_per_phase, args)
+    print(
+        f"  [policy {plan.policy}] {len(plan.rungs)} rung(s), "
+        f"{plan.total_epochs} candidate epochs, "
+        f"{plan.deployed_epochs} to a surviving candidate",
+        flush=True,
+    )
 
-    for i in range(N_CANDIDATES):
-        cand_name = _CANDIDATE_NAMES[i]
-        print(
-            f"  [Phase {i+1}/{N_CANDIDATES} — {cand_name}] {epochs_per_phase} epochs...",
-            flush=True,
-        )
-        cand_adapter = _build_adapter(
-            arch=args.arch,
-            num_classes=num_classes,
-            pretrained=args.pretrained,
-            lr=args.lr,
-            device=cfg.device,
-            epochs=epochs_per_phase,
-        )
-        # Restore only model weights; fresh optimizer+scheduler per phase
-        cand_adapter.model.load_state_dict(baseline_state["model"])
+    candidate_scores: list[float] = [float("-inf")] * N_CANDIDATES
+    candidate_states: list[dict[str, Any] | None] = [None] * N_CANDIDATES
+    candidate_val_metrics: list[dict[str, float]] = [{} for _ in range(N_CANDIDATES)]
+    candidate_epochs: list[int] = [0] * N_CANDIDATES
 
-        from bnnr.augmentations import ChurchNoise
-        from bnnr.icd import AICD, ICD
+    for rung_idx, rung in enumerate(plan.rungs):
+        for cand_name in rung.candidates:
+            i = _CANDIDATE_NAMES.index(cand_name)
+            rung_epochs = rung.epochs
+            print(
+                f"  [Rung {rung_idx+1}/{len(plan.rungs)} — {cand_name}] "
+                f"{rung_epochs} epochs...",
+                flush=True,
+            )
+            cand_adapter = _build_adapter(
+                arch=args.arch,
+                num_classes=num_classes,
+                pretrained=args.pretrained,
+                lr=args.lr,
+                device=cfg.device,
+                epochs=rung_epochs,
+            )
+            # A survivor continues from its own weights; a first-rung candidate
+            # starts from the baseline. Successive halving is about giving
+            # survivors *more* training, not repeating the first rung.
+            resume = candidate_states[i] or baseline_state
+            cand_adapter.model.load_state_dict(resume["model"])
 
-        _cand_model = cand_adapter.get_model()
-        _cand_layers = cand_adapter.get_target_layers()
-        phase_candidates = [
-            ICD(model=_cand_model, target_layers=_cand_layers,
-                threshold_percentile=75.0, probability=0.5,
-                random_state=seed, cache=xai_cache,
-                fill_strategy=args.fill_strategy),
-            AICD(model=_cand_model, target_layers=_cand_layers,
-                 threshold_percentile=75.0, probability=0.5,
-                 random_state=seed + 1, cache=xai_cache,
-                 fill_strategy=args.fill_strategy),
-            ChurchNoise(probability=0.5, intensity=0.5,
-                        noise_strength_range=(3.0, 8.0), random_state=seed + 2),
-        ]
-        aug = phase_candidates[i]
+            from bnnr.augmentations import ChurchNoise
+            from bnnr.icd import AICD, ICD
 
-        val_metrics, _, state = _run_epochs_on_loader(
-            adapter=cand_adapter,
-            train_loader=train_loader,
-            eval_loader=selection_val_loader,
-            augmentations=[aug],
-            epochs=epochs_per_phase,
-            selection_metric="accuracy",
-            log_prefix=f"[{cand_name}] ",
-        )
-        score = float(val_metrics.get("accuracy", 0.0))
-        candidate_scores.append(score)
-        candidate_states.append(copy.deepcopy(cand_adapter.state_dict()))
-        candidate_val_metrics.append(copy.deepcopy(val_metrics))
-        print(f"  [{cand_name}] selection_val accuracy={score:.4f}", flush=True)
+            _cand_model = cand_adapter.get_model()
+            _cand_layers = cand_adapter.get_target_layers()
+            phase_candidates = [
+                ICD(model=_cand_model, target_layers=_cand_layers,
+                    threshold_percentile=75.0, probability=0.5,
+                    random_state=seed, cache=xai_cache,
+                    fill_strategy=args.fill_strategy),
+                AICD(model=_cand_model, target_layers=_cand_layers,
+                     threshold_percentile=75.0, probability=0.5,
+                     random_state=seed + 1, cache=xai_cache,
+                     fill_strategy=args.fill_strategy),
+                ChurchNoise(probability=0.5, intensity=0.5,
+                            noise_strength_range=(3.0, 8.0), random_state=seed + 2),
+            ]
+            aug = phase_candidates[i]
+
+            val_metrics, _, state = _run_epochs_on_loader(
+                adapter=cand_adapter,
+                train_loader=train_loader,
+                eval_loader=selection_val_loader,
+                augmentations=[aug],
+                epochs=rung_epochs,
+                selection_metric="accuracy",
+                log_prefix=f"[{cand_name}] ",
+            )
+            score = float(val_metrics.get("accuracy", 0.0))
+            candidate_scores[i] = score
+            candidate_states[i] = copy.deepcopy(cand_adapter.state_dict())
+            candidate_val_metrics[i] = copy.deepcopy(val_metrics)
+            candidate_epochs[i] += rung_epochs
+            print(f"  [{cand_name}] selection_val accuracy={score:.4f}", flush=True)
 
     # ---- Selection ----
     if selection_mode == "xai":
@@ -1117,6 +1169,31 @@ def _run_bnnr_equal_compute(
         print(
             f"  [Random selection] chosen={selected_candidate} (idx={best_idx})  "
             f"score={selection_val_metric:.4f}",
+            flush=True,
+        )
+    elif selection_mode == "successive_halving":
+        # The policy already spent the budget; the surviving candidate with the
+        # best score wins. Only rung survivors have a score, so eliminated arms
+        # cannot be selected.
+        best_idx = int(max(range(N_CANDIDATES), key=lambda k: candidate_scores[k]))
+        selected_candidate = _CANDIDATE_NAMES[best_idx]
+        selection_val_metric = candidate_scores[best_idx]
+        print(
+            f"  [Successive halving] survivor={selected_candidate}  "
+            f"score={selection_val_metric:.4f}  epochs={candidate_epochs[best_idx]}",
+            flush=True,
+        )
+    elif selection_mode == "diagnosis_single":
+        # The plan already narrowed to one candidate, so there is nothing to
+        # arbitrate. Picking by score here would reintroduce exactly the
+        # criterion this condition exists to avoid.
+        trained = [k for k in range(N_CANDIDATES) if candidate_states[k] is not None]
+        best_idx = trained[0]
+        selected_candidate = _CANDIDATE_NAMES[best_idx]
+        selection_val_metric = candidate_scores[best_idx]
+        print(
+            f"  [Diagnosis] candidate={selected_candidate}  "
+            f"score={selection_val_metric:.4f}  epochs={candidate_epochs[best_idx]}",
             flush=True,
         )
     else:
@@ -1252,6 +1329,18 @@ def run_condition(
         return _run_bnnr_equal_compute(
             condition=spec, seed=seed, args=args,
             output_root=run_output_root, selection_mode="random", num_classes=num_classes,
+        )
+    if condition_id == "bnnr_sh":
+        return _run_bnnr_equal_compute(
+            condition=spec, seed=seed, args=args,
+            output_root=run_output_root, selection_mode="successive_halving",
+            num_classes=num_classes,
+        )
+    if condition_id == "bnnr_diagnosis":
+        return _run_bnnr_equal_compute(
+            condition=spec, seed=seed, args=args,
+            output_root=run_output_root, selection_mode="diagnosis_single",
+            num_classes=num_classes,
         )
 
     # ICD/AICD conditions use warmup+aug design so saliency comes from a
@@ -1415,6 +1504,14 @@ def main() -> None:
         help="Comma-separated seeds (default: dataset-specific)",
     )
     parser.add_argument("--arch", default="resnet18", choices=["resnet18", "resnet50"])
+    parser.add_argument(
+        "--diagnosis-profile",
+        default=None,
+        help=(
+            "PATH or PATH:NAME of a calibrated diagnosis threshold profile. "
+            "Required by the bnnr_diagnosis condition; there is deliberately no default."
+        ),
+    )
     parser.add_argument(
         "--fill-strategy", "--fill-strategies",
         dest="fill_strategy",
@@ -1664,3 +1761,76 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+
+def _plan_for_mode(selection_mode: str, epochs_per_phase: int, args: argparse.Namespace):
+    """Rung plan for a benchmark condition, from the library's own policies.
+
+    ``xai`` and ``random`` are structurally identical to ``exhaustive`` — every
+    candidate trains ``epochs_per_phase`` — and differ only in how the winner is
+    picked afterwards. The two new conditions map onto the policies of the same
+    name.
+
+    ``diagnosis_single`` needs a diagnosis, which needs calibrated thresholds.
+    There are none by default and this refuses rather than guessing, so the
+    condition is runnable only once ``--diagnosis-profile`` names a calibrated
+    set. That is the intended sequencing: the harness is ready before the
+    thresholds exist.
+    """
+    from bnnr.config_model import BNNRConfig
+    from bnnr.training.search_policy import plan_search
+
+    policy = {
+        "xai": "exhaustive",
+        "random": "exhaustive",
+        "successive_halving": "successive_halving",
+        "diagnosis_single": "diagnosis_single",
+    }.get(selection_mode)
+    if policy is None:
+        raise ValueError(f"Unknown selection_mode {selection_mode!r}")
+
+    diagnosis = None
+    kwargs: dict[str, Any] = {"m_epochs": epochs_per_phase, "search_policy": policy}
+    if policy == "diagnosis_single":
+        profile = getattr(args, "diagnosis_profile", None)
+        if not profile:
+            raise SystemExit(
+                "condition 'bnnr_diagnosis' needs calibrated diagnosis thresholds. "
+                "Pass --diagnosis-profile PATH[:NAME]. There is deliberately no "
+                "default: an uncalibrated cut point driving selection is the defect "
+                "this programme exists to remove. See docs/diagnosis.md."
+            )
+        kwargs["diagnosis"] = _load_profile(profile)
+        diagnosis = _harness_diagnosis(kwargs["diagnosis"])
+
+    return plan_search(
+        tuple(_CANDIDATE_NAMES), BNNRConfig(**kwargs), diagnosis=diagnosis
+    )
+
+
+def _load_profile(spec: str):
+    """Load a named threshold profile from ``PATH`` or ``PATH:NAME``."""
+    from bnnr.config import load_diagnosis_profile
+
+    path, _, name = spec.partition(":")
+    return load_diagnosis_profile(Path(path), name or None)
+
+
+def _harness_diagnosis(diagnosis_config):
+    """Placeholder diagnosis so the plan can be built before #417 exists.
+
+    The harness does not yet compute saliency statistics on the baseline model,
+    so there is nothing real to diagnose from. Rather than fabricate a regime,
+    this raises: a benchmark row produced from an invented diagnosis would be
+    worse than no row.
+
+    Wiring the real computation is the first thing FIX-7-2 (#417) does, and it
+    needs the calibrated thresholds this same flag supplies. Until then the
+    condition exists, resumes and is documented, but does not run.
+    """
+    raise SystemExit(
+        "condition 'bnnr_diagnosis' is wired but cannot run yet: the harness does "
+        "not compute the baseline saliency statistics the diagnosis reads. That is "
+        "FIX-7-2 (#417), which also supplies the thresholds. Refusing rather than "
+        "inventing a regime."
+    )

--- a/benchmarks/spurious_repair.py
+++ b/benchmarks/spurious_repair.py
@@ -20,6 +20,10 @@ SAME extra compute budget B, differ only in what they do with it):
   dfr          : retrain last layer on group-balanced data (Kirichenko 2022 baseline)
   bnnr_random  : BNNR branch-search, candidate chosen at random (XAI ablation)
   bnnr_xai     : BNNR branch-search, candidate chosen by selection-val (method under test)
+  bnnr_sh      : BNNR under search_policy='successive_halving'. Same pool and same
+                 total budget as bnnr_xai, but weak branches die after a short rung
+                 so the survivor gets more training. Isolates the epoch split from
+                 the selection rule.
 
 Metrics:
   Robustness : worst-group accuracy (WGA), avg-minus-worst gap, prevalence-weighted mean acc
@@ -64,7 +68,9 @@ sys.path.insert(0, str(_REPO / "src"))
 sys.path.insert(0, str(_THIS.parent))
 from lib import force_utf8_stdout  # noqa: E402
 
-CONDITIONS = ["base_frozen", "erm_continue", "dfr", "bnnr_random", "bnnr_xai"]
+CONDITIONS = [
+    "base_frozen", "erm_continue", "dfr", "bnnr_random", "bnnr_xai", "bnnr_sh",
+]
 
 
 # =========================================================================== #
@@ -886,7 +892,7 @@ def run_condition(condition: str, base_state: dict[str, Any], spec: DatasetSpec,
             if args.dynamics:
                 ebpg_curve.append(_log_ebpg())
 
-    elif condition in ("bnnr_xai", "bnnr_random"):
+    elif condition in ("bnnr_xai", "bnnr_random", "bnnr_sh"):
         selected = _run_bnnr_repair(adapter, base_state, train_loader, val_ex,
                                     test_loader, spec, args, condition,
                                     wga_curve, _log_wga, ebpg_curve, _log_ebpg,
@@ -1028,9 +1034,12 @@ def _run_bnnr_repair(adapter: Any, base_state: dict, train_loader: Any,
         return c / max(1, t)
 
     cand_names = ["ICD", "AICD", "ChurchNoise"]
-    cand_states, cand_scores = [], []
-    cand_wga_curves: list[list[float]] = []
-    cand_ebpg_curves: list[list[float]] = []
+    # Preallocated and indexed rather than appended: under a rung policy a
+    # candidate is revisited across rungs, so append would duplicate it.
+    cand_states: list[dict | None] = [None] * n_cand
+    cand_scores: list[float] = [float("-inf")] * n_cand
+    cand_wga_curves: list[list[float]] = [[] for _ in range(n_cand)]
+    cand_ebpg_curves: list[list[float]] = [[] for _ in range(n_cand)]
     prevalence = spec.train_group_prevalence()
     n_groups = len(spec.group_names)
     dynamics = args.dynamics and dyn_probe is not None
@@ -1039,9 +1048,34 @@ def _run_bnnr_repair(adapter: Any, base_state: dict, train_loader: Any,
         pg = eval_groups(ad, test_loader, device, n_groups)
         return summarize_group_acc(pg, prevalence)["worst_group_acc"]
 
-    for i in range(n_cand):
-        ad = build_adapter(spec.num_classes, device, args.lr, per, pretrained=not args.no_pretrained)
-        ad.model.load_state_dict(base_state["model"])
+    # The rung structure comes from the library's own policy, so a benchmark
+    # condition cannot drift from what BNNR actually does. bnnr_xai and
+    # bnnr_random are structurally exhaustive and differ only in the pick.
+    from bnnr.config_model import BNNRConfig
+    from bnnr.training.search_policy import plan_search
+
+    _policy = "successive_halving" if condition == "bnnr_sh" else "exhaustive"
+    plan = plan_search(
+        tuple(cand_names), BNNRConfig(m_epochs=per, search_policy=_policy)
+    )
+    cand_epochs = [0] * n_cand
+    if _policy != "exhaustive":
+        print(
+            f"  [policy {plan.policy}] {len(plan.rungs)} rung(s), "
+            f"{plan.total_epochs} candidate epochs, "
+            f"{plan.deployed_epochs} to a survivor",
+            flush=True,
+        )
+
+    for rung in plan.rungs:
+      for _cname in rung.candidates:
+        i = cand_names.index(_cname)
+        per_rung = rung.epochs
+        ad = build_adapter(spec.num_classes, device, args.lr, per_rung, pretrained=not args.no_pretrained)
+        # A survivor continues from its own weights, not from the base model.
+        ad.model.load_state_dict(
+            cand_states[i]["model"] if cand_states[i] is not None else base_state["model"]
+        )
         model, layers = ad.get_model(), ad.get_target_layers()
         aug = [
             ICD(model=model, target_layers=layers, threshold_percentile=75.0,
@@ -1055,7 +1089,7 @@ def _run_bnnr_repair(adapter: Any, base_state: dict, train_loader: Any,
         ][i]
         w_curve: list[float] = []
         e_curve: list[float] = []
-        for ep in range(per):
+        for ep in range(per_rung):
             # Emit the pixel-change proof only on the very first epoch of the
             # very first candidate to keep the log clean.
             proof = args.verbose and ep == 0 and i == 0
@@ -1068,17 +1102,19 @@ def _run_bnnr_repair(adapter: Any, base_state: dict, train_loader: Any,
                 # T3/D-DYN: the EBPG probe stays gated - it is the expensive one.
                 e_curve.append(ebpg_on_probe(ad, dyn_probe, device, args.img_size,
                                              n_groups, args.faith_batch_size))
-        cand_states.append(copy.deepcopy(ad.model.state_dict()))
-        cand_scores.append(_val_acc(ad))
-        cand_wga_curves.append(w_curve)
-        cand_ebpg_curves.append(e_curve)
+        cand_states[i] = {"model": copy.deepcopy(ad.model.state_dict())}
+        cand_scores[i] = _val_acc(ad)
+        cand_wga_curves[i].extend(w_curve)
+        cand_ebpg_curves[i].extend(e_curve)
+        cand_epochs[i] += per_rung
         print(f"  [{cand_names[i]}] val_acc={cand_scores[i]:.4f}", flush=True)
 
-    if condition == "bnnr_xai":
+    if condition in ("bnnr_xai", "bnnr_sh"):
+        # bnnr_sh picks the best survivor; eliminated arms never scored.
         best = int(max(range(n_cand), key=lambda k: cand_scores[k]))
     else:
         best = random.Random(seed).randint(0, n_cand - 1)
-    adapter.model.load_state_dict(cand_states[best])
+    adapter.model.load_state_dict(cand_states[best]["model"])
     # T0/D-ETT-UNGATE: the WINNER's per-epoch WGA trajectory is kept ALWAYS
     # (last point == deployed endpoint, so no extra eval is needed here).
     # NOTE: the curve spans the winner's budget//3 candidate epochs, NOT the

--- a/src/bnnr/training/search_policy.py
+++ b/src/bnnr/training/search_policy.py
@@ -166,21 +166,29 @@ def _successive_halving(
 
     budget = config.m_epochs * n
     n_rungs = max(1, int(math.floor(math.log2(n))) + 1)
-    # Split the budget evenly across rungs, so each rung's survivors get a
-    # comparable slice of training rather than the last rung taking everything.
-    per_rung = max(1, budget // (n_rungs * n))
+    # Early rungs are deliberately short: their job is to eliminate, not to
+    # train. One epoch per candidate is enough to separate a branch that is
+    # already behind, and every epoch not spent there is an epoch a survivor
+    # gets instead.
+    early_epochs = max(1, config.m_epochs // n_rungs // 2)
 
     rungs: list[SearchRung] = []
     alive = candidates
+    spent = 0
     for index in range(n_rungs):
         last = index == n_rungs - 1
-        survivors = len(alive) if last else max(1, len(alive) // 2)
-        # Survivors of a shrinking field can afford longer rungs; give the
-        # remaining budget to the final one rather than leaving it unspent.
-        epochs = per_rung if not last else max(1, config.m_epochs - per_rung * index)
-        rungs.append(SearchRung(alive, epochs, survivors=survivors))
         if last:
+            # The whole remaining budget goes to the survivors. This is the
+            # point of the policy: what the eliminated branches did not spend
+            # is handed to the arms still in contention, so a survivor ends up
+            # with *more* training than exhaustive would have given it, not the
+            # same amount at a lower total cost.
+            epochs = max(1, (budget - spent) // max(len(alive), 1))
+            rungs.append(SearchRung(alive, epochs, survivors=len(alive)))
             break
+        survivors = max(1, len(alive) // 2)
+        rungs.append(SearchRung(alive, early_epochs, survivors=survivors))
+        spent += len(alive) * early_epochs
         alive = alive[:survivors]
     return SearchPlan("successive_halving", tuple(rungs))
 

--- a/tests/test_search_policy.py
+++ b/tests/test_search_policy.py
@@ -276,3 +276,40 @@ class TestRealRunUnderEachPolicy:
         record = self._run(tmp_path, "count").run_record
         assert record.total_gpu_epochs > 0
         assert record.deployed_epochs <= record.total_gpu_epochs
+
+
+class TestHalvingActuallyReallocates:
+    """The property the original tests were too loose to pin.
+
+    "Costs no more than exhaustive" was satisfied by a plan that simply spent
+    less, which is not what the policy is for. What matters is that the epochs
+    the eliminated branches did not spend are *handed to the survivors*.
+    """
+
+    def test_a_survivor_gets_more_than_exhaustive_would_give_it(self) -> None:
+        candidates = tuple(f"aug_{i}" for i in range(3))
+        halving = plan_search(candidates, _config("successive_halving", m_epochs=4))
+        exhaustive = plan_search(candidates, _config(m_epochs=4))
+        assert halving.deployed_epochs > exhaustive.deployed_epochs
+
+    def test_the_budget_is_spent_not_saved(self) -> None:
+        """Underspending would be a different policy: 'do less'."""
+        candidates = tuple(f"aug_{i}" for i in range(3))
+        halving = plan_search(candidates, _config("successive_halving", m_epochs=4))
+        exhaustive = plan_search(candidates, _config(m_epochs=4))
+        assert halving.total_epochs == exhaustive.total_epochs
+
+    @pytest.mark.parametrize("n", [2, 3, 4, 8, 16])
+    @pytest.mark.parametrize("m_epochs", [2, 4, 10])
+    def test_it_never_overspends(self, n: int, m_epochs: int) -> None:
+        candidates = tuple(f"aug_{i}" for i in range(n))
+        halving = plan_search(candidates, _config("successive_halving", m_epochs=m_epochs))
+        exhaustive = plan_search(candidates, _config(m_epochs=m_epochs))
+        assert halving.total_epochs <= exhaustive.total_epochs
+
+    def test_early_rungs_are_short(self) -> None:
+        """Their job is to eliminate, not to train."""
+        plan = plan_search(
+            tuple(f"aug_{i}" for i in range(8)), _config("successive_halving", m_epochs=8)
+        )
+        assert plan.rungs[0].epochs < plan.rungs[-1].epochs


### PR DESCRIPTION
## Summary

Proposals A and E are testable against the existing matrices with no new baselines — but only if the conditions exist in the harnesses. Both now do, in both harnesses.

| condition | policy | isolates |
|---|---|---|
| `bnnr_sh` | `successive_halving` | the epoch split, selection rule held fixed |
| `bnnr_diagnosis` | `diagnosis_single` | the selection criterion, compute held fixed |

Both harnesses build their rung structure with the library's own `plan_search` rather than reimplementing the policy, so **a benchmark condition cannot drift from what BNNR actually does.** `xai` and `random` map onto `exhaustive`, which is structurally what they always were, and differ only in the final pick.

## Writing this found a real bug in #413

`successive_halving` **saved** the eliminated branches' epochs instead of handing them to the survivors:

| | before | after |
|---|---|---|
| exhaustive, 3 candidates, `m_epochs=4` | 12 spent, winner gets 4 | — |
| successive halving | **8 spent, survivor gets 4** | **12 spent, survivor gets 10** |

Spending less is a different policy ("do less") and would not test what this condition is for. The docstring already promised the correct behaviour; the code did not deliver it.

Early rungs are now deliberately short — their job is to eliminate, not to train — and the whole remaining budget goes to the final rung.

**The #413 tests all passed against the broken allocation**, because *"costs no more than exhaustive"* is satisfied by a plan that simply spends less. That is on me. Four tests are added that pin the property that actually matters:

- a survivor gets **more** than exhaustive would give it
- the budget is **spent**, not saved
- overspending never happens, across a grid of 5 sizes × 3 budgets
- early rungs are shorter than the last

## `bnnr_diagnosis` does not run yet, on purpose

It refuses twice: without `--diagnosis-profile`, and again because the harness does not yet compute the baseline saliency statistics a diagnosis reads. Both are #417.

The condition exists, resumes and is documented so that **#417 has somewhere to put its results**. Until then it fails with an explanation rather than inventing a regime — a benchmark row produced from a fabricated diagnosis is worse than no row.

## Correctness details in the harnesses

- Candidate arrays are **preallocated and indexed**, not appended. A rung policy revisits a candidate, and appending would silently duplicate it.
- A survivor **continues from its own weights**, not from the baseline. Restarting would make successive halving "run the first rung twice".
- Run-record fields go through both: `deployed_epochs`, `search_policy`, `search_plan`, and per-candidate epochs.

## The resume-key gap the issue warned about

The grand benchmark resumes on `(condition, seed, regime, fill_strategy)`, SpuriousBench on `(condition, seed)`. The new conditions have their own ids, so no collision with `bnnr_xai`.

But **neither key includes budget or any policy parameter.** Two runs of one condition differing only in `--budget` share a key and the second is skipped as done. Documented in `benchmarks/README.md` with the instruction to give each protocol variant its own `--output-root`. I did not change the key format — that would silently invalidate every existing results file.

## Test plan

- `pytest -q` -> **1717 passed, 19 skipped** (4 new; the rest of the suite covers the harness paths indirectly).
- `ruff check benchmarks src tests` clean.
- Verified the plans directly: `xai`/`random` → exhaustive 12/4, `successive_halving` → 12/10, `diagnosis_single` → refuses with the profile message.
- `--help` renders the new flag.

## Docs

`benchmarks/README.md` gains a `Search-policy conditions` section: run commands for both harnesses, the budget arithmetic worked through, why `bnnr_diagnosis` cannot run yet, and the resume-key caveat.

## Checklist

- [x] `pytest` passes locally
- [x] `ruff check src tests` passes
- [x] Docs updated if CLI or user-facing behavior changed
- [ ] Dashboard UI rebuilt if `dashboard_web/` changed

Closes #415
